### PR TITLE
fix: include vmtools packages

### DIFF
--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -34,9 +34,6 @@ remove:
   - fuse
   - fedora-chromium-config
   - fedora-flathub-remote
-  - open-vm-tools
-  - open-vm-tools-desktop
-  - virtualbox-guest-additions
   - passim
   - sudo
   - sudo-python-plugin


### PR DESCRIPTION
Any services that are automatically enabled via these packages can be disabled as needed