### PR TITLE
Replace Extension Manager with Extensions

### DIFF
--- a/files/system/usr/share/ublue-os/firstboot/yafti.yml
+++ b/files/system/usr/share/ublue-os/firstboot/yafti.yml
@@ -57,7 +57,7 @@ screens:
             - Disk Usage Analyzer: org.gnome.baobab
             - Document Scanner: org.gnome.SimpleScan
             - Document Viewer: org.gnome.Evince
-            - Extension Manager: com.mattjakeman.ExtensionManager
+            - Extensions: org.gnome.Extensions
             - Font Viewer: org.gnome.font-viewer
             - Image Viewer: org.gnome.Loupe
             - Logs: org.gnome.Logs


### PR DESCRIPTION
As the only trusted extensions are now system extensions, a lot of the features of Extensions Manager are unnecessary in a fresh install, and it adds an extra party of trust as it's an unofficial app. Extensions is officially apart of Gnome Project, and has less permissions, so should be safer.