### PR TITLE
Use /bin/false everywhere in kernel module blacklist

### DIFF
--- a/config/files/usr/etc/modprobe.d/blacklist.conf
+++ b/config/files/usr/etc/modprobe.d/blacklist.conf
@@ -1,8 +1,8 @@
 # unused network protocols
-install dccp /bin/true
-install sctp /bin/true
-install rds /bin/true
-install tipc /bin/true
+install dccp /bin/false
+install sctp /bin/false
+install rds /bin/false
+install tipc /bin/false
 install n-hdlc /bin/false
 install ax25 /bin/false
 install netrom /bin/false
@@ -20,14 +20,14 @@ install can /bin/false
 install atm /bin/false
 
 # firewire and thunderbolt
-install firewire-core /bin/true
-install firewire_core /bin/true
-install firewire-ohci /bin/true
-install firewire_ohci /bin/true
-install firewire_sbp2 /bin/true
-install firewire-sbp2 /bin/true
-install firewire-net /bin/true
-install thunderbolt /bin/true
+install firewire-core /bin/false
+install firewire_core /bin/false
+install firewire-ohci /bin/false
+install firewire_ohci /bin/false
+install firewire_sbp2 /bin/false
+install firewire-sbp2 /bin/false
+install firewire-net /bin/false
+install thunderbolt /bin/false
 install ohci1394 /bin/false
 install sbp2 /bin/false
 install dv1394 /bin/false
@@ -42,23 +42,23 @@ install hfs /bin/false
 install hfsplus /bin/false
 install squashfs /bin/false
 install udf /bin/false
-install cifs /bin/true
-install nfs /bin/true
-install nfsv3 /bin/true
-install nfsv4 /bin/true
-install ksmbd /bin/true
-install gfs2 /bin/true
+install cifs /bin/false
+install nfs /bin/false
+install nfsv3 /bin/false
+install nfsv4 /bin/false
+install ksmbd /bin/false
+install gfs2 /bin/false
 
 # disable vivid
 install vivid /bin/false
 
 # disable GNSS
-install gnss /bin/true
-install gnss-mtk /bin/true
-install gnss-serial /bin/true
-install gnss-sirf /bin/true
-install gnss-usb /bin/true
-install gnss-ubx /bin/true
+install gnss /bin/false
+install gnss-mtk /bin/false
+install gnss-serial /bin/false
+install gnss-sirf /bin/false
+install gnss-usb /bin/false
+install gnss-ubx /bin/false
 
 # https://en.wikipedia.org/wiki/Bluetooth#History_of_security_concerns
 install bluetooth /bin/false


### PR DESCRIPTION
Be consistent and use /bin/false everywhere

Using /bin/true everywhere is okay too but it makes debugging harder so I think /bin/false is preferable