### PR TITLE
[doc] add recommendation against laptop image for latest AMD laptop

### DIFF
--- a/config/recipes/laptop/laptop-bling.yml
+++ b/config/recipes/laptop/laptop-bling.yml
@@ -5,4 +5,10 @@ install:
   # - https://blue-build.org/reference/modules/bling/
   # - https://github.com/blue-build/modules/blob/main/modules/bling/installers/laptop.sh
   # - https://github.com/blue-build/modules/blob/main/modules/bling/50-laptop.conf
+  #
+  # **AMD 7040 series** user should consider avoiding bling `laptop` configuration at the moment.
+  # This bling config will install TLP over PPD and apply several rules to save battery life.
+  # However, TLP config will likely interfere with AMD suspend feature, 
+  # hence PPD is typically recommended for **AMD 7040 series** users.
+  # See: https://community.frame.work/t/tracking-ppd-v-tlp-for-amd-ryzen-7040/39423/6
   - laptop 


### PR DESCRIPTION
Some TLP config can interfere with suspension of AMD 7040 series CPU, recommend using the desktop image for now.

Because of AMD team's active involvement in [PPD](https://gitlab.freedesktop.org/upower/power-profiles-daemon) (in particular [Mario Limonciello](https://gitlab.freedesktop.org/superm1)), see version 0.20 and 0.13 in [changelog](https://gitlab.freedesktop.org/upower/power-profiles-daemon/-/blob/main/NEWS?ref_type=heads), PPD probably should be recommended over TLP for AMD 7040 laptops at this point.