### PR TITLE
force sddm to use wayland instead of xorg

### DIFF
--- a/config/files/usr/etc/sddm.conf.d/10-wayland.conf
+++ b/config/files/usr/etc/sddm.conf.d/10-wayland.conf
@@ -1,4 +1,10 @@
+# Sets the display server to wayland instead of xorg
 [General]
 DisplayServer=wayland
+# uses kwin_wayland as a compositor for sddm instead of sway,
+# drm mode for rendering,
+# disables lock-screen as we are not logged in yet,
+# disables global shortcuts to make sure user shortcuts are not inherited for security reasons
+# and uses the system locale as opposed to the user's locale
 [Wayland]
 CompositorCommand=kwin_wayland --drm --no-lockscreen --no-global-shortcuts --locale1

--- a/config/files/usr/etc/sddm.conf.d/10-wayland.conf
+++ b/config/files/usr/etc/sddm.conf.d/10-wayland.conf
@@ -1,0 +1,4 @@
+[General]
+DisplayServer=wayland
+[Wayland]
+CompositorCommand=kwin_wayland --drm --no-lockscreen --no-global-shortcuts --locale1


### PR DESCRIPTION
Given that the main focus is security I think this is a good idea :)

Straight from [Arch Wiki](https://wiki.archlinux.org/title/SDDM#Running_under_Wayland)

Also has the added benefit of making sddm look proper on a HiDPI monitor if the user sets the appropriate settings in KDE.