### PR TITLE
doc: remove redundant contributors file

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,2 +1,0 @@
-* [@qoijjj](https://github.com/qoijjj)
-* [@34N0](https://github.com/34N0)


### PR DESCRIPTION
Since the recent migration the repository supports the contributors feature. This file is thus now obsolete as well as incomplete.