### PR TITLE
fix: fix usbguard notifications for non-wheel users

### DIFF
--- a/docs/POSTINSTALL-README.md
+++ b/docs/POSTINSTALL-README.md
@@ -98,7 +98,7 @@ When using a non-wheel user, you can add the user to other groups if you want. F
 - use libvirt: `libvirt`
 - use `adb` and `fastboot`: `plugdev`
 - use systemwide flatpaks: `flatpak`
-- use usbguard: `ipc`
+- use usbguard: `usbguard`
 
 > [!NOTE]
 > You don't need to login using your wheel user to use it for privileged operations. When logged in as your non-wheel user, polkit will prompt you to authenticate as your wheel user as needed, or when requested by calling `run0`.

--- a/docs/POSTINSTALL-README.md
+++ b/docs/POSTINSTALL-README.md
@@ -98,6 +98,7 @@ When using a non-wheel user, you can add the user to other groups if you want. F
 - use libvirt: `libvirt`
 - use `adb` and `fastboot`: `plugdev`
 - use systemwide flatpaks: `flatpak`
+- use usbguard: `ipc`
 
 > [!NOTE]
 > You don't need to login using your wheel user to use it for privileged operations. When logged in as your non-wheel user, polkit will prompt you to authenticate as your wheel user as needed, or when requested by calling `run0`.

--- a/files/justfiles/hardening.just
+++ b/files/justfiles/hardening.just
@@ -106,7 +106,6 @@ flatpak-permissions-lockdown:
 setup-usbguard:
     #!/usr/bin/bash
     echo "Notice: This will generate a policy based on your existing connected USB devices."
-    ACTIVE_USERNAME=$(whoami)
     run0 sh -c '
         mkdir -p /var/log/usbguard
         mkdir -p /etc/usbguard
@@ -114,5 +113,7 @@ setup-usbguard:
         usbguard generate-policy > /etc/usbguard/rules.conf
         systemctl enable --now usbguard.service
         usbguard add-user $1
-    ' -- $ACTIVE_USERNAME
+	sed -i "/IPCAllowedGroups=wheel/s/$/ ipc/" /etc/usbguard/usbguard-daemon.conf
+	systemctl restart usbguard
+    ' -- $USER
     systemctl enable --user --now usbguard-notifier.service

--- a/files/justfiles/hardening.just
+++ b/files/justfiles/hardening.just
@@ -111,9 +111,8 @@ setup-usbguard:
         mkdir -p /etc/usbguard
         chmod 755 /etc/usbguard
         usbguard generate-policy > /etc/usbguard/rules.conf
+	sed -i "/IPCAllowedGroups=wheel/s/$/ usbguard/" /etc/usbguard/usbguard-daemon.conf
         systemctl enable --now usbguard.service
         usbguard add-user $1
-	sed -i "/IPCAllowedGroups=wheel/s/$/ usbguard/" /etc/usbguard/usbguard-daemon.conf
-	systemctl restart usbguard
     ' -- $USER
     systemctl enable --user --now usbguard-notifier.service

--- a/files/justfiles/hardening.just
+++ b/files/justfiles/hardening.just
@@ -112,6 +112,7 @@ setup-usbguard:
         chmod 755 /etc/usbguard
         usbguard generate-policy > /etc/usbguard/rules.conf
 	sed -i "/IPCAllowedGroups=wheel/s/$/ usbguard/" /etc/usbguard/usbguard-daemon.conf
+        restorecon -vR /var/log/usbguard
         systemctl enable --now usbguard.service
         usbguard add-user $1
     ' -- $USER

--- a/files/justfiles/hardening.just
+++ b/files/justfiles/hardening.just
@@ -111,7 +111,7 @@ setup-usbguard:
         mkdir -p /etc/usbguard
         chmod 755 /etc/usbguard
         usbguard generate-policy > /etc/usbguard/rules.conf
-	sed -i "/IPCAllowedGroups=wheel/s/$/ usbguard/" /etc/usbguard/usbguard-daemon.conf
+        sed -i "/IPCAllowedGroups=wheel/s/$/ usbguard/" /etc/usbguard/usbguard-daemon.conf
         restorecon -vR /var/log/usbguard
         systemctl enable --now usbguard.service
         usbguard add-user $1

--- a/files/justfiles/hardening.just
+++ b/files/justfiles/hardening.just
@@ -113,7 +113,7 @@ setup-usbguard:
         usbguard generate-policy > /etc/usbguard/rules.conf
         systemctl enable --now usbguard.service
         usbguard add-user $1
-	sed -i "/IPCAllowedGroups=wheel/s/$/ ipc/" /etc/usbguard/usbguard-daemon.conf
+	sed -i "/IPCAllowedGroups=wheel/s/$/ usbguard/" /etc/usbguard/usbguard-daemon.conf
 	systemctl restart usbguard
     ' -- $USER
     systemctl enable --user --now usbguard-notifier.service


### PR DESCRIPTION
added a line in the setup-usbguard script to make the necessary configuration changes and an extra entry in the docs to tell users to add that group when setting up a separate wheel user