### PR TITLE
fix: comment description whitespace

### DIFF
--- a/files/justfiles/secureblue.just
+++ b/files/justfiles/secureblue.just
@@ -670,7 +670,6 @@ audit-secureblue:
     fi
 
 # Debug dump pastebin for issue reporting
-
 debug-info:
     #!/usr/bin/bash
     rpm_ostree_status=$(echo -e "=== Rpm-Ostree Status ===\n"; rpm-ostree status --verbose)


### PR DESCRIPTION
the commentary explaining the script was one live above making so it doesn't show its explanation when you run ujust