### PR TITLE
feat: improve l1tf sysctl default

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -170,6 +170,3 @@ refactor: share logic between 4d3d3d3 and flarhgunnstow
 style: convert tabs to spaces
 test: ensure Tayne retains clothing
 ```
-
-## Attribution
-This guide is based on the **contributing.md**. [Make your own](https://contributing.md/)!

--- a/docs/KARGS.md
+++ b/docs/KARGS.md
@@ -97,3 +97,7 @@
 **Disables support for 32-bit processes, and syscalls**
 
 `ia32_emulation=0`
+
+**Force enables all available mitigations for the L1TF vulnerability.**
+
+`l1tf=full,force`

--- a/files/justfiles/audit.just
+++ b/files/justfiles/audit.just
@@ -64,6 +64,7 @@ audit-secureblue:
         "efi=disable_early_pci_dma"
         "debugfs=off"
         "ia32_emulation=0"
+        "l1tf=full,force"
     )
 
     for karg in "${KARGS_LIST[@]}"; do

--- a/files/justfiles/kargs.just
+++ b/files/justfiles/kargs.just
@@ -8,6 +8,13 @@ set-kargs-hardening:
         IAEMU_NO="--append-if-missing=ia32_emulation=0"
         echo "Disabling 32-bit support, for the next boot."
     fi
+    read -p "Do you want to force disable Simultaneous Multithreading (SMT) / Hyperthreading? (This can cause a reduction in the performance of certain tasks in favor of security) (Note that in most hardware SMT will be disabled anyways to mitigate a known vulnerability, this turns it off on all hardware regardless) [y/N]: " YES
+    if [[ "$YES" == [Yy]* ]]; then
+        NOSMT_YES="--append-if-missing=nosmt=force"
+        echo "Force disabling SMT/Hyperthreading."
+    else
+        echo "Not force disabling SMT/Hyperthreading."
+    fi
     read -p "Would you like to set additional (unstable) hardening kargs? (Warning: Setting these kargs may lead to boot issues on some hardware.) [y/N]: " YES
     if [[ "$YES" == [Yy]* ]]; then
     UNSTABLE_YES="--append-if-missing=efi=disable_early_pci_dma \
@@ -18,8 +25,7 @@ set-kargs-hardening:
     fi
     echo "Applying boot parameters..."
     rpm-ostree kargs \
-      ${UNSTABLE_YES:+$UNSTABLE_YES} ${IAEMU_NO:+$IAEMU_NO} \
-      --append-if-missing=init_on_alloc=1 \
+      ${UNSTABLE_YES:+$UNSTABLE_YES} ${IAEMU_NO:+$IAEMU_NO} ${NOSMT_YES:+$NOSMT_YES} \
       --append-if-missing=init_on_free=1 \
       --append-if-missing=slab_nomerge \
       --append-if-missing=page_alloc.shuffle=1 \

--- a/files/justfiles/kargs.just
+++ b/files/justfiles/kargs.just
@@ -8,13 +8,6 @@ set-kargs-hardening:
         IAEMU_NO="--append-if-missing=ia32_emulation=0"
         echo "Disabling 32-bit support, for the next boot."
     fi
-    read -p "Do you want to force disable Simultaneous Multithreading (SMT) / Hyperthreading? (This can cause a reduction in the performance of certain tasks in favor of security) (Note that in most hardware SMT will be disabled anyways to mitigate a known vulnerability, this turns it off on all hardware regardless) [y/N]: " YES
-    if [[ "$YES" == [Yy]* ]]; then
-        NOSMT_YES="--append-if-missing=nosmt=force"
-        echo "Force disabling SMT/Hyperthreading."
-    else
-        echo "Not force disabling SMT/Hyperthreading."
-    fi
     read -p "Would you like to set additional (unstable) hardening kargs? (Warning: Setting these kargs may lead to boot issues on some hardware.) [y/N]: " YES
     if [[ "$YES" == [Yy]* ]]; then
     UNSTABLE_YES="--append-if-missing=efi=disable_early_pci_dma \
@@ -25,7 +18,7 @@ set-kargs-hardening:
     fi
     echo "Applying boot parameters..."
     rpm-ostree kargs \
-      ${UNSTABLE_YES:+$UNSTABLE_YES} ${IAEMU_NO:+$IAEMU_NO} ${NOSMT_YES:+$NOSMT_YES} \
+      ${UNSTABLE_YES:+$UNSTABLE_YES} ${IAEMU_NO:+$IAEMU_NO} \
       --append-if-missing=init_on_alloc=1 \
       --append-if-missing=init_on_free=1 \
       --append-if-missing=slab_nomerge \
@@ -46,7 +39,8 @@ set-kargs-hardening:
       --append-if-missing=spectre_v2=on \
       --append-if-missing=spec_store_bypass_disable=on \
       --append-if-missing=l1d_flush=on \
-      --append-if-missing=gather_data_sampling=force 
+      --append-if-missing=gather_data_sampling=force \
+      --append-if-missing=l1tf=full,force
     echo "Hardening kargs applied."
 
 # Remove all hardening boot parameters (requires reboot)
@@ -76,7 +70,8 @@ remove-kargs-hardening:
       --delete-if-present="spec_store_bypass_disable=on" \
       --delete-if-present="l1d_flush=on" \
       --delete-if-present="gather_data_sampling=force" \
-      --delete-if-present="ia32_emulation=0"
+      --delete-if-present="ia32_emulation=0" \
+      --delete-if-present="l1tf=full,force"
     echo "Hardening kargs removed."
 
 # Set nvidia kargs

--- a/files/justfiles/kargs.just
+++ b/files/justfiles/kargs.just
@@ -26,6 +26,7 @@ set-kargs-hardening:
     echo "Applying boot parameters..."
     rpm-ostree kargs \
       ${UNSTABLE_YES:+$UNSTABLE_YES} ${IAEMU_NO:+$IAEMU_NO} ${NOSMT_YES:+$NOSMT_YES} \
+      --append-if-missing=init_on_alloc=1 \
       --append-if-missing=init_on_free=1 \
       --append-if-missing=slab_nomerge \
       --append-if-missing=page_alloc.shuffle=1 \


### PR DESCRIPTION
From the kernel docs:

```
full,force

Same as ‘full’, but disables SMT and L1D flush runtime control. Implies the ‘nosmt=force’ command line option. (i.e. sysfs control of SMT is disabled.)
```
https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/l1tf.html

So we no longer need to prompt for nosmt forcing.