### PR TITLE
feat: refactor flatpak audit for readability and extensibility

### DIFF
--- a/files/system/usr/share/ublue-os/just/70-secureblue.just
+++ b/files/system/usr/share/ublue-os/just/70-secureblue.just
@@ -536,22 +536,19 @@ audit-secureblue:
         for f in ${!flatpaks[@]}; do
             has_network=false
             has_x11=false
+            status="$STATUS_SUCCESS"
             fullref=${flatpaks["$f"]}
             permissions=$(flatpak info --show-permissions "$fullref")
             if hasPermission "$permissions" "shared" "network"; then
                 has_network=true
+                [[ "$status" != "$STATUS_FAILURE" ]] && status="$STATUS_WARNING"
             fi
             if hasPermission "$permissions" "sockets" "x11" && ! hasPermission "$permissions" "sockets" "fallback-x11"  ]]; then
                 has_x11=true
+                status="$STATUS_FAILURE"
             fi
             flatpak_test_string="Auditing $f"
-            if [[ ! $has_network == "true" && ! $has_x11 == "true" ]]; then
-                print_status "$flatpak_test_string" "$STATUS_SUCCESS"
-            elif [[ $has_x11 == "true" ]]; then
-                print_status "$flatpak_test_string" "$STATUS_FAILURE"
-            elif [[ $has_network == "true" ]]; then
-                print_status "$flatpak_test_string" "$STATUS_WARNING"
-            fi
+            print_status "$flatpak_test_string" "$status"
             if [[ $has_network == "true" ]]; then
                 echo "> $f has network access!"
             fi

--- a/files/system/usr/share/ublue-os/just/70-secureblue.just
+++ b/files/system/usr/share/ublue-os/just/70-secureblue.just
@@ -534,27 +534,24 @@ audit-secureblue:
             flatpaks+=(["${ref}"]="${ref}//${version}")
         done <<<$(flatpak list | sort -k 1 | cut --fields 2,4)
         for f in ${!flatpaks[@]}; do
-            has_network=false
-            has_x11=false
+            warnings=()
             status="$STATUS_SUCCESS"
             fullref=${flatpaks["$f"]}
             permissions=$(flatpak info --show-permissions "$fullref")
+
             if hasPermission "$permissions" "shared" "network"; then
-                has_network=true
                 [[ "$status" != "$STATUS_FAILURE" ]] && status="$STATUS_WARNING"
+                warnings+=("> $f has network access!")
             fi
             if hasPermission "$permissions" "sockets" "x11" && ! hasPermission "$permissions" "sockets" "fallback-x11"; then
-                has_x11=true
                 status="$STATUS_FAILURE"
+                warnings+=("> $f has x11 access!")
             fi
             flatpak_test_string="Auditing $f"
             print_status "$flatpak_test_string" "$status"
-            if [[ $has_network == "true" ]]; then
-                echo "> $f has network access!"
-            fi
-            if [[ $has_x11 == "true" ]]; then
-                echo "> $f has x11 access!"
-            fi
+            for warning in "${warnings[@]}"; do
+                echo "$warning"
+            done
         done
     fi
 

--- a/files/system/usr/share/ublue-os/just/70-secureblue.just
+++ b/files/system/usr/share/ublue-os/just/70-secureblue.just
@@ -543,7 +543,7 @@ audit-secureblue:
                 has_network=true
                 [[ "$status" != "$STATUS_FAILURE" ]] && status="$STATUS_WARNING"
             fi
-            if hasPermission "$permissions" "sockets" "x11" && ! hasPermission "$permissions" "sockets" "fallback-x11"  ]]; then
+            if hasPermission "$permissions" "sockets" "x11" && ! hasPermission "$permissions" "sockets" "fallback-x11"; then
                 has_x11=true
                 status="$STATUS_FAILURE"
             fi


### PR DESCRIPTION
Rather than calculating the status at the end of the check, each permission check should downgrade the status accordingly. Network will downgrade SUCCESS to WARNING, but not touch FAILURE, and so on.
This is significantly more readable, as the status is set in the same block that does the actual check, rather than being nested with boolean logic in `test`.
Likewise, this is more extensible: the only requirements for a new permissions check are a new boolean `has_permission`, a block that performs the check and downgrades the status, and a block that prints a message prepended with `> ` at the end.