### PR TITLE
Chromium policy: preinstall UBO-Lite & NoScript

### DIFF
--- a/config/files/usr/etc/chromium/policies/managed/hardening.json
+++ b/config/files/usr/etc/chromium/policies/managed/hardening.json
@@ -27,4 +27,8 @@
 	"UrlKeyedAnonymizedDataCollectionEnabled": false,
 	"WebRtcEventLogCollectionAllowed": false,
 	"WebRtcIPHandling": "disable_non_proxied_udp"
+	"ExtensionInstallForcelist": [
+		"ddkjiahejlhfcafbddmgiahcphecmpfh;https://clients2.google.com/service/update2/crx",
+		"doojmbjmlfjjnbmnoijecmcbfeoakpjm;https://clients2.google.com/service/update2/crx"
+		],
 }


### PR DESCRIPTION
Those Extensions are then preinstalled and cannot be uninstalled without root access. Both can be turned off.