### PR TITLE
fix: motd when no image tag is in use

### DIFF
--- a/files/system/usr/libexec/ublue-motd
+++ b/files/system/usr/libexec/ublue-motd
@@ -4,7 +4,11 @@
 
 RPM_OSTREE_STATUS=$(rpm-ostree status --json --booted)
 IMAGE_REF_NAME=$(echo $RPM_OSTREE_STATUS | jq -r '.deployments[0]."container-image-reference" // empty | split("/")[-1]')
-IMAGE_TAG=$(echo $RPM_OSTREE_STATUS | jq -r '.deployments[0]."container-image-reference" // empty | split(":")[-1]')
+if [ -n "$(echo $RPM_OSTREE_STATUS | grep 'hardened:')" ] ; then
+    IMAGE_TAG=$(echo $RPM_OSTREE_STATUS | jq -r '.deployments[0]."container-image-reference" // empty | split(":")[-1]')
+else
+    IMAGE_TAG='ERROR-IMAGE-TAG-MISSING'
+fi
 TIP=""
 
 IMAGE_DATE=$(echo $RPM_OSTREE_STATUS | jq -r '.deployments[0].timestamp')
@@ -24,6 +28,8 @@ done
 
 if $isDeprecated; then
     TIP='**You are on a deprecated image,** [rebase:](https://github.com/secureblue/secureblue/blob/live/files/system/usr/libexec/deprecated-images.json.md)'
+elif [ "$IMAGE_TAG" == 'ERROR-IMAGE-TAG-MISSING' ]; then
+    TIP='**You are missing an image tag, which is unsupported by secureblue. Rebase to the `latest` tag to ensure you continue to receive updates.**'
 elif [ "$IMAGE_TAG" != "latest" ]; then
     TIP='**You are on a specific tag, which is unsupported by secureblue. Rebase to the `latest` tag to ensure you continue to receive updates.**'
 elif [ "$DIFFERENCE" -ge "$WEEK" ]; then


### PR DESCRIPTION
#517 and #519 
This adds preventative logic to make motd work when no image tag is in use, and adds a warning about the issue.