### PR TITLE
feat: add check for hardened_malloc flatpak preload

### DIFF
--- a/files/system/usr/share/ublue-os/just/70-secureblue.just
+++ b/files/system/usr/share/ublue-os/just/70-secureblue.just
@@ -572,6 +572,10 @@ audit-secureblue:
                 status="$STATUS_FAILURE"
                 warnings+=("> $f has x11 access!")
             fi
+            if ! hasPermission "$permissions" "LD_PRELOAD" .*"/libhardened_malloc.so"; then
+                status="$STATUS_FAILURE"
+                warnings+=("> $f is not using hardened_malloc!")
+            fi
             flatpak_test_string="Auditing $f"
             print_status "$flatpak_test_string" "$status"
             for warning in "${warnings[@]}"; do

--- a/files/system/usr/share/ublue-os/just/70-secureblue.just
+++ b/files/system/usr/share/ublue-os/just/70-secureblue.just
@@ -356,7 +356,7 @@ audit-secureblue:
         local line=$(grep "^${prefix}=" <<< "$permissions" | sed -e "s/^${prefix}=//" -e "s/#.*//")
         IFS=';' read -r -a list <<< "$line"
         for p in ${list[@]}; do
-            if [[ "$p" =~ $query ]]; then
+            if [[ "$p" =~ ^$query$ ]]; then
                 return
             fi
         done

--- a/files/system/usr/share/ublue-os/just/70-secureblue.just
+++ b/files/system/usr/share/ublue-os/just/70-secureblue.just
@@ -356,7 +356,7 @@ audit-secureblue:
         local line=$(grep "^${prefix}=" <<< "$permissions" | sed -e "s/^${prefix}=//" -e "s/#.*//")
         IFS=';' read -r -a list <<< "$line"
         for p in ${list[@]}; do
-            if [[ "$p" == "$query" ]]; then
+            if [[ "$p" =~ $query ]]; then
                 return
             fi
         done
@@ -559,30 +559,24 @@ audit-secureblue:
             flatpaks+=(["${ref}"]="${ref}//${version}")
         done <<<$(flatpak list | sort -k 1 | cut --fields 2,4)
         for f in ${!flatpaks[@]}; do
-            has_network=false
-            has_x11=false
+            warnings=()
+            status="$STATUS_SUCCESS"
             fullref=${flatpaks["$f"]}
             permissions=$(flatpak info --show-permissions "$fullref")
+
             if hasPermission "$permissions" "shared" "network"; then
-                has_network=true
+                [[ "$status" != "$STATUS_FAILURE" ]] && status="$STATUS_WARNING"
+                warnings+=("> $f has network access!")
             fi
-            if hasPermission "$permissions" "sockets" "x11" && ! hasPermission "$permissions" "sockets" "fallback-x11"  ]]; then
-                has_x11=true
+            if hasPermission "$permissions" "sockets" "x11" && ! hasPermission "$permissions" "sockets" "fallback-x11"; then
+                status="$STATUS_FAILURE"
+                warnings+=("> $f has x11 access!")
             fi
             flatpak_test_string="Auditing $f"
-            if [[ ! $has_network == "true" && ! $has_x11 == "true" ]]; then
-                print_status "$flatpak_test_string" "$STATUS_SUCCESS"
-            elif [[ $has_x11 == "true" ]]; then
-                print_status "$flatpak_test_string" "$STATUS_FAILURE"
-            elif [[ $has_network == "true" ]]; then
-                print_status "$flatpak_test_string" "$STATUS_WARNING"
-            fi
-            if [[ $has_network == "true" ]]; then
-                echo "> $f has network access!"
-            fi
-            if [[ $has_x11 == "true" ]]; then
-                echo "> $f has x11 access!"
-            fi
+            print_status "$flatpak_test_string" "$status"
+            for warning in "${warnings[@]}"; do
+                echo "$warning"
+            done
         done
     fi
 


### PR DESCRIPTION
Chose failure for no preload based on design principles—incompatibility with hardened_malloc is more a flaw in an application than it is a necessity like network access.

Also added some ternary logic for `status` to make things a little more extensible for future checks.

Closes #411