### PR TITLE
[FEAT] Add ujust debug-info

### DIFF
--- a/files/system/usr/share/ublue-os/just/70-secureblue.just
+++ b/files/system/usr/share/ublue-os/just/70-secureblue.just
@@ -672,3 +672,7 @@ audit-secureblue:
         done
     fi
 
+#Debug pastebin for issue reporting
+debug-info: 
+    #!/usr/bin/bash 
+    fpaste <(echo "=== Rpm-Ostree Status ===" && rpm-ostree status) <(fpaste --sysinfo --printonly) <(echo "=== Flatpaks Installed ===" && flatpak list --columns=application,version,options) <(echo "=== Audit Results ===" && ujust audit-secureblue) <(echo "=== Listing Local Overrides ===" && ujust check-local-overrides) <(echo "=== Recent System Events ===" && journalctl -b -p err..alert --since "1 hour ago") <(echo "=== Failed Services ===" && systemctl list-units --state=failed)


### PR DESCRIPTION
issue:https://github.com/secureblue/secureblue/issues/479
Adds a debug-info script to collect and share system information and debug data. The script uses fpaste to upload the output of several system commands to a pastebin service, including rpm-ostree status, system information, installed Flatpaks, audit results, local overrides, recent system events, and failed services. This script can be used to help with debugging and troubleshooting system issues by providing a comprehensive overview of the system's current state.





