### PR TITLE
fix: Assure that "disabling CoreDump tweak" is applied correctly

### DIFF
--- a/config/files/usr/etc/systemd/system.conf.d/disable-coredump.conf
+++ b/config/files/usr/etc/systemd/system.conf.d/disable-coredump.conf
@@ -1,0 +1,2 @@
+[Manager]
+DumpCore=no

--- a/config/files/usr/etc/systemd/user.conf.d/disable-coredump.conf
+++ b/config/files/usr/etc/systemd/user.conf.d/disable-coredump.conf
@@ -1,0 +1,2 @@
+[Manager]
+DumpCore=no


### PR DESCRIPTION
Since Fedora uses systemd, we need to make this change too, else it won't be applied throughout the system, but only in SSH/TTY sessions.

Bluefin had the same issue with open-file limits tweak here: https://github.com/ublue-os/bluefin/pull/988

I usually put those config overrides to `/usr/lib`, but I will put them in `/usr/etc` to comply with the project's structure.

As far as I look, this is the only tweak which needs this systemd conf change.