### PR TITLE
Remove Totem (gnome videos) in gnome-packages.yml

### DIFF
--- a/recipes/common/gnome-packages.yml
+++ b/recipes/common/gnome-packages.yml
@@ -15,3 +15,4 @@ remove:
   - malcontent-ui-libs
   - malcontent-control
   - fedora-chromium-config-gnome
+  - Totem


### PR DESCRIPTION
remove Totem, the gnome videos app, because it has been abandoned