### PR TITLE
Have yafti run `ujust harden-flatpak` instead of duplicating its code

### DIFF
--- a/config/files/usr/share/ublue-os/firstboot/yafti.yml
+++ b/config/files/usr/share/ublue-os/firstboot/yafti.yml
@@ -18,6 +18,7 @@ screens:
         This step will enable hardening for installed flatpaks.
       actions:
         - run: flatpak override --user --filesystem=host-os:ro --env=LD_PRELOAD=/var/run/host/usr/lib64/libhardened_malloc.so
+        - run: uarches=$(/var/run/host/usr/lib64/ld-linux-x86-64.so.2 --help | grep '(supported, searched)' | cut -d'v' -f2); bestuarch=${uarches:0:1}; if [ ! -z "${bestuarch}" ]; then flatpak override --user --env=LD_PRELOAD=/var/run/host/usr/lib64/glibc-hwcaps/x86-64-v$bestuarch/libhardened_malloc.so; fi
 
   can-we-modify-your-flatpaks:
     source: yafti.screen.consent

--- a/config/files/usr/share/ublue-os/firstboot/yafti.yml
+++ b/config/files/usr/share/ublue-os/firstboot/yafti.yml
@@ -17,8 +17,7 @@ screens:
       description: |
         This step will enable hardening for installed flatpaks.
       actions:
-        - run: flatpak override --user --filesystem=host-os:ro --env=LD_PRELOAD=/var/run/host/usr/lib64/libhardened_malloc.so
-        - run: uarches=$(/var/run/host/usr/lib64/ld-linux-x86-64.so.2 --help | grep '(supported, searched)' | cut -d'v' -f2); bestuarch=${uarches:0:1}; if [ ! -z "${bestuarch}" ]; then flatpak override --user --env=LD_PRELOAD=/var/run/host/usr/lib64/glibc-hwcaps/x86-64-v$bestuarch/libhardened_malloc.so; fi
+        - run: ujust harden-flatpak
 
   can-we-modify-your-flatpaks:
     source: yafti.screen.consent

--- a/config/files/usr/share/ublue-os/just/60-custom.just
+++ b/config/files/usr/share/ublue-os/just/60-custom.just
@@ -177,3 +177,13 @@ toggle-anticheat-support:
     else 
         echo "The sysctl hardening file is missing the ptrace_scope setting."
     fi
+
+
+# Detect microarchitecture support and apply highest supported flatpak malloc hwcap
+set-flatpak-malloc-hwcap:
+    #!/usr/bin/pkexec /usr/bin/bash
+    uarches=$(/var/run/host/usr/lib64/ld-linux-x86-64.so.2 --help | grep '(supported, searched)' | cut -d'v' -f2)
+    bestuarch=${uarches:0:1}
+    if [ ! -z "${bestuarch}" ]
+        then flatpak override --user --env=LD_PRELOAD=/var/run/host/usr/lib64/glibc-hwcaps/x86-64-v$bestuarch/libhardened_malloc.so
+    fi

--- a/config/files/usr/share/ublue-os/just/60-custom.just
+++ b/config/files/usr/share/ublue-os/just/60-custom.just
@@ -177,13 +177,3 @@ toggle-anticheat-support:
     else 
         echo "The sysctl hardening file is missing the ptrace_scope setting."
     fi
-
-
-# Detect microarchitecture support and apply highest supported flatpak malloc hwcap
-set-flatpak-malloc-hwcap:
-    #!/usr/bin/pkexec /usr/bin/bash
-    uarches=$(/var/run/host/usr/lib64/ld-linux-x86-64.so.2 --help | grep '(supported, searched)' | cut -d'v' -f2)
-    bestuarch=${uarches:0:1}
-    if [ ! -z "${bestuarch}" ]
-        then flatpak override --user --env=LD_PRELOAD=/var/run/host/usr/lib64/glibc-hwcaps/x86-64-v$bestuarch/libhardened_malloc.so
-    fi


### PR DESCRIPTION
<details><summary>Old</summary>
<p>

Alternative to #322, this adds my automatic hwcap for flatpak override script to yafti instead of ujust.

This script runs ld-linux-x86-64.so.2 --help to identify supported microarchitectures, then applies a flatpak override to set LD_PRELOAD to load the highest supported hwcap for libhardened_malloc.so

The script only edits the flatpak override if v2, v3, or v4 support is detected, so it should run after, and not replace the current override command in yafti.

</p>
</details>

Edit: now we're just abstracting yafti to call `ujust harden-flatpak` and handling the code in ujust