### PR TITLE
Cleaner syntax for disabling ICMP Redirect

### DIFF
--- a/config/files/usr/etc/sysctl.d/hardening.conf
+++ b/config/files/usr/etc/sysctl.d/hardening.conf
@@ -3,13 +3,10 @@ net.ipv4.conf.all.rp_filter = 1
 net.ipv4.conf.default.rp_filter = 1
 
 # Disable ICMP Redirect Acceptance
-net.ipv4.conf.all.accept_redirects = 0
-net.ipv4.conf.all.send_redirects = 0
-net.ipv4.conf.default.accept_redirects = 0
-net.ipv4.conf.all.secure_redirects = 0
-net.ipv4.conf.default.secure_redirects = 0
-net.ipv6.conf.all.accept_redirects = 0
-net.ipv6.conf.default.accept_redirects = 0
+net.ipv4.conf.*.send_redirects = 0
+net.ipv4.conf.*.accept_redirects = 0
+net.ipv4.conf.*.secure_redirects = 0
+net.ipv6.conf.*.accept_redirects = 0
 
 # Enable Log Spoofed Packets, Source Routed Packets, Redirect Packets
 net.ipv4.conf.all.log_martians = 1


### PR DESCRIPTION
This syntax is cleaner than what is done originally. I and GOS use this syntax.

To further drive the point home, you missed `net.ipv4.conf.default.send_redirects = 0` in the original config