### PR TITLE
feat: add gnome-keyring-pam to cosmic images

### DIFF
--- a/recipes/common/cosmic-modules.yml
+++ b/recipes/common/cosmic-modules.yml
@@ -3,6 +3,7 @@ modules:
       install:
         - NetworkManager-tui
         - NetworkManager-openvpn
+        - gnome-keyring-pam
     - type: systemd
       system:
         enabled:


### PR DESCRIPTION
This enables the automatic unlock of the user keyring, just like how gnome works.