### PR TITLE
fix: temp remove pam_authramp

### DIFF
--- a/config/common/common-scripts.yml
+++ b/config/common/common-scripts.yml
@@ -1,6 +1,7 @@
 type: script
 scripts:
-  - addauthramp.sh
+  # hotfix disable authramp
+  # - addauthramp.sh
   - optoutauthselect.sh
   - setfilepermissions.sh
   # this sets up the proper policy & signing files for signed images to work


### PR DESCRIPTION
Currently there is the possibility users using SDDM can get locked out.

I am sorry about this one.

This will be resolved soon but i do not feel comfortable with this being part of staging, :disappointed: 