### PR TITLE
chore: Rebuild initramfs to include initramfs-related changes from mo…

### DIFF
--- a/config/scripts/initramfs-rebuild.sh
+++ b/config/scripts/initramfs-rebuild.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Rebuild initramfs so initramfs changes are refreshed & deployed inside the image
+rpm-ostree cliwrap install-to-root /
+QUALIFIED_KERNEL="$(rpm -qa | grep -P 'kernel-(\d+\.\d+\.\d+)' | sed -E 's/kernel-//')"
+/usr/libexec/rpm-ostree/wrapped/dracut --no-hostonly --kver "${QUALIFIED_KERNEL}" --reproducible -v --add ostree -f "/lib/modules/${QUALIFIED_KERNEL}/initramfs.img"
+chmod 0600 "/lib/modules/${QUALIFIED_KERNEL}/initramfs.img"

--- a/recipes/common/common-scripts.yml
+++ b/recipes/common/common-scripts.yml
@@ -6,3 +6,4 @@ scripts:
   - homebrewanalyticsoptout.sh
   - hardencontainerpolicy.sh
   - httpsmirrors.sh
+  - initramfs-rebuild.sh


### PR DESCRIPTION
…dprobe & similar

The only thing I'm not sure if modprobe.d modifications should be moved from `/usr/etc/` to `/usr/lib/`.
I think that it should work this way still, unless dracut has some bug.

Bluefin uses the same script to regenerate initramfs.