### PR TITLE
remove wheel dependency, sort new

### DIFF
--- a/config/files/usr/share/polkit-1/rules.d/org.projectatomic.rpmostree1.rules
+++ b/config/files/usr/share/polkit-1/rules.d/org.projectatomic.rpmostree1.rules
@@ -2,15 +2,10 @@
    Allows only upgrades and repo refreshes without sudo
  */
 polkit.addRule(function(action, subject) {
-    if (action.id == "org.projectatomic.rpmostree1.repo-refresh" &&
-        subject.active == true && subject.local == true) {
-            return polkit.Result.YES;
-    }
-
-    if ((action.id == "org.projectatomic.rpmostree1.upgrade" ) &&
+    if ((action.id == "org.projectatomic.rpmostree1.repo-refresh" ||
+        action.id == "org.projectatomic.rpmostree1.upgrade") &&
         subject.active == true &&
-        subject.local == true &&
-        subject.isInGroup("wheel")) {
+        subject.local == true) {
             return polkit.Result.YES;
     }
 });


### PR DESCRIPTION
currently non-wheel users will not have automatic upgrades. Without the ability to

```
action.id == "org.projectatomic.rpmostree1.rollback" ||
action.id == "org.projectatomic.rpmostree1.bootconfig" ||
action.id == "org.projectatomic.rpmostree1.reload-daemon" ||
action.id == "org.projectatomic.rpmostree1.cancel" ||
action.id == "org.projectatomic.rpmostree1.cleanup" ||
action.id == "org.projectatomic.rpmostree1.client-management"
```

there should be no security benefit of having this rule at all, I would say it is a huge problem as nonwheel users get no upgrades.

I would also remove the dependency to be local and logged in, as I dont think this is necessary too, and in some cases (ssh, remote login, RDP, VNC) this could prevent upgrades