### PR TITLE
io_uring typo fix

### DIFF
--- a/config/files/usr/etc/sysctl.d/hardening.conf
+++ b/config/files/usr/etc/sysctl.d/hardening.conf
@@ -44,4 +44,4 @@ kernel.core_pattern=|/bin/false
 ## Disable io_uring
 ## https://lore.kernel.org/lkml/20230629132711.1712536-1-matteorizzo@google.com/T/
 ## https://security.googleblog.com/2023/06/learnings-from-kctf-vrps-42-linux.html
-io_uring_disabled = 2
+kernel.io_uring_disabled = 2


### PR DESCRIPTION
This is under /proc/sys/kernel so you need kernel. to be set

https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.3_release_notes/technology-previews#technology-previews-file-systems-and-storage