### PR TITLE
feat: just commands to override modprobe blacklist

### DIFF
--- a/config/files/usr/share/ublue-os/just/60-custom.just
+++ b/config/files/usr/share/ublue-os/just/60-custom.just
@@ -112,3 +112,28 @@ toggle-ghns:
     else
       echo "No kdeglobals file found. Are you on kinoite?"
     fi
+
+# enable a kernel module that is disabled by modprobe.d (require restart)
+override-enable-module mod_name:
+    #!/usr/bin/pkexec /usr/bin/bash
+    MOD_NAME="{{ mod_name }}"
+    MOD_FILE="/etc/modprobe.d/99-$MOD_NAME.conf"
+    if test -e $MOD_FILE; then
+      echo "$MOD_NAME module is already enabled. You might forgot to restart for the override to take effect."
+    else
+      sudo sh -c 'echo "install $1 /sbin/modprobe --ignore-install $1" >> "$2"' _ "$MOD_NAME" "$MOD_FILE" 
+      sudo chmod 644 $MOD_FILE
+      echo "Override created to enable $MOD_NAME module. Reboot to take effect."
+    fi
+  
+# reset the override by `just override-enable-module`, i.e. disable the module again (require restart)
+override-reset-module mod_name:
+    #!/usr/bin/pkexec /usr/bin/bash
+    MOD_NAME="{{ mod_name }}"
+    MOD_FILE="/etc/modprobe.d/99-$MOD_NAME.conf"
+    if test -e $MOD_FILE; then
+      sudo rm -f $MOD_FILE
+      echo "Override for $MOD_NAME module has been reset. Reboot to take effect."
+    else
+      echo "No override found for $MOD_NAME module."
+    fi


### PR DESCRIPTION
The `override-enable-module` command will add a `99-<module name>.conf` file in the `modprobe.d` folder, that will enable the kernel module with `<module name>`. 
And the `override-reset-module` command will remove the said file, hence removing the override.

Since `rpm-ostree` will not update files `etc` that have been edited, directly editing `blacklist.conf` will result in the system not receiving crucial changes: like disabling dangerous modules, or enabling necessary modules. 

This PR allows user to enable modules without editing `blacklist.conf`, hence `blacklist.conf` can be updated with the system.