### PR TITLE
fix: add back malcontent ui libs

### DIFF
--- a/recipes/common/silverblue-modules.yml
+++ b/recipes/common/silverblue-modules.yml
@@ -17,8 +17,6 @@ modules:
         - mod_dnssd
         - gnome-remote-desktop
         - libvncserver
-        - malcontent-ui-libs
-        - malcontent-control
         - fedora-chromium-config-gnome
         - gnome-software-rpm-ostree
         - totem-video-thumbnailer


### PR DESCRIPTION
As there's no reason not to include them