### PR TITLE
add `delete-kargs-hardening` and documentation

### DIFF
--- a/config/files/usr/share/ublue-os/just/60-custom.just
+++ b/config/files/usr/share/ublue-os/just/60-custom.just
@@ -2,23 +2,23 @@ import '100-bling.just'
 # Include some of your custom scripts here!
 
 # hardening Kernel Arguments
-harden_kargs := "init_on_alloc=1" + \
-               "init_on_free=1" + \
-               "slab_nomerge" + \
-               "page_alloc.shuffle=1" + \
-               "randomize_kstack_offset=on" + \
-               "vsyscall=none" + \
-               "debugfs=off" + \
+harden_kargs := "init_on_alloc=1 " + \
+               "init_on_free=1 " + \
+               "slab_nomerge " + \
+               "page_alloc.shuffle=1 " + \
+               "randomize_kstack_offset=on " + \
+               "vsyscall=none " + \
+               "debugfs=off " + \
                "lockdown=confidentiality "+ \
-               "random.trust_cpu=off" + \
-               "random.trust_bootloader=off" + \
-               "iommu=force" + \
-               "intel_iommu=on" + \
-               "amd_iommu=force_isolation" + \
-               "iommu.passthrough=0" + \
-               "iommu.strict=1" + \
-               "pti=on" + \
-               "module.sig_enforce=1" + \
+               "random.trust_cpu=off " + \
+               "random.trust_bootloader=off " + \
+               "iommu=force " + \
+               "intel_iommu=on " + \
+               "amd_iommu=force_isolation " + \
+               "iommu.passthrough=0 " + \
+               "iommu.strict=1 " + \
+               "pti=on " + \
+               "module.sig_enforce=1 " + \
                "mitigations=auto,nosmt"
 
 # harden karg that might cause boot issue
@@ -27,21 +27,20 @@ harden_kargs_unstable := "efi=disable_early_pci_dma"
 
 # Add additional boot parameters for hardening (requires reboot)
 set-kargs-hardening:
-    rpm-ostree kargs --append-if-missing="{{harden_karg}}" 
+    rpm-ostree kargs --append-if-missing="{{harden_kargs}}" 
 
 set-kargs-hardening-unstable:
     echo "Warning: setting these kargs may lead to boot issues on some hardware."
-    rpm-ostree kargs --append-if-missing="{{harden_karg_unstable}}"
+    rpm-ostree kargs --append-if-missing="{{harden_kargs_unstable}}"
 
 # delete boot parameters for hardening
 delete-kargs-hardening:
-    rpm-ostree kargs --delete-if-present="{{harden_karg}} {{harden_karg_unstable}}"
+    rpm-ostree kargs --delete-if-present="{{harden_kargs}} {{harden_kargs_unstable}}"
 
-# enable hardenmalloc for flatpak
 harden-flatpak:
     flatpak override --user --filesystem=host-os:ro --env=LD_PRELOAD=/var/run/host/usr/lib64/libhardened_malloc.so
 
-# enable cups print system
+# enable CUPS (Common UNIX Printing System)
 enable-cups:
     firewall-cmd --permanent --add-port=631/tcp
     firewall-cmd --permanent --add-port=631/udp 

--- a/config/files/usr/share/ublue-os/just/60-custom.just
+++ b/config/files/usr/share/ublue-os/just/60-custom.just
@@ -1,36 +1,47 @@
 import '100-bling.just'
 # Include some of your custom scripts here!
 
+# hardening Kernel Arguments
+harden_kargs := "init_on_alloc=1" + \
+               "init_on_free=1" + \
+               "slab_nomerge" + \
+               "page_alloc.shuffle=1" + \
+               "randomize_kstack_offset=on" + \
+               "vsyscall=none" + \
+               "debugfs=off" + \
+               "lockdown=confidentiality "+ \
+               "random.trust_cpu=off" + \
+               "random.trust_bootloader=off" + \
+               "iommu=force" + \
+               "intel_iommu=on" + \
+               "amd_iommu=force_isolation" + \
+               "iommu.passthrough=0" + \
+               "iommu.strict=1" + \
+               "pti=on" + \
+               "module.sig_enforce=1" + \
+               "mitigations=auto,nosmt"
+
+# harden karg that might cause boot issue
+# See https://github.com/secureblue/secureblue/issues/169
+harden_kargs_unstable := "efi=disable_early_pci_dma"
+
 # Add additional boot parameters for hardening (requires reboot)
 set-kargs-hardening:
-    rpm-ostree kargs \
-      --append-if-missing="init_on_alloc=1" \
-      --append-if-missing="init_on_free=1" \
-      --append-if-missing="slab_nomerge" \
-      --append-if-missing="page_alloc.shuffle=1" \
-      --append-if-missing="randomize_kstack_offset=on" \
-      --append-if-missing="vsyscall=none" \
-      --append-if-missing="debugfs=off" \
-      --append-if-missing="lockdown=confidentiality" \
-      --append-if-missing="random.trust_cpu=off" \
-      --append-if-missing="random.trust_bootloader=off" \
-      --append-if-missing="iommu=force" \
-      --append-if-missing="intel_iommu=on" \
-      --append-if-missing="amd_iommu=force_isolation" \
-      --append-if-missing="iommu.passthrough=0" \
-      --append-if-missing="iommu.strict=1" \
-      --append-if-missing="pti=on" \
-      --append-if-missing="module.sig_enforce=1" \
-      --append-if-missing="mitigations=auto,nosmt"
+    rpm-ostree kargs --append-if-missing="{{harden_karg}}" 
 
 set-kargs-hardening-unstable:
     echo "Warning: setting these kargs may lead to boot issues on some hardware."
-    rpm-ostree kargs \
-      --append-if-missing="efi=disable_early_pci_dma"
+    rpm-ostree kargs --append-if-missing="{{harden_karg_unstable}}"
 
+# delete boot parameters for hardening
+delete-kargs-hardening:
+    rpm-ostree kargs --delete-if-present="{{harden_karg}} {{harden_karg_unstable}}"
+
+# enable hardenmalloc for flatpak
 harden-flatpak:
     flatpak override --user --filesystem=host-os:ro --env=LD_PRELOAD=/var/run/host/usr/lib64/libhardened_malloc.so
 
+# enable cups print system
 enable-cups:
     firewall-cmd --permanent --add-port=631/tcp
     firewall-cmd --permanent --add-port=631/udp 


### PR DESCRIPTION
Groups all kargs into two variables, and added additional documentation. Replaces https://github.com/secureblue/secureblue/pull/199