### PR TITLE
fix: remove -base from the naming scheme of the cosmic images

### DIFF
--- a/recipes/general/recipe-cosmic-main-userns.yml
+++ b/recipes/general/recipe-cosmic-main-userns.yml
@@ -2,7 +2,7 @@ name: cosmic-main-userns-hardened
 
 description: "Cosmic main with some hardening applied"
 
-base-image: ghcr.io/ublue-os/cosmic-base
+base-image: ghcr.io/ublue-os/cosmic
 
 image-version: 40
 

--- a/recipes/general/recipe-cosmic-main.yml
+++ b/recipes/general/recipe-cosmic-main.yml
@@ -2,7 +2,7 @@ name: cosmic-main-hardened
 
 description: "Cosmic main with some hardening applied"
 
-base-image: ghcr.io/ublue-os/cosmic-base
+base-image: ghcr.io/ublue-os/cosmic
 
 image-version: 40
 

--- a/recipes/general/recipe-cosmic-nvidia-userns.yml
+++ b/recipes/general/recipe-cosmic-nvidia-userns.yml
@@ -2,7 +2,7 @@ name: cosmic-nvidia-userns-hardened
 
 description: "Cosmic nvidia with some hardening applied"
 
-base-image: ghcr.io/ublue-os/cosmic-base-nvidia
+base-image: ghcr.io/ublue-os/cosmic-nvidia
 
 image-version: 40
 

--- a/recipes/general/recipe-cosmic-nvidia.yml
+++ b/recipes/general/recipe-cosmic-nvidia.yml
@@ -2,7 +2,7 @@ name: cosmic-nvidia-hardened
 
 description: "Cosmic nvidia with some hardening applied"
 
-base-image: ghcr.io/ublue-os/cosmic-base-nvidia
+base-image: ghcr.io/ublue-os/cosmic-nvidia
 
 image-version: 40
 


### PR DESCRIPTION
fix: This follows a naming change upstream