### PR TITLE
fix: remove sushi and gnome photos from yafti

### DIFF
--- a/files/system/usr/share/ublue-os/firstboot/yafti.yml
+++ b/files/system/usr/share/ublue-os/firstboot/yafti.yml
@@ -62,8 +62,6 @@ screens:
             - Image Viewer: org.gnome.Loupe
             - Logs: org.gnome.Logs
             - Maps: org.gnome.Maps
-            - Photos (Organizer): org.gnome.Photos
-            - Sushi (Nautilus Previewer): org.gnome.NautilusPreviewer
             - Text Editor: org.gnome.TextEditor
             - Weather: org.gnome.Weather
 

--- a/recipes/common/silverblue-modules.yml
+++ b/recipes/common/silverblue-modules.yml
@@ -6,7 +6,6 @@ modules:
         - adw-gtk3-theme
         - gnome-epub-thumbnailer
         - gnome-tweaks
-        - sushi
       remove:
         - gnome-tour
         - yelp

--- a/recipes/common/silverblue-modules.yml
+++ b/recipes/common/silverblue-modules.yml
@@ -6,6 +6,7 @@ modules:
         - adw-gtk3-theme
         - gnome-epub-thumbnailer
         - gnome-tweaks
+        - sushi
       remove:
         - gnome-tour
         - yelp


### PR DESCRIPTION
[Sushi](https://flathub.org/apps/org.gnome.NautilusPreviewer) (the nautilus file previewer) and [Gnome Photos](https://flathub.org/apps/org.gnome.Photos) (a photo library app) are not flathub verified, so yafti should not offer to install them.

Fixes #595