### PR TITLE
Replace hardcoded Fedora version in Copr repos

### DIFF
--- a/config/common/common-packages.yml
+++ b/config/common/common-packages.yml
@@ -1,6 +1,6 @@
 type: rpm-ostree
 repos: 
-  - https://copr.fedorainfracloud.org/coprs/secureblue/hardened_malloc/repo/fedora-39/secureblue-hardened_malloc-fedora-39.repo
+  - https://copr.fedorainfracloud.org/coprs/secureblue/hardened_malloc/repo/fedora-%OS_VERSION%/secureblue-hardened_malloc-fedora-%OS_VERSION%.repo
 install:    
   - lm_sensors
   - lynis

--- a/config/common/gui-packages.yml
+++ b/config/common/gui-packages.yml
@@ -1,6 +1,6 @@
 type: rpm-ostree
 repos:
-  - https://copr.fedorainfracloud.org/coprs/secureblue/bubblejail/repo/fedora-39/secureblue-bubblejail-fedora-39.repo
+  - https://copr.fedorainfracloud.org/coprs/secureblue/bubblejail/repo/fedora-%OS_VERSION%/secureblue-bubblejail-fedora-%OS_VERSION%.repo
 install:    
   - python3-pip
   # GNOME's GTK4 theme, Libadwaita. Already included in Silverblue, but not


### PR DESCRIPTION
Hi @qoijjj,

I'm proposing a slight change to the way the COPR addresses are referenced: 

- Let's use %OS_VERSION% and let the package manager fill in with the appropriate OS version.