### PR TITLE
use random mac address by default and related documentations

### DIFF
--- a/config/files/usr/etc/NetworkManager/conf.d/rand_mac.conf
+++ b/config/files/usr/etc/NetworkManager/conf.d/rand_mac.conf
@@ -3,6 +3,6 @@
 wifi.scan-rand-mac-address=yes
  
 [connection-mac-randomization]
-# Generate a random MAC for each Network and associate the two permanently.
-ethernet.cloned-mac-address=stable
-wifi.cloned-mac-address=stable
+# generate a random mac address per each connection of the network
+ethernet.cloned-mac-address=random
+wifi.cloned-mac-address=random

--- a/config/files/usr/etc/NetworkManager/conf.d/rand_mac.conf.readme.md
+++ b/config/files/usr/etc/NetworkManager/conf.d/rand_mac.conf.readme.md
@@ -1,0 +1,24 @@
+# Random MAC Address Settings
+
+The `rand_mac.conf` is a configuration file to let network manager using random mac address when possible.
+See https://www.networkmanager.dev/docs/api/latest/NetworkManager.conf.html 
+or `man NetworkManager.conf` for detailed official documentation on the configurations.
+
+### Random MAC Address For Scanning
+
+`wifi.scan-rand-mac-address=yes` use a random mac address when scanning networks,
+this is already the default on fedora systems.
+
+### Random MAC Address For Connection
+
+`ethernet.cloned-mac-address=random` and `wifi.cloned-mac-address=random` 
+will generate a random mac address for **each connection** to network.
+
+The `random` setting is different from `stable` setting:
+for `stable`, the system will generate a permanent mac address and associate it with each network.
+`stable` setting is useful when you are on a home/company network, 
+where stable mac addresses are important for admin purposes.
+
+You can manually change the random mac address setting to `stable` for individual networks in Gnome: 
+`Setting > Wifi > Gear icon on the right of the network name > Identity > Cloned Mac Address`.
+The global setting can also be changed by editing the `rand_mac.conf` file.


### PR DESCRIPTION
Random mac address is the default on GrapheneOS, and I have been daily driving secureblue with random mac address by default for a week now, it seems usable. 
Users can also manually revert this change through GUIs in Gnome for individual trusted networks like home/company network.

However, people might encounter problem like unstable Wi-Fi connection on weaker router, unable to use app relies on stable IP address of the device, etc. if they don't change the mac address to `stable` on a trusted network.