### PR TITLE
docs: fix dead links, add missing items

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for taking the time to look into helping out!
 All contributions are appreciated!
-Please refer to our [Code of Conduct](/CODE_OF_CONDUCT.md) while you're at it!
+Please refer to our [Code of Conduct](CODE_OF_CONDUCT.md) while you're at it!
 
 Feel free to report issues as you find them!
 
@@ -32,7 +32,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the
-[CONTRIBUTING.md Code of Conduct](/CODE_OF_CONDUCT.md).
+[CONTRIBUTING.md Code of Conduct](CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
 to secureblueadmin@proton.me
 

--- a/docs/POSTINSTALL-README.md
+++ b/docs/POSTINSTALL-README.md
@@ -44,7 +44,7 @@ ujust enroll-secure-boot-key
 ```
 ujust set-kargs-hardening
 ```
-This command applies a fixed set of hardened boot parameters, and asks you whether or not the following kargs should *also* be set along with those (all of which are detailed in the link above):
+This command applies a fixed set of hardened boot parameters, and asks you whether or not the following kargs should *also* be set along with those (all of which are documented in the link above):
 
 ### 32-bit support
 If you answer `N`, or press enter without any input, support for 32-bit programs will be disabled on the next boot. If you run exclusively modern software, chances are likely you don't need this, so it's safe to disable for additional attack surface reduction.

--- a/docs/POSTINSTALL-README.md
+++ b/docs/POSTINSTALL-README.md
@@ -57,7 +57,7 @@ If you answer `Y` when prompted, simultaneous multithreading (SMT, often called 
 Note that in most hardware SMT will be disabled anyways to mitigate a known vulnerability. This option turns it off on all hardware regardless.
 
 ### Unstable hardening kargs
-If you answer `Y` when prompted, additional (unstable) hardening kargs will be applied, which can cause issues on some hardware, but stable on other hardware.
+If you answer `Y` when prompted, unstable hardening kargs will be aditionally applied, which can cause issues on some hardware, but are stable on other hardware.
 
 ## Setup USBGuard
 

--- a/docs/POSTINSTALL-README.md
+++ b/docs/POSTINSTALL-README.md
@@ -39,17 +39,23 @@ ujust enroll-secure-boot-key
 ## Set hardened kargs
 
 > [!NOTE]
-> Learn about the hardening applied by the kargs set by the command below [here](files/system/usr/share/ublue-os/just/70-secureblue.just.readme.md).
+> Learn about the hardening applied by the kargs set by the command below [here](/files/system/usr/share/ublue-os/just/70-secureblue.just.readme.md).
 
 ```
 ujust set-kargs-hardening
 ```
-When you run the command, it will ask a couple questions for if you want to apply additional boot parameters, after that a set of hardened boot parameters will be applied, as well as the ones applied by your choices. (These kargs are *also* documented in the [link above](files/system/usr/share/ublue-os/just/70-secureblue.just.readme.md#additional-unstable-kargs))
+This command applies a fixed set of hardened boot parameters, and asks you whether or not the following kargs should *also* be set along with those (all of which are detailed in the link above):
 
 ### 32-bit support
 If you answer `N`, or press enter without any input, support for 32-bit programs will be disabled on the next boot. If you run exclusively modern software, chances are likely you don't need this, so it's safe to disable for additional attack surface reduction.
 
 However, there are certain exceptions. A couple common usecases are if you need Steam, or run an ocassional application in Wine you'll likely want to keep support for 32-bit programs. If this is the case, answer `Y`.
+
+### Force disable simultaneous multithreading
+If you answer `Y` when prompted, simultaneous multithreading (SMT, often called Hyperthreading) will be forcefully disabled. This can cause a reduction in the performance of certain tasks in favor of security.
+
+Note that in most hardware SMT will be disabled anyways to mitigate a known vulnerability. This option turns it off on all hardware regardless.
+
 ### Unstable hardening kargs
 If you answer `Y` when prompted, additional (unstable) hardening kargs will be applied, which can cause issues on some hardware, but stable on other hardware.
 

--- a/docs/POSTINSTALL-README.md
+++ b/docs/POSTINSTALL-README.md
@@ -52,12 +52,10 @@ If you answer `N`, or press enter without any input, support for 32-bit programs
 However, there are certain exceptions. A couple common usecases are if you need Steam, or run an ocassional application in Wine you'll likely want to keep support for 32-bit programs. If this is the case, answer `Y`.
 
 ### Force disable simultaneous multithreading
-If you answer `Y` when prompted, simultaneous multithreading (SMT, often called Hyperthreading) will be forcefully disabled. This can cause a reduction in the performance of certain tasks in favor of security.
-
-Note that in most hardware SMT will be disabled anyways to mitigate a known vulnerability. This option turns it off on all hardware regardless.
+If you answer `Y` when prompted, simultaneous multithreading (SMT, often called Hyperthreading) will be disabled on all hardware, regardless of known vulnerabilities. This can cause a reduction in the performance of certain tasks in favor of security.
 
 ### Unstable hardening kargs
-If you answer `Y` when prompted, unstable hardening kargs will be aditionally applied, which can cause issues on some hardware, but are stable on other hardware.
+If you answer `Y` when prompted, unstable hardening kargs will be additionally applied, which can cause issues on some hardware, but are stable on other hardware.
 
 ## Setup USBGuard
 

--- a/files/system/usr/share/ublue-os/just/70-secureblue.just.readme.md
+++ b/files/system/usr/share/ublue-os/just/70-secureblue.just.readme.md
@@ -80,7 +80,7 @@
 
 ### Force disable simultaneous multithreading
 
-**Disables this hardware feature on user request, regardless of mitigation necessity**
+**Disables this hardware feature on user request, regardless of whether it is affected by known vulnerabilities**
 
 `nosmt=force`
 

--- a/files/system/usr/share/ublue-os/just/70-secureblue.just.readme.md
+++ b/files/system/usr/share/ublue-os/just/70-secureblue.just.readme.md
@@ -78,6 +78,12 @@
 
 `gather_data_sampling=force`
 
+### Force disable simultaneous multithreading
+
+**Disables this hardware feature on user request, regardless of mitigation necessity**
+
+`nosmt=force`
+
 ### Additional (unstable) kargs
 
 **Fill IOMMU protection gap by setting the busmaster bit during early boot**


### PR DESCRIPTION
Fixes links that were broken in the `docs` folder change, adds the missing `nosmt=force` item in the kargs readme and in the post-install readme, and attempts to further simplify the language used in the description of hardened kargs settings.