### PR TITLE
fix: undo removing fedora-logos

### DIFF
--- a/recipes/common/desktop-modules.yml
+++ b/recipes/common/desktop-modules.yml
@@ -12,12 +12,6 @@ modules:
         - installsignedkernel.sh
     - from-file: common/desktop-packages.yml
     - from-file: common/desktop-scripts.yml
-    - type: files
-      files:
-        - source: system/usr/share/pixmaps
-          destination: /usr/share/pixmaps
-        - source: system/usr/share/plymouth
-          destination: /usr/share/plymouth
     - type: fonts
       fonts:
         nerd-fonts:

--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -26,7 +26,6 @@ install:
   # ensure universal font coverage
   - google-noto-fonts-all
 remove:
-  - fedora-logos
   - firefox
   - firefox-langpacks
   - fuse


### PR DESCRIPTION
removing fedora-logos force installs generic-logos, which makes the kde plasma menu icon a hotdog :smile: 

we will need to do an in-place replace of fedora-logos instead, like bazzite does. This pr will remove the hotdogs in the interim.