### PR TITLE
chore: Switch Silverblue, Kinoite & Sway base images to official quay URL

### DIFF
--- a/recipes/general/recipe-kinoite-main-userns.yml
+++ b/recipes/general/recipe-kinoite-main-userns.yml
@@ -2,7 +2,7 @@ name: kinoite-main-userns-hardened
 
 description: "Kinoite with userns, hardened"
 
-base-image: quay.io/fedora-ostree-desktops/kinoite
+base-image: quay.io/fedora/fedora-kinoite
 
 image-version: 41
 

--- a/recipes/general/recipe-kinoite-main.yml
+++ b/recipes/general/recipe-kinoite-main.yml
@@ -2,7 +2,7 @@ name: kinoite-main-hardened
 
 description: "Kinoite, hardened"
 
-base-image: quay.io/fedora-ostree-desktops/kinoite
+base-image: quay.io/fedora/fedora-kinoite
 
 image-version: 41
 

--- a/recipes/general/recipe-kinoite-nvidia-open-userns.yml
+++ b/recipes/general/recipe-kinoite-nvidia-open-userns.yml
@@ -2,7 +2,7 @@ name: kinoite-nvidia-open-userns-hardened
 
 description: "Kinoite with nvidia-open and userns, hardened"
 
-base-image: quay.io/fedora-ostree-desktops/kinoite
+base-image: quay.io/fedora/fedora-kinoite
 
 image-version: 41
 

--- a/recipes/general/recipe-kinoite-nvidia-open.yml
+++ b/recipes/general/recipe-kinoite-nvidia-open.yml
@@ -2,7 +2,7 @@ name: kinoite-nvidia-open-hardened
 
 description: "Kinoite with nvidia-open, hardened"
 
-base-image: quay.io/fedora-ostree-desktops/kinoite
+base-image: quay.io/fedora/fedora-kinoite
 
 image-version: 41
 

--- a/recipes/general/recipe-kinoite-nvidia-userns.yml
+++ b/recipes/general/recipe-kinoite-nvidia-userns.yml
@@ -2,7 +2,7 @@ name: kinoite-nvidia-userns-hardened
 
 description: "Kinoite with nvidia and userns, hardened"
 
-base-image: quay.io/fedora-ostree-desktops/kinoite
+base-image: quay.io/fedora/fedora-kinoite
 
 image-version: 41
 

--- a/recipes/general/recipe-kinoite-nvidia.yml
+++ b/recipes/general/recipe-kinoite-nvidia.yml
@@ -2,7 +2,7 @@ name: kinoite-nvidia-hardened
 
 description: "Kinoite with nvidia, hardened"
 
-base-image: quay.io/fedora-ostree-desktops/kinoite
+base-image: quay.io/fedora/fedora-kinoite
 
 image-version: 41
 

--- a/recipes/general/recipe-sericea-main-userns.yml
+++ b/recipes/general/recipe-sericea-main-userns.yml
@@ -2,7 +2,7 @@ name: sericea-main-userns-hardened
 
 description: "Sericea with userns, hardened"
 
-base-image: quay.io/fedora-ostree-desktops/sericea
+base-image: quay.io/fedora/fedora-sway-atomic
 
 image-version: 41
 

--- a/recipes/general/recipe-sericea-main.yml
+++ b/recipes/general/recipe-sericea-main.yml
@@ -2,7 +2,7 @@ name: sericea-main-hardened
 
 description: "Sericea, hardened"
 
-base-image: quay.io/fedora-ostree-desktops/sericea
+base-image: quay.io/fedora/fedora-sway-atomic
 
 image-version: 41
 

--- a/recipes/general/recipe-sericea-nvidia-open-userns.yml
+++ b/recipes/general/recipe-sericea-nvidia-open-userns.yml
@@ -2,7 +2,7 @@ name: sericea-nvidia-open-userns-hardened
 
 description: "Sericea with userns and nvidia-open, hardened"
 
-base-image: quay.io/fedora-ostree-desktops/sericea
+base-image: quay.io/fedora/fedora-sway-atomic
 
 image-version: 41
 

--- a/recipes/general/recipe-sericea-nvidia-open.yml
+++ b/recipes/general/recipe-sericea-nvidia-open.yml
@@ -2,7 +2,7 @@ name: sericea-nvidia-open-hardened
 
 description: "Sericea with nvidia-open, hardened"
 
-base-image: quay.io/fedora-ostree-desktops/sericea
+base-image: quay.io/fedora/fedora-sway-atomic
 
 image-version: 41
 

--- a/recipes/general/recipe-sericea-nvidia-userns.yml
+++ b/recipes/general/recipe-sericea-nvidia-userns.yml
@@ -2,7 +2,7 @@ name: sericea-nvidia-userns-hardened
 
 description: "Sericea with nvidia and userns, hardened"
 
-base-image: quay.io/fedora-ostree-desktops/sericea
+base-image: quay.io/fedora/fedora-sway-atomic
 
 image-version: 41
 

--- a/recipes/general/recipe-sericea-nvidia.yml
+++ b/recipes/general/recipe-sericea-nvidia.yml
@@ -2,7 +2,7 @@ name: sericea-nvidia-hardened
 
 description: "Sericea with nvidia, hardened"
 
-base-image: quay.io/fedora-ostree-desktops/sericea
+base-image: quay.io/fedora/fedora-sway-atomic
 
 image-version: 41
 

--- a/recipes/general/recipe-silverblue-main-userns.yml
+++ b/recipes/general/recipe-silverblue-main-userns.yml
@@ -2,7 +2,7 @@ name: silverblue-main-userns-hardened
 
 description: "Silverblue with userns, hardened"
 
-base-image: quay.io/fedora-ostree-desktops/silverblue
+base-image: quay.io/fedora/fedora-silverblue
 
 image-version: 41 
 

--- a/recipes/general/recipe-silverblue-main.yml
+++ b/recipes/general/recipe-silverblue-main.yml
@@ -2,7 +2,7 @@ name: silverblue-main-hardened
 
 description: "Silverblue, hardened"
 
-base-image: quay.io/fedora-ostree-desktops/silverblue
+base-image: quay.io/fedora/fedora-silverblue
 
 image-version: 41 
 

--- a/recipes/general/recipe-silverblue-nvidia-open-userns.yml
+++ b/recipes/general/recipe-silverblue-nvidia-open-userns.yml
@@ -2,7 +2,7 @@ name: silverblue-nvidia-open-userns-hardened
 
 description: "Silverblue with nvidia-open and userns, hardened"
 
-base-image: quay.io/fedora-ostree-desktops/silverblue
+base-image: quay.io/fedora/fedora-silverblue
 
 image-version: 41
 

--- a/recipes/general/recipe-silverblue-nvidia-open.yml
+++ b/recipes/general/recipe-silverblue-nvidia-open.yml
@@ -2,7 +2,7 @@ name: silverblue-nvidia-open-hardened
 
 description: "Silverblue with nvidia-open, hardened"
 
-base-image: quay.io/fedora-ostree-desktops/silverblue
+base-image: quay.io/fedora/fedora-silverblue
 
 image-version: 41
 

--- a/recipes/general/recipe-silverblue-nvidia-userns.yml
+++ b/recipes/general/recipe-silverblue-nvidia-userns.yml
@@ -2,7 +2,7 @@ name: silverblue-nvidia-userns-hardened
 
 description: "Silverblue with nvidia and userns, hardened"
 
-base-image: quay.io/fedora-ostree-desktops/silverblue
+base-image: quay.io/fedora/fedora-silverblue
 
 image-version: 41
 

--- a/recipes/general/recipe-silverblue-nvidia.yml
+++ b/recipes/general/recipe-silverblue-nvidia.yml
@@ -2,7 +2,7 @@ name: silverblue-nvidia-hardened
 
 description: "Silverblue with nvidia, hardened"
 
-base-image: quay.io/fedora-ostree-desktops/silverblue
+base-image: quay.io/fedora/fedora-silverblue
 
 image-version: 41
 


### PR DESCRIPTION
The only difference in packages is some addition of virtualization `qemu` packages iirc, don't know the exact changelog (might be the regular update though, P5 says there's no change in packages).