### PR TITLE
Add docs to JIT disable in Gnome

### DIFF
--- a/files/system/usr/etc/profile.d/gnome-disable-jit.sh
+++ b/files/system/usr/etc/profile.d/gnome-disable-jit.sh
@@ -1,2 +1,2 @@
-export JavaScriptCoreUseJIT=0 # See https://trac.webkit.org/wiki/EnvironmentVariables
-export GJS_DISABLE_JIT=1 # See https://gitlab.gnome.org/GNOME/gjs/-/blob/master/doc/Environment.md
+export JavaScriptCoreUseJIT=0 # https://trac.webkit.org/wiki/EnvironmentVariables
+export GJS_DISABLE_JIT=1 # https://gitlab.gnome.org/GNOME/gjs/-/blob/master/doc/Environment.md

--- a/files/system/usr/etc/profile.d/gnome-disable-jit.sh
+++ b/files/system/usr/etc/profile.d/gnome-disable-jit.sh
@@ -1,2 +1,2 @@
-export JavaScriptCoreUseJIT=0
-export GJS_DISABLE_JIT=1
+export JavaScriptCoreUseJIT=0 # See https://trac.webkit.org/wiki/EnvironmentVariables
+export GJS_DISABLE_JIT=1 # See https://gitlab.gnome.org/GNOME/gjs/-/blob/master/doc/Environment.md

--- a/files/system/usr/share/ublue-os/just/60-custom.just
+++ b/files/system/usr/share/ublue-os/just/60-custom.just
@@ -186,6 +186,6 @@ toggle-gnome-jit-js:
     	sudo rm -f $ENV_FILE
     	echo "JIT JavaScript for Gnome and WebkitGTK has been enabled."
     else
-    	sudo sh -c 'echo -e "export JavaScriptCoreUseJIT=0 # https://trac.webkit.org/wiki/EnvironmentVariables\nexport GJS_DISABLE_JIT=1 # https://gitlab.gnome.org/GNOME/gjs/-/blob/master/doc/Environment.md" > /etc/profile.d/gnome-disable-jit.sh'
+    	sudo cp /usr/$ENV_FILE $ENV_FILE
     	echo "JIT JavaScript for Gnome and WebkitGTK has been disabled."
     fi

--- a/files/system/usr/share/ublue-os/just/60-custom.just
+++ b/files/system/usr/share/ublue-os/just/60-custom.just
@@ -184,8 +184,8 @@ toggle-gnome-jit-js:
     ENV_FILE="/etc/profile.d/gnome-disable-jit.sh"
     if test -e $ENV_FILE; then
     	sudo rm -f $ENV_FILE
-    	echo "JIT has been enabled."
+    	echo "JIT JavaScript for Gnome and WebkitGTK has been enabled."
     else
-    	sudo sh -c 'echo -e "export JavaScriptCoreUseJIT=0\nexport GJS_DISABLE_JIT=1" > /etc/profile.d/gnome-disable-jit.sh'
-    	echo "JIT has been disabled."
+    	sudo sh -c 'echo -e "export JavaScriptCoreUseJIT=0 # https://trac.webkit.org/wiki/EnvironmentVariables\nexport GJS_DISABLE_JIT=1 # https://gitlab.gnome.org/GNOME/gjs/-/blob/master/doc/Environment.md" > /etc/profile.d/gnome-disable-jit.sh'
+    	echo "JIT JavaScript for Gnome and WebkitGTK has been disabled."
     fi


### PR DESCRIPTION
Adds links to variable's documentation.
Also improves clarity on what JIT is being disabled for in the just output.