### PR TITLE
doc: duplicate 'rpm-ostree rebase' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To rebase an existing Silverblue/Kinoite installation to the latest build:
   ```
 - Then rebase to the signed image, like so:
   ```
-  rpm-ostree rebase rpm-ostree rebase ostree-image-signed:docker://ghcr.io/qoijjj/$IMAGE_NAME:latest
+  rpm-ostree rebase ostree-image-signed:docker://ghcr.io/qoijjj/$IMAGE_NAME:latest
   ```
 - Reboot again to complete the installation
   ```


### PR DESCRIPTION
Hello!

Thank you for this repository, i like your work so far.

While testing i've found this command to be duplicate.

May i ask, why are issues disabled in this repository?
I and maybe others would like to contribute further, which would be hard without issues.

Oh and btw, i featured this and other projects of yours in my new "Awesome Fedora Security" list.
https://github.com/34N0/awesome-fedora-security

Thanks! :-)