### PR TITLE
Remove podman and all dependent packages

### DIFF
--- a/config/common-packages.yml
+++ b/config/common-packages.yml
@@ -25,6 +25,9 @@ remove:
   - virtualbox-guest-additions
   - openssh-server
   - bubblewrap
+  - toolbox
+  - distrobox
+  - podman
 
 
 

--- a/config/kinoite-packages.yml
+++ b/config/kinoite-packages.yml
@@ -10,7 +10,6 @@ remove:
   - kf5-akonadi-server-mysql
   - kwalletmanager5
   - fedora-flathub-remote
-  - toolbox
   - kde-print-manager
   - kde-print-manager-libs
   - hplip

--- a/config/scripts/chromium.sh
+++ b/config/scripts/chromium.sh
@@ -6,7 +6,7 @@
 set -oue pipefail
 
 echo "Installing chromium from koji updates-testing"
-koji download-build --arch=x86_64 $(koji latest-build f39-updates-candidate chromium | awk 'NR==3 {print $1}')
+koji download-build --arch=x86_64 $(koji latest-build f39-updates chromium | awk 'NR==3 {print $1}')
 rm chromedriver-*.rpm
 rm chromium-headless-*.rpm
 rpm-ostree install *.rpm

--- a/config/silverblue-packages.yml
+++ b/config/silverblue-packages.yml
@@ -31,5 +31,4 @@ remove:
   - libppd
   - malcontent-ui-libs
   - malcontent-control
-  - toolbox
   - fedora-flathub-remote


### PR DESCRIPTION
Podman can only be used with either unprivileged user namespaces or as root, which is even less secure. As such, podman and dependent packages will be removed and users should layer the development packages they need on a case by case basis (or layer them temporarily using --apply-live)