### PR TITLE
feat: add install-steam and enable-flatpak-unfiltered ujust commands

### DIFF
--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -150,7 +150,7 @@ with-standard-malloc APP:
 # Add the flathub-unverified flatpak repo
 enable-flathub-unverified:
     #!/usr/bin/bash
-    flatpak remote-add --if-not-exists --user --subset=unverified flathub-unverified https://flathub.org/repo/flathub.flatpakrepo
+    flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
 
 # Install Steam via choice of 3 methods
 install-steam:

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -198,12 +198,11 @@ install-steam:
             ;;
     esac
 
+    echo "Steam requires support for 32-bit processes/syscalls."
     if [ -n "$(rpm-ostree kargs | grep 'ia32_emulation=0')" ] ; then
-        echo "Steam requires support for 32-bit processes/syscalls."
         echo "This script will now remove the 'ia32_emulation=0' kernel argument."
         rpm-ostree kargs --delete-if-present="ia32_emulation=0"
     else
-        echo "Steam requires support for 32-bit processes/syscalls."
         echo "Do not set the 'ia32_emulation=0' kernel argument."
     fi
     if [[ "$method_selection" == 3 ]]; then

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -195,16 +195,18 @@ install-steam:
             run0 curl -o /etc/yum.repos.d/negativo-steam.repo https://negativo17.org/repos/fedora-steam.repo
             echo "Installing Steam."
             rpm-ostree install steam
-            echo "Steam native layer installed. Please reboot to access the new deployment"
-            reboot_now=""
-            read -p "Would you like to reboot now? [y/N] " reboot_now
-            if [[ "$reboot_now" == [Yy]* ]]; then
-                echo "Rebooting"
-                systemctl reboot
-            fi
             ;;
     esac
 
     echo "Steam requires support for 32-bit processes/syscalls."
     echo "This script will now remove the 'ia32_emulation=0' kernel argument if present."
     rpm-ostree kargs --delete-if-present="ia32_emulation=0"
+    if [[ "$method_selection" == 3 ]]; then
+        echo "Steam native layer installed. Please reboot to access the new deployment"
+        reboot_now=""
+        read -p "Would you like to reboot now? [y/N] " reboot_now
+        if [[ "$reboot_now" == [Yy]* ]]; then
+            echo "Rebooting"
+            systemctl reboot
+        fi
+    fi

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -184,6 +184,8 @@ install-steam:
             ujust enable-flathub-unverified
             echo "Installing Steam flatpak."
             flatpak install com.valvesoftware.Steam
+            echo "Disabling hardened_malloc for Steam."
+            flatpak override --user --unset-env=LD_PRELOAD=/var/run/host/usr/lib64/libhardened_malloc.so --unset-env=LD_PRELOAD=/var/run/host/usr/lib64/glibc-hwcaps/x86-64-v*/libhardened_malloc.so --nofilesystem=host-os:ro com.valvesoftware.Steam
             ;;
         2)
             echo "Distrobox method selected."

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -158,7 +158,6 @@ install-steam:
     valid_input="0"
     method_selection=""
     echo "Please select a method to install steam:"
-    echo "    0) Cancel - do not install Steam."
     echo "    1) Flatpak - will enable the flathub-unverified repo"
     echo "    2) Distrobox - will configure the bazzite-arch distrobox image"
     echo "    3) Native layer - will enable the negativo17 Steam repo"

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -163,8 +163,8 @@ install-steam:
     echo "    2) Distrobox - will configure the bazzite-arch distrobox image"
     echo "    3) Native layer - will enable the negativo17 Steam repo"
     while [[ "$valid_input" == "0" ]]; do
-        read -p "Selection [0-3]: " method_selection
-        if [[ "$method_selection" == [0123]* ]]; then
+        read -p "Selection [1-3]: " method_selection
+        if [[ "$method_selection" == [123]* ]]; then
             valid_input="1"
         else
             echo "That is not a valid selection."
@@ -174,10 +174,6 @@ install-steam:
 
     echo "" # blank space
     case "$method_selection" in
-        0)
-            echo "Cancel selected. Exiting and not installing Steam."
-            exit 0
-            ;;
         1)
             echo "Flatpak method selected."
             echo "Enabling Flathub-unverified repo."

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -208,7 +208,7 @@ install-steam:
         3)
             echo "Native layer method selected."
             echo "Enabling negativo17 Steam repo."
-            run0 curl -o /etc/yum.repos.d/negativo-steam.repo https://negativo17.org/repos/fedora-steam.repo
+            run0 curl -o /etc/yum.repos.d/fedora-steam.repo https://negativo17.org/repos/fedora-steam.repo
             echo "Installing Steam."
             rpm-ostree install steam
             ;;

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -157,7 +157,7 @@ install-steam:
     #!/bin/bash
     if [ -n "$(rpm-ostree status | grep 'kinoite\|sericea\|silverblue\|sway')" ] ; then
         echo "Steam requires Xwayland, which your variant of secureblue has disabled by default."
-        echo "Please run 'ujust toggle-xwayland', then reboot to enable it if you have not already done so"
+        echo "If you have not already done so, please run 'ujust toggle-xwayland' and reboot to enable it."
         toggle_xwayland_now=""
         read -p "Would you like to toggle Xwayland now? [y/N] " toggle_xwayland_now
         if [[ "$toggle_xwayland_now" == [Yy]* ]]; then

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -180,7 +180,7 @@ install-steam:
             echo "Installing Steam flatpak."
             flatpak install -y flathub com.valvesoftware.Steam
             echo "Disabling hardened_malloc for Steam."
-            flatpak override --user --unset-env=LD_PRELOAD=/var/run/host/usr/lib64/libhardened_malloc.so --unset-env=LD_PRELOAD=/var/run/host/usr/lib64/glibc-hwcaps/x86-64-v*/libhardened_malloc.so --nofilesystem=host-os:ro com.valvesoftware.Steam
+            flatpak override --user --unset-env=LD_PRELOAD --nofilesystem=host-os com.valvesoftware.Steam
             ;;
         2)
             echo "Distrobox method selected."

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -192,7 +192,7 @@ install-steam:
             echo "Creating bazzite-arch distrobox."
             distrobox-create --unshare-netns --nvidia --image ghcr.io/ublue-os/bazzite-arch --name bazzite-arch -Y
             echo "Exporting Steam from bazzite-arch distrobox."
-            distrobox-enter -n bazzite-arch -- '  distrobox-export --app steam'
+            distrobox-enter -n bazzite-arch -- distrobox-export --app steam
             ;;
         3)
             echo "Native layer method selected."

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -155,6 +155,22 @@ enable-flathub-unfiltered:
 # Install Steam via choice of 3 methods
 install-steam:
     #!/bin/bash
+    if [ -n "$(rpm-ostree status | grep 'kinoite\|sericea\|silverblue\|sway')" ] ; then
+        echo "Steam requires Xwayland, which your variant of secureblue has disabled by default."
+        echo "Please run 'ujust toggle-xwayland', then reboot to enable it if you have not already done so"
+        toggle_xwayland_now=""
+        read -p "Would you like to toggle Xwayland now? [y/N] " toggle_xwayland_now
+        if [[ "$toggle_xwayland_now" == [Yy]* ]]; then
+            echo "Running 'ujust toggle-xwayland'"
+            ujust toggle-xwayland
+            reboot_now=""
+            read -p "Would you like to reboot now? [y/N] " reboot_now
+            if [[ "$reboot_now" == [Yy]* ]]; then
+                echo "Rebooting"
+                systemctl reboot
+            fi
+        fi
+    fi
     valid_input="0"
     method_selection=""
     echo "Please select a method to install steam:"

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -199,7 +199,7 @@ install-steam:
             echo "Enabling negativo17 Steam repo."
             run0 curl -o /etc/yum.repos.d/negativo-steam.repo https://negativo17.org/repos/fedora-steam.repo
             echo "Installing Steam."
-            rmp-ostree install steam
+            rpm-ostree install steam
             echo "Steam native layer installed. Please reboot to access the new deployment"
             reboot_now=""
             read -p "Would you like to reboot now? [y/N] " reboot_now

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -176,10 +176,9 @@ install-steam:
     echo "Please select a method to install steam:"
     echo "    1) Flatpak - will enable the flathub-unverified repo"
     echo "    2) Distrobox - will configure the bazzite-arch distrobox image"
-    echo "    3) Native layer - will enable the negativo17 Steam repo"
     while [[ "$valid_input" == "0" ]]; do
-        read -p "Selection [1-3]: " method_selection
-        if [[ "$method_selection" == [123]* ]]; then
+        read -p "Selection [1-2]: " method_selection
+        if [[ "$method_selection" == [12]* ]]; then
             valid_input="1"
         else
             echo "That is not a valid selection."
@@ -205,13 +204,6 @@ install-steam:
             echo "Exporting Steam from bazzite-arch distrobox."
             distrobox-enter -n bazzite-arch -- distrobox-export --app steam
             ;;
-        3)
-            echo "Native layer method selected."
-            echo "Enabling negativo17 Steam repo."
-            run0 curl -o /etc/yum.repos.d/fedora-steam.repo https://negativo17.org/repos/fedora-steam.repo
-            echo "Installing Steam."
-            rpm-ostree install steam
-            ;;
     esac
 
     echo "Steam requires support for 32-bit processes/syscalls."
@@ -220,13 +212,4 @@ install-steam:
         rpm-ostree kargs --delete-if-present="ia32_emulation=0"
     else
         echo "Do not set the 'ia32_emulation=0' kernel argument."
-    fi
-    if [[ "$method_selection" == 3 ]]; then
-        echo "Steam native layer installed. Please reboot to access the new deployment"
-        reboot_now=""
-        read -p "Would you like to reboot now? [y/N] " reboot_now
-        if [[ "$reboot_now" == [Yy]* ]]; then
-            echo "Rebooting"
-            systemctl reboot
-        fi
     fi

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -178,7 +178,7 @@ install-steam:
             echo "Enabling Flathub-unverified repo."
             ujust enable-flathub-unverified
             echo "Installing Steam flatpak."
-            flatpak install com.valvesoftware.Steam
+            flatpak install -y flathub com.valvesoftware.Steam
             echo "Disabling hardened_malloc for Steam."
             flatpak override --user --unset-env=LD_PRELOAD=/var/run/host/usr/lib64/libhardened_malloc.so --unset-env=LD_PRELOAD=/var/run/host/usr/lib64/glibc-hwcaps/x86-64-v*/libhardened_malloc.so --nofilesystem=host-os:ro com.valvesoftware.Steam
             ;;

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -198,9 +198,14 @@ install-steam:
             ;;
     esac
 
-    echo "Steam requires support for 32-bit processes/syscalls."
-    echo "This script will now remove the 'ia32_emulation=0' kernel argument if present."
-    rpm-ostree kargs --delete-if-present="ia32_emulation=0"
+    if [ -n "$(rpm-ostree kargs | grep 'ia32_emulation=0')" ] ; then
+        echo "Steam requires support for 32-bit processes/syscalls."
+        echo "This script will now remove the 'ia32_emulation=0' kernel argument."
+        rpm-ostree kargs --delete-if-present="ia32_emulation=0"
+    else
+        echo "Steam requires support for 32-bit processes/syscalls."
+        echo "Do not set the 'ia32_emulation=0' kernel argument."
+    fi
     if [[ "$method_selection" == 3 ]]; then
         echo "Steam native layer installed. Please reboot to access the new deployment"
         reboot_now=""

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -147,8 +147,8 @@ with-standard-malloc APP:
     #!/usr/bin/bash
     bwrap --dev-bind / / --ro-bind /dev/null /etc/ld.so.preload {{ APP }}
 
-# Add the flathub-unverified flatpak repo
-enable-flathub-unverified:
+# Add the unfiltered Flathub flatpak repo
+enable-flathub-unfiltered:
     #!/usr/bin/bash
     flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
 
@@ -175,8 +175,8 @@ install-steam:
     case "$method_selection" in
         1)
             echo "Flatpak method selected."
-            echo "Enabling Flathub-unverified repo."
-            ujust enable-flathub-unverified
+            echo "Enabling the unfiltered Flathub repo."
+            ujust enable-flathub-unfiltered
             echo "Installing Steam flatpak."
             flatpak install -y flathub com.valvesoftware.Steam
             echo "Disabling hardened_malloc for Steam."

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -146,3 +146,68 @@ toolbox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/toolbox/toolbox.i
 with-standard-malloc APP:
     #!/usr/bin/bash
     bwrap --dev-bind / / --ro-bind /dev/null /etc/ld.so.preload {{ APP }}
+
+# Add the flathub-unverified flatpak repo
+enable-flathub-unverified:
+    #!/usr/bin/bash
+    flatpak remote-add --if-not-exists --user --subset=unverified flathub-unverified https://flathub.org/repo/flathub.flatpakrepo
+
+# Install Steam via choice of 3 methods
+install-steam:
+    #!/bin/bash
+    valid_input="0"
+    method_selection=""
+    echo "Please select a method to install steam:"
+    echo "    0) Cancel - do not install Steam."
+    echo "    1) Flatpak - will enable the flathub-unverified repo"
+    echo "    2) Distrobox - will configure the bazzite-arch distrobox image"
+    echo "    3) Native layer - will enable the negativo17 Steam repo"
+    while [[ "$valid_input" == "0" ]]; do
+        read -p "Selection [0-3]: " method_selection
+        if [[ "$method_selection" == [0123]* ]]; then
+            valid_input="1"
+        else
+            echo "That is not a valid selection."
+        fi
+    done
+    valid_input="0"
+
+    echo "" # blank space
+    case "$method_selection" in
+        0)
+            echo "Cancel selected. Exiting and not installing Steam."
+            exit 0
+            ;;
+        1)
+            echo "Flatpak method selected."
+            echo "Enabling Flathub-unverified repo."
+            ujust enable-flathub-unverified
+            echo "Installing Steam flatpak."
+            flatpak install com.valvesoftware.Steam
+            ;;
+        2)
+            echo "Distrobox method selected."
+            echo "Creating bazzite-arch distrobox."
+            distrobox-create --unshare-netns --nvidia --image ghcr.io/ublue-os/bazzite-arch --name bazzite-arch -Y
+            echo "Exporting Steam from bazzite-arch distrobox."
+            distrobox-enter -n bazzite-arch -- '  distrobox-export --app steam'
+            ;;
+        3)
+            echo "Native layer method selected."
+            echo "Enabling negativo17 Steam repo."
+            run0 curl -o /etc/yum.repos.d/negativo-steam.repo https://negativo17.org/repos/fedora-steam.repo
+            echo "Installing Steam."
+            rmp-ostree install steam
+            echo "Steam native layer installed. Please reboot to access the new deployment"
+            reboot_now=""
+            read -p "Would you like to reboot now? [y/N] " reboot_now
+            if [[ "$reboot_now" == [Yy]* ]]; then
+                echo "Rebooting"
+                systemctl reboot
+            fi
+            ;;
+    esac
+
+    echo "Steam requires support for 32-bit processes/syscalls."
+    echo "This script will now remove the 'ia32_emulation=0' kernel argument if present."
+    rpm-ostree kargs --delete-if-present="ia32_emulation=0"


### PR DESCRIPTION
Resolves #639.
This new PR removes the native install option, as that currently is not compatible with secureblue due to missing 32bit dependencies. If and when native install support materializes, we can patch it back in from #649