### PR TITLE
feat: add ujust debug-info round2

### DIFF
--- a/files/justfiles/secureblue.just
+++ b/files/justfiles/secureblue.just
@@ -669,7 +669,16 @@ audit-secureblue:
         done
     fi
 
-# Debug pastebin for issue reporting
+# Debug dump pastebin for issue reporting
 debug-info: 
-    #!/usr/bin/bash 
-    fpaste --confirm --private <(echo "=== Rpm-Ostree Status ===" && rpm-ostree status) <(fpaste --sysinfo --printonly) <(echo "=== Flatpaks Installed ===" && flatpak list --columns=application,version,options) <(echo "=== Audit Results ===" && ujust audit-secureblue) <(echo "=== Listing Local Overrides ===" && ujust check-local-overrides) <(echo "=== Recent System Events ===" && journalctl -b -p err..alert --since "1 hour ago") <(echo "=== Failed Services ===" && systemctl list-units --state=failed)
+    #!/usr/bin/bash
+    rpm_ostree_status=$(echo -e "=== Rpm-Ostree Status ===\n"; rpm-ostree status --verbose)
+    sysinfo=$(echo -e "\n"; fpaste --sysinfo --printonly)
+    flatpaks=$(echo "=== Flatpaks Installed ==="; flatpak list --columns=application,version,options)
+    audit_results=$(echo -e "\n=== Audit Results ===\n"; ujust audit-secureblue)
+    local_overrides=$(echo -e "\n=== Listing Local Overrides ===\n"; ujust check-local-overrides)
+    recent_events=$(echo -e "\n=== Recent System Events ===\n"; journalctl -b -p err..alert --since "1 hour ago")
+    failed_services=$(echo -e "\n=== Failed Services ===\n"; systemctl list-units --state=failed)
+    content="$rpm_ostree_status$sysinfo$flatpaks$audit_results$local_overrides$recent_events$failed_services"
+    echo "$content" | fpaste --confirm --private=1
+

--- a/files/justfiles/secureblue.just
+++ b/files/justfiles/secureblue.just
@@ -670,7 +670,8 @@ audit-secureblue:
     fi
 
 # Debug dump pastebin for issue reporting
-debug-info: 
+
+debug-info:
     #!/usr/bin/bash
     rpm_ostree_status=$(echo -e "=== Rpm-Ostree Status ===\n"; rpm-ostree status --verbose)
     sysinfo=$(echo -e "\n"; fpaste --sysinfo --printonly)
@@ -681,4 +682,3 @@ debug-info:
     failed_services=$(echo -e "\n=== Failed Services ===\n"; systemctl list-units --state=failed)
     content="$rpm_ostree_status$sysinfo$flatpaks$audit_results$local_overrides$recent_events$failed_services"
     echo "$content" | fpaste --confirm --private=1
-

--- a/files/justfiles/secureblue.just
+++ b/files/justfiles/secureblue.just
@@ -669,7 +669,7 @@ audit-secureblue:
         done
     fi
 
-#Debug pastebin for issue reporting
+# Debug pastebin for issue reporting
 debug-info: 
     #!/usr/bin/bash 
     fpaste --confirm --private <(echo "=== Rpm-Ostree Status ===" && rpm-ostree status) <(fpaste --sysinfo --printonly) <(echo "=== Flatpaks Installed ===" && flatpak list --columns=application,version,options) <(echo "=== Audit Results ===" && ujust audit-secureblue) <(echo "=== Listing Local Overrides ===" && ujust check-local-overrides) <(echo "=== Recent System Events ===" && journalctl -b -p err..alert --since "1 hour ago") <(echo "=== Failed Services ===" && systemctl list-units --state=failed)

--- a/files/justfiles/secureblue.just
+++ b/files/justfiles/secureblue.just
@@ -668,3 +668,8 @@ audit-secureblue:
             done
         done
     fi
+
+#Debug pastebin for issue reporting
+debug-info: 
+    #!/usr/bin/bash 
+    fpaste --confirm --private <(echo "=== Rpm-Ostree Status ===" && rpm-ostree status) <(fpaste --sysinfo --printonly) <(echo "=== Flatpaks Installed ===" && flatpak list --columns=application,version,options) <(echo "=== Audit Results ===" && ujust audit-secureblue) <(echo "=== Listing Local Overrides ===" && ujust check-local-overrides) <(echo "=== Recent System Events ===" && journalctl -b -p err..alert --since "1 hour ago") <(echo "=== Failed Services ===" && systemctl list-units --state=failed)


### PR DESCRIPTION
issue:https://github.com/secureblue/secureblue/issues/479
Adds a debug-info script to collect and share system information and debug data. The script uses fpaste to upload the output of several system commands to a pastebin service, including rpm-ostree status, system information, installed Flatpaks, audit results, local overrides, recent system events, and failed services. This script can be used to help with debugging and troubleshooting system issues by providing a comprehensive overview of the system's current state.