### PR TITLE
feat: Revert "tweak: enable negativo17 multimedia repo (#663)"

### DIFF
--- a/files/scripts/removeunusedrepos.sh
+++ b/files/scripts/removeunusedrepos.sh
@@ -4,6 +4,7 @@
 set -oue pipefail
 
 rm -f /etc/yum.repos.d/negativo17-fedora-nvidia.repo
+rm -f /etc/yum.repos.d/negativo17-fedora-multimedia.repo
 rm -f /etc/yum.repos.d/eyecantcu-supergfxctl.repo
 rm -f /etc/yum.repos.d/_copr_ublue-os-akmods.repo
 rm -f /etc/yum.repos.d/nvidia-container-toolkit.repo


### PR DESCRIPTION
This reverts commit d0fe2eaf4ed9b7a806d6490b6822e32a4ee6e508.

It's no longer required since we won't be layering steam.