### PR TITLE
feat: lock users for 24 hours after 50 failed login attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Hardening applied:
 - Require a password for sudo every time it's called
 - Disable passwordless sudo for rpm-ostree
 - Setting more restrictive file permissions (Based on recommendations from [lynis](https://cisofy.com/lynis/))
+- Brute force protection by locking user accounts for 24 hours after 50 failed login attempts
 - Installing dnf-automatic and chkrootkit
 - Disabling unprivileged user namespaces
 - Replacing bubblewrap with bubblewrap-suid so flatpak can be used without unprivileged user namespaces

--- a/config/files/usr/etc/pam.d/password-auth
+++ b/config/files/usr/etc/pam.d/password-auth
@@ -1,0 +1,30 @@
+auth        required                                     pam_env.so
+auth        required                                     pam_faildelay.so delay=2000000
+auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
+auth        [default=1 ignore=ignore success=ok]         pam_localuser.so
+auth        required                                     pam_faillock.so preauth
+auth        sufficient                                   pam_unix.so nullok
+auth        [default=die]                                pam_faillock.so authfail 
+auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
+auth        sufficient                                   pam_sss.so forward_pass
+auth        required                                     pam_deny.so
+
+account     required                                     pam_faillock.so
+account     required                                     pam_unix.so
+account     sufficient                                   pam_localuser.so
+account     sufficient                                   pam_usertype.so issystem
+account     [default=bad success=ok user_unknown=ignore] pam_sss.so
+account     required                                     pam_permit.so
+
+password    requisite                                    pam_pwquality.so local_users_only
+password    sufficient                                   pam_unix.so yescrypt shadow nullok use_authtok
+password    [success=1 default=ignore]                   pam_localuser.so
+password    sufficient                                   pam_sss.so use_authtok
+password    required                                     pam_deny.so
+
+session     optional                                     pam_keyinit.so revoke
+session     required                                     pam_limits.so
+-session    optional                                     pam_systemd.so
+session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
+session     required                                     pam_unix.so
+session     optional                                     pam_sss.so

--- a/config/files/usr/etc/pam.d/system-auth
+++ b/config/files/usr/etc/pam.d/system-auth
@@ -1,0 +1,31 @@
+auth        required                                     pam_env.so
+auth        required                                     pam_faildelay.so delay=2000000
+auth        sufficient                                   pam_fprintd.so
+auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
+auth        [default=1 ignore=ignore success=ok]         pam_localuser.so
+auth        required                                     pam_faillock.so preauth
+auth        sufficient                                   pam_unix.so nullok
+auth        [default=die]                                pam_faillock.so authfail 
+auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
+auth        sufficient                                   pam_sss.so forward_pass
+auth        required                                     pam_deny.so
+
+account     required                                     pam_faillock.so
+account     required                                     pam_unix.so
+account     sufficient                                   pam_localuser.so
+account     sufficient                                   pam_usertype.so issystem
+account     [default=bad success=ok user_unknown=ignore] pam_sss.so
+account     required                                     pam_permit.so
+
+password    requisite                                    pam_pwquality.so local_users_only
+password    sufficient                                   pam_unix.so yescrypt shadow nullok use_authtok
+password    [success=1 default=ignore]                   pam_localuser.so
+password    sufficient                                   pam_sss.so use_authtok
+password    required                                     pam_deny.so
+
+session     optional                                     pam_keyinit.so revoke
+session     required                                     pam_limits.so
+-session    optional                                     pam_systemd.so
+session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
+session     required                                     pam_unix.so
+session     optional                                     pam_sss.so

--- a/config/files/usr/etc/security/faillock.conf
+++ b/config/files/usr/etc/security/faillock.conf
@@ -1,0 +1,62 @@
+# Configuration for locking the user after multiple failed
+# authentication attempts.
+#
+# The directory where the user files with the failure records are kept.
+# The default is /var/run/faillock.
+# dir = /var/run/faillock
+#
+# Will log the user name into the system log if the user is not found.
+# Enabled if option is present.
+audit
+#
+# Don't print informative messages.
+# Enabled if option is present.
+# silent
+#
+# Don't log informative messages via syslog.
+# Enabled if option is present.
+# no_log_info
+#
+# Only track failed user authentications attempts for local users
+# in /etc/passwd and ignore centralized (AD, IdM, LDAP, etc.) users.
+# The `faillock` command will also no longer track user failed
+# authentication attempts. Enabling this option will prevent a
+# double-lockout scenario where a user is locked out locally and
+# in the centralized mechanism.
+# Enabled if option is present.
+# local_users_only
+#
+# Deny access if the number of consecutive authentication failures
+# for this user during the recent interval exceeds n tries.
+# The default is 3.
+deny = 50
+#
+# The length of the interval during which the consecutive
+# authentication failures must happen for the user account
+# lock out is <replaceable>n</replaceable> seconds.
+# The default is 900 (15 minutes).
+# fail_interval = 900
+#
+# The access will be re-enabled after n seconds after the lock out.
+# The value 0 has the same meaning as value `never` - the access
+# will not be re-enabled without resetting the faillock
+# entries by the `faillock` command.
+# The default is 600 (10 minutes).
+unlock_time = 86400
+#
+# Root account can become locked as well as regular accounts.
+# Enabled if option is present.
+even_deny_root
+#
+# This option implies the `even_deny_root` option.
+# Allow access after n seconds to root account after the
+# account is locked. In case the option is not specified
+# the value is the same as of the `unlock_time` option.
+# root_unlock_time = 900
+#
+# If a group name is specified with this option, members
+# of the group will be handled by this module the same as
+# the root account (the options `even_deny_root>` and
+# `root_unlock_time` will apply to them.
+# By default, the option is not set.
+# admin_group = <admin_group_name>


### PR DESCRIPTION
fixes #17 

proof:
```bash
dev@fedora:~$journalctl | grep "temporarily locked" 
Dec 07 20:46:55 fedora gdm-password][2892]: pam_faillock(gdm-password:auth): Consecutive login failures for user dev account temporarily locked
```