### PR TITLE
chromium: Disable VAAPI and enable wayland

### DIFF
--- a/config/files/usr/etc/chromium/chromium.conf
+++ b/config/files/usr/etc/chromium/chromium.conf
@@ -1,4 +1,4 @@
 # system wide chromium flags
 CHROMIUM_FLAGS=""
-CHROMIUM_FLAGS+=" --enable-features=VaapiVideoEncoder,VaapiVideoDecodeLinuxGL"
+CHROMIUM_FLAGS+=" --ozone-platform=wayland"
 CHROMIUM_FLAGS+=" --js-flags=--jitless"


### PR DESCRIPTION
Short version: wayland is not enabled by default but enabling it breaks VAAPI.
See #142 for details.