### PR TITLE
remove quotes from "privacy" and add a comma for grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ secureblue applies hardening with the following goals in mind:
 - Avoid sacrificing usability for most use cases where possible
 
 The following are not in scope:
-- Anything that sacrifices security for "privacy". Fedora is already sufficiently private and "privacy" often serves as a euphemism for security theater. This is especially true when at odds with improving security.
-- Anything related to "degoogling" chromium. For example, we will not be replacing [hardened-chromium](https://github.com/secureblue/hardened-chromium) with Brave or ungoogled-chromium. Both of them make changes that sacrifice security for "privacy", such as enabling MV2. <sup>[why?](https://developer.chrome.com/docs/extensions/develop/migrate/improve-security)</sup>
+- Anything that sacrifices security for privacy. Fedora is already sufficiently private, and privacy often serves as a euphemism for security theater. This is especially true when at odds with improving security.
+- Anything related to "degoogling" chromium. For example, we will not be replacing [hardened-chromium](https://github.com/secureblue/hardened-chromium) with Brave or ungoogled-chromium. Both of them make changes that sacrifice security for privacy, such as enabling MV2. <sup>[why?](https://developer.chrome.com/docs/extensions/develop/migrate/improve-security)</sup>
 
 # Hardening
 


### PR DESCRIPTION
Quotes aren't needed on "privacy", and using them unnecessarily may be needlessly confusing or interpreted as hostile.

Also a comma has been added between the two phrases of the Fedora sentence.