### PR TITLE
fix: only install brew on desktop images

### DIFF
--- a/recipes/common/common-modules.yml
+++ b/recipes/common/common-modules.yml
@@ -26,8 +26,6 @@ modules:
         - source: system/etc
           destination: /etc
     - from-file: common/common-scripts.yml
-    - type: brew 
-      brew-analytics: false
     - type: script
       scripts:
         - enablecommonautoupdate.sh

--- a/recipes/common/desktop-modules.yml
+++ b/recipes/common/desktop-modules.yml
@@ -16,3 +16,5 @@ modules:
       scripts:
         - enableflatpakautoupdate.sh
     - type: yafti
+    - type: brew 
+      brew-analytics: false


### PR DESCRIPTION
For some reason, installing brew on coreos disables selinux.