### PR TITLE
feat: add harden-one-flatpak ujust command

### DIFF
--- a/files/system/usr/share/ublue-os/just/70-secureblue.just
+++ b/files/system/usr/share/ublue-os/just/70-secureblue.just
@@ -93,6 +93,19 @@ harden-flatpak:
         flatpak override --user --env=LD_PRELOAD=/var/run/host/usr/lib64/glibc-hwcaps/x86-64-v"$bestuarch"/libhardened_malloc.so
     fi
 
+# Harden a specified flatpak by preloading hardened_malloc (highest supported hwcap)
+harden-one-flatpak:
+    #!/usr/bin/bash
+    uarches="$(/usr/lib64/ld-linux-x86-64.so.2 --help | grep '(supported, searched)' | cut -d'v' -f2)"
+    bestuarch="${uarches:0:1}"
+    if [ -z "$bestuarch" ] ; then
+        echo "No microarchitecture support detected. Using default x86-64-v1 architecture for $1's malloc."
+        flatpak override --user --env=LD_PRELOAD=/var/run/host/usr/lib64/libhardened_malloc.so "$1"
+    else
+        echo "x86-64-v$bestuarch support detected. Using x86-64-v$bestuarch microarchitecture for $1's malloc."
+        flatpak override --user --env=LD_PRELOAD=/var/run/host/usr/lib64/glibc-hwcaps/x86-64-v"$bestuarch"/libhardened_malloc.so "$1"
+    fi
+
 # Toggle the cups service on/off
 toggle-cups:
     #!/usr/bin/pkexec /usr/bin/bash


### PR DESCRIPTION
adds a new ujust command to apply the hardened_malloc envar to a specified flatpak. This way, the audit-ujust script can recommend users run `ujust harden-one-flatpak $someflatpak` to enable the best hwcap version of their hardened_malloc library as an override for a particular flatpak (as opposed to the global override, which app-specific overrides take priority over).

This script omits `flatpak override --user --filesystem=host-os:ro $1` as it is just as easy to tell users to run that, and the flatpak audit suggestions #528 will do that once the filesystem=host:ro check #535 is merged. I'm not sure whether we want to include the host-os:ro override in this command. On the one hand, a user might expect this harden-one-flatpak ujust command to fully enable the hadened_malloc. On the other hand, needlessly enabling the per-app host-os:ro override may not be ideal (due to its priority over the global override).