### PR TITLE
Add ujust to toggle Gnome JS JIT

### DIFF
--- a/files/system/usr/etc/profile.d/gnome-disable-jit.sh
+++ b/files/system/usr/etc/profile.d/gnome-disable-jit.sh
@@ -1,0 +1,2 @@
+export JavaScriptCoreUseJIT=0
+export GJS_DISABLE_JIT=1

--- a/files/system/usr/share/ublue-os/just/60-custom.just
+++ b/files/system/usr/share/ublue-os/just/60-custom.just
@@ -177,3 +177,15 @@ toggle-anticheat-support:
     else 
         echo "The sysctl hardening file is missing the ptrace_scope setting."
     fi
+
+# Toggle Gnome JIT JavaScript for GJS and WebkitGTK (requires session restart)
+toggle-gnome-jit-js:
+    #!/usr/bin/pkexec /usr/bin/bash
+    ENV_FILE="/etc/profile.d/gnome-disable-jit.sh"
+    if test -e $ENV_FILE; then
+    	sudo rm -f $ENV_FILE
+    	echo "JIT has been enabled."
+    else
+    	sudo sh -c 'echo -e "export JavaScriptCoreUseJIT=0\nexport GJS_DISABLE_JIT=1" > /etc/profile.d/gnome-disable-jit.sh'
+    	echo "JIT has been disabled."
+    fi


### PR DESCRIPTION
This will disable JIT if it is enabled, and vice versa.
It works by adding a shell script to the system `profile.d` that will `export` 2 environment variables to disable JIT for both WebkitGTK (the engine used by epiphany) and GJS (the mozjs-based engine used by Gnome to render its UI).