### PR TITLE
chore: add cleanup for chrony state

### DIFF
--- a/files/system/etc/tmpfiles.d/chrony.conf
+++ b/files/system/etc/tmpfiles.d/chrony.conf
@@ -1,0 +1,1 @@
+d /var/lib/chrony 0755 chrony chrony 30d


### PR DESCRIPTION
From GrapheneOS: ntsdumpdir gradually creates stale state.