### PR TITLE
fix: remove redundant pkexec line in kargs commands

### DIFF
--- a/files/system/usr/share/ublue-os/just/70-secureblue.just
+++ b/files/system/usr/share/ublue-os/just/70-secureblue.just
@@ -1,6 +1,6 @@
 # Add additional boot parameters for hardening (requires reboot)
 set-kargs-hardening:
-    #!/usr/bin/pkexec /usr/bin/bash
+    #!/usr/bin/bash
     read -p "Do you need support for 32-bit processes/syscalls? (This is mostly used by legacy software, with some exceptions, such as Steam) [y/N]: " YES
     if [[ "$YES" == [Yy]* ]]; then
         echo "Keeping 32-bit support."
@@ -51,7 +51,7 @@ set-kargs-hardening:
 
 # Remove all hardening boot parameters (requires reboot)
 remove-kargs-hardening:
-    #!/usr/bin/pkexec /usr/bin/bash
+    #!/usr/bin/bash
     rpm-ostree kargs \
       --delete-if-present="init_on_alloc=1" \
       --delete-if-present="init_on_free=1" \


### PR DESCRIPTION
`rpm-ostree` already calls polkit for authorisation, and these commands only run `rpm-ostree` once, by starting the scripts with pkexec you're assuming `rpm-ostree` is already a fully trusted program before it even has the chance to call polkit by itself.