### PR TITLE
feat: audit-secureblue: check for filesystem=host:ro and device=all

### DIFF
--- a/files/system/usr/share/ublue-os/just/70-secureblue.just
+++ b/files/system/usr/share/ublue-os/just/70-secureblue.just
@@ -669,9 +669,10 @@ audit-secureblue:
             status="$STATUS_FAILURE"
                 warnings+=("> $f has inter-process communications access!")
             fi
-            if hasPermission "$permissions" "device" "all"; then
+            if hasPermission "$permissions" "devices" "all"; then
                 [[ "$status" != "$STATUS_FAILURE" ]] && status="$STATUS_WARNING"
-                warnings+=("> $f has access to all devices!")
+                warnings+=("> $f has device=all permission,
+> granting access to GPU, input devices, virtualizaton, and shared memory!")
             fi
             flatpak_test_string="Auditing $f"
             print_status "$flatpak_test_string" "$status"

--- a/files/system/usr/share/ublue-os/just/70-secureblue.just
+++ b/files/system/usr/share/ublue-os/just/70-secureblue.just
@@ -672,7 +672,8 @@ audit-secureblue:
             if hasPermission "$permissions" "devices" "all"; then
                 [[ "$status" != "$STATUS_FAILURE" ]] && status="$STATUS_WARNING"
                 warnings+=("> $f has device=all permission,
-> granting access to GPU, input devices, and virtualization!")
+> granting access to GPU, input devices, raw USB, and virtualization,
+> and introducing a vector for sandbox escapes!")
             fi
             flatpak_test_string="Auditing $f"
             print_status "$flatpak_test_string" "$status"

--- a/files/system/usr/share/ublue-os/just/70-secureblue.just
+++ b/files/system/usr/share/ublue-os/just/70-secureblue.just
@@ -672,7 +672,7 @@ audit-secureblue:
             if hasPermission "$permissions" "devices" "all"; then
                 [[ "$status" != "$STATUS_FAILURE" ]] && status="$STATUS_WARNING"
                 warnings+=("> $f has device=all permission,
-> granting access to GPU, input devices, virtualization, and shared memory!")
+> granting access to GPU, input devices, and virtualization!")
             fi
             flatpak_test_string="Auditing $f"
             print_status "$flatpak_test_string" "$status"

--- a/files/system/usr/share/ublue-os/just/70-secureblue.just
+++ b/files/system/usr/share/ublue-os/just/70-secureblue.just
@@ -672,7 +672,7 @@ audit-secureblue:
             if hasPermission "$permissions" "devices" "all"; then
                 [[ "$status" != "$STATUS_FAILURE" ]] && status="$STATUS_WARNING"
                 warnings+=("> $f has device=all permission,
-> granting access to GPU, input devices, virtualizaton, and shared memory!")
+> granting access to GPU, input devices, virtualization, and shared memory!")
             fi
             flatpak_test_string="Auditing $f"
             print_status "$flatpak_test_string" "$status"

--- a/files/system/usr/share/ublue-os/just/70-secureblue.just
+++ b/files/system/usr/share/ublue-os/just/70-secureblue.just
@@ -652,6 +652,11 @@ audit-secureblue:
                 status="$STATUS_FAILURE"
                 warnings+=("> $f is not using hardened_malloc!")
             fi
+            if ! hasPermission "$permissions" "filesystems" "host-os:ro"; then
+                status="$STATUS_FAILURE"
+                warnings+=("> $f is missing host-os:ro permission,
+> which is needed to load hardened_malloc!")
+            fi
             if [[ "$bluetooth_loaded" == "true" ]] && hasPermission "$permissions" "features" "bluetooth"; then
                 status="$STATUS_FAILURE"
                 warnings+=("> $f has bluetooth access!")
@@ -663,6 +668,10 @@ audit-secureblue:
             if hasPermission "$permissions" "shared" "ipc"; then
             status="$STATUS_FAILURE"
                 warnings+=("> $f has inter-process communications access!")
+            fi
+            if hasPermission "$permissions" "device" "all"; then
+                [[ "$status" != "$STATUS_FAILURE" ]] && status="$STATUS_WARNING"
+                warnings+=("> $f has access to all devices!")
             fi
             flatpak_test_string="Auditing $f"
             print_status "$flatpak_test_string" "$status"


### PR DESCRIPTION
filesystem=host:ro is needed by hardened_malloc
device=all weakens the sandbox and grants webcam/mic access