### PR TITLE
Add to harden-flatpak logic that applies the highest supported hwcap

### DIFF
--- a/files/system/usr/share/ublue-os/just/60-custom.just
+++ b/files/system/usr/share/ublue-os/just/60-custom.just
@@ -60,7 +60,7 @@ remove-kargs-hardening:
 harden-flatpak:
     #!/usr/bin/bash
     flatpak override --user --filesystem=host-os:ro
-    #`ld-linux-x86-64.so.2 --help` prints ld.so linker info, including detected hwcaps support. Grep those, then use cut and substring selection (:0:1) to isolate the 1st character after 'v', which will be 4, 3, or 2, corresponding to the system's highest supported hwcap. On x86_64-v1 systems, grep finds no matches, leaving our variables empty.
+    #`ld-linux-x86-64.so.2 --help` prints ld.so linker info, including detected hwcaps support. Grep those, then use cut and substring selection (:0:1) to isolate the 1st character after 'v', which will be 4, 3, or 2, corresponding to the systems highest supported hwcap. On x86_64-v1 systems, grep finds no matches, leaving our variables empty.
     uarches="$(/var/run/host/usr/lib64/ld-linux-x86-64.so.2 --help | grep '(supported, searched)' | cut -d'v' -f2)"
     bestuarch="${uarches:0:1}"
     #If bestuarch is empty, set LD_PRELOAD to the x86-64-v1 arch. If not empty, set LD_PRELOAD to the supported hwcap in $bestuarch.

--- a/files/system/usr/share/ublue-os/just/60-custom.just
+++ b/files/system/usr/share/ublue-os/just/60-custom.just
@@ -60,10 +60,10 @@ remove-kargs-hardening:
 harden-flatpak:
     #!/usr/bin/bash
     flatpak override --user --filesystem=host-os:ro
-    # `ld-linux-x86-64.so.2 --help` prints ld.so linker info, including detected hwcaps support. Grep those, then use cut and substring selection (:0:1) to isolate the 1st character after 'v', which will be 4, 3, or 2, corresponding to the systems highest supported hwcap. On x86_64-v1 systems, grep finds no matches, leaving our variables empty.
+#   `ld-linux-x86-64.so.2 --help` prints ld.so linker info, including detected hwcaps support. Grep those, then use cut and substring selection (:0:1) to isolate the 1st character after 'v', which will be 4, 3, or 2, corresponding to the system's highest supported hwcap. On x86_64-v1 systems, grep finds no matches, leaving our variables empty.
     uarches="$(/var/run/host/usr/lib64/ld-linux-x86-64.so.2 --help | grep '(supported, searched)' | cut -d'v' -f2)"
     bestuarch="${uarches:0:1}"
-    #If bestuarch is empty, set LD_PRELOAD to the x86-64-v1 arch. If not empty, set LD_PRELOAD to the supported hwcap in $bestuarch.
+#   If bestuarch is empty, set LD_PRELOAD to the x86-64-v1 arch. If not empty, set LD_PRELOAD to the supported hwcap in $bestuarch.
     if [ -z "$bestuarch" ] ; then
         echo "No microarchitecture support detected. Using default x86-64-v1 architecture."
         flatpak override --user --env=LD_PRELOAD=/var/run/host/usr/lib64/libhardened_malloc.so

--- a/files/system/usr/share/ublue-os/just/60-custom.just
+++ b/files/system/usr/share/ublue-os/just/60-custom.just
@@ -61,7 +61,7 @@ harden-flatpak:
     #!/usr/bin/bash
     flatpak override --user --filesystem=host-os:ro
 #   `ld-linux-x86-64.so.2 --help` prints ld.so linker info, including detected hwcaps support. Grep those, then use cut and substring selection (:0:1) to isolate the 1st character after 'v', which will be 4, 3, or 2, corresponding to the system's highest supported hwcap. On x86_64-v1 systems, grep finds no matches, leaving our variables empty.
-    uarches="$(/var/run/host/usr/lib64/ld-linux-x86-64.so.2 --help | grep '(supported, searched)' | cut -d'v' -f2)"
+    uarches="$(/usr/lib64/ld-linux-x86-64.so.2 --help | grep '(supported, searched)' | cut -d'v' -f2)"
     bestuarch="${uarches:0:1}"
 #   If bestuarch is empty, set LD_PRELOAD to the x86-64-v1 arch. If not empty, set LD_PRELOAD to the supported hwcap in $bestuarch.
     if [ -z "$bestuarch" ] ; then

--- a/files/system/usr/share/ublue-os/just/60-custom.just
+++ b/files/system/usr/share/ublue-os/just/60-custom.just
@@ -60,7 +60,7 @@ remove-kargs-hardening:
 harden-flatpak:
     #!/usr/bin/bash
     flatpak override --user --filesystem=host-os:ro
-    #`ld-linux-x86-64.so.2 --help` prints ld.so linker info, including detected hwcaps support. Grep those, then use cut and substring selection (:0:1) to isolate the 1st character after 'v', which will be 4, 3, or 2, corresponding to the systems highest supported hwcap. On x86_64-v1 systems, grep finds no matches, leaving our variables empty.
+    # `ld-linux-x86-64.so.2 --help` prints ld.so linker info, including detected hwcaps support. Grep those, then use cut and substring selection (:0:1) to isolate the 1st character after 'v', which will be 4, 3, or 2, corresponding to the systems highest supported hwcap. On x86_64-v1 systems, grep finds no matches, leaving our variables empty.
     uarches="$(/var/run/host/usr/lib64/ld-linux-x86-64.so.2 --help | grep '(supported, searched)' | cut -d'v' -f2)"
     bestuarch="${uarches:0:1}"
     #If bestuarch is empty, set LD_PRELOAD to the x86-64-v1 arch. If not empty, set LD_PRELOAD to the supported hwcap in $bestuarch.

--- a/files/system/usr/share/ublue-os/just/60-custom.just
+++ b/files/system/usr/share/ublue-os/just/60-custom.just
@@ -56,10 +56,21 @@ remove-kargs-hardening:
       --delete-if-present="debugfs=off"
     echo "Hardening kargs removed."
 
-# Harden flatpaks by preloading hardened_malloc
+# Harden flatpaks by preloading hardened_malloc (highest supported hwcap)
 harden-flatpak:
     #!/usr/bin/bash
-    flatpak override --user --filesystem=host-os:ro --env=LD_PRELOAD=/var/run/host/usr/lib64/libhardened_malloc.so
+    flatpak override --user --filesystem=host-os:ro
+    #`ld-linux-x86-64.so.2 --help` prints ld.so linker info, including detected hwcaps support. Grep those, then use cut and substring selection (:0:1) to isolate the 1st character after 'v', which will be 4, 3, or 2, corresponding to the system's highest supported hwcap. On x86_64-v1 systems, grep finds no matches, leaving our variables empty.
+    uarches="$(/var/run/host/usr/lib64/ld-linux-x86-64.so.2 --help | grep '(supported, searched)' | cut -d'v' -f2)"
+    bestuarch="${uarches:0:1}"
+    #If bestuarch is empty, set LD_PRELOAD to the x86-64-v1 arch. If not empty, set LD_PRELOAD to the supported hwcap in $bestuarch.
+    if [ -z "$bestuarch" ] ; then
+        echo "No microarchitecture support detected. Using default x86-64-v1 architecture."
+        flatpak override --user --env=LD_PRELOAD=/var/run/host/usr/lib64/libhardened_malloc.so
+    else
+        echo "x86-64-v$bestuarch support detected. Using x86-64-v$bestuarch microarchitecture."
+        flatpak override --user --env=LD_PRELOAD=/var/run/host/usr/lib64/glibc-hwcaps/x86-64-v"$bestuarch"/libhardened_malloc.so
+    fi
 
 # Toggle the cups service on/off
 toggle-cups:


### PR DESCRIPTION
checks detected hwcaps support and applies the highest supported hwcap for libhardened_malloc.so