### PR TITLE
docs: added group permissions details

### DIFF
--- a/POSTINSTALL-README.md
+++ b/POSTINSTALL-README.md
@@ -53,7 +53,7 @@ polkit.addRule(function(action, subject) {
 EOF
 ```
 
-The custom rule allows the groups `wheel` and `diskadmin` to do the actions for unlocking and mounting these drives. Note the requirement on `active` and `local`, and the exactly specified actions.
+The custom rule allows the group`diskadmin` to do the actions for unlocking and mounting these drives. Note the requirement on `active` and `local`, and the exactly specified actions.
 
 ## Chromium Extension
 

--- a/POSTINSTALL-README.md
+++ b/POSTINSTALL-README.md
@@ -18,13 +18,42 @@ If you wish to password-protect booting existing entries, you can add the `grub_
 
 Creating a dedicated wheel user and removing wheel from your primary user helps prevent certain attack vectors:
 
-https://www.kicksecure.com/wiki/Dev/Strong_Linux_User_Account_Isolation#LD_PRELOAD
-https://www.kicksecure.com/wiki/Root#Prevent_Malware_from_Sniffing_the_Root_Password
+- https://www.kicksecure.com/wiki/Dev/Strong_Linux_User_Account_Isolation#LD_PRELOAD
+- https://www.kicksecure.com/wiki/Root#Prevent_Malware_from_Sniffing_the_Root_Password
 
 1. ```adduser admin```
 2. ```usermod -aG wheel admin```
 3. ```gpasswd -d {your username here} wheel```
 4. reboot
+
+When not in the wheel group, a user can be added to a dedicated group, otherwise certain actions are blocked:
+
+- use virtual machines: `libvirt`
+- use `adb` and `fastboot`: `plugdev`
+- use systemwide flatpaks: `flatpak`
+
+Be aware that granting these permissions will increase attack surface, so keep them as minimal as possible. Some actions don't have an associated group yet, you can create your own rules and groups to fix this.
+
+**Example**: Use LUKS encrypted backup drives
+
+1. `sudo groupadd diskadmin`
+2. `sudo usermod -aG diskadmin {your username here}`
+3. execute this command (*explanation below*)
+
+```
+cat >> /etc/polkit-1/rules.d/80-udisks2.rules <<EOF
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.freedesktop.udisks2.encrypted-unlock-system" || action.id == "org.freedesktop.udisks2.filesystem-mount-system" &&
+        subject.active == true && subject.local == true &&
+        subject.isInGroup("diskadmin"))
+        {
+        return polkit.Result.YES;
+    }
+});
+EOF
+```
+
+The custom rule allows the groups `wheel` and `diskadmin` to do the actions for unlocking and mounting these drives. Note the requirement on `active` and `local`, and the exactly specified actions.
 
 ## Chromium Extension
 


### PR DESCRIPTION
I tried following the above style, but the codeblock was the best way to do it. I highly dislike guides like "open nano here and copy paste", and the command is specifically explained below.