### PR TITLE
feat: add toggle-mac-randomization

### DIFF
--- a/.github/workflows/tests/justfile_tests.bats
+++ b/.github/workflows/tests/justfile_tests.bats
@@ -29,3 +29,12 @@ setup() {
     [ "$status" -eq 0 ]
     [ ! -f "${HOME}/.config/no-show-user-motd" ]
 }
+
+@test "Ensure MAC address randomization works properly" {
+    run ujust toggle-mac-randomization
+    [ "$status" -eq 0 ]
+    [ -f "/etc/NetworkManager/conf.d/rand_mac.conf" ]
+    run ujust toggle-mac-randomization
+    [ "$status" -eq 0 ]
+    [ ! -f "/etc/NetworkManager/conf.d/rand_mac.conf" ]
+}

--- a/.github/workflows/tests/justfile_tests.bats
+++ b/.github/workflows/tests/justfile_tests.bats
@@ -5,6 +5,7 @@ setup() {
     sudo mkdir -p /usr/share/bluebuild/justfiles/
     sudo mkdir -p /usr/lib/ujust/
 
+    sudo ln -s /bin/run0 /usr/bin/sudo
 
     sudo cp -fr files/system/usr/lib/ujust /usr/lib/ujust
     sudo cp -f files/system/usr/bin/ujust /usr/bin/ujust

--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -271,6 +271,14 @@ toggle-mac-randomization:
         echo "MAC randomization disabled."
         systemctl restart NetworkManager
     else
+        read -p "Do you want to use per-connection Wi-Fi MAC address randomization? [y/N]" randomization_level
+        randomization_level=${randomization_level:-n}
+
+        if [ "$randomization_level" == [Yy]* ]; then
+            randomization_level=random
+        else
+            randomization_level=stable
+        fi
         cat <<EOL > $RAND_MAC_FILE
     [device-mac-randomization]
     # "yes" is already the default for scanning
@@ -279,7 +287,7 @@ toggle-mac-randomization:
     [connection-mac-randomization]
     # Generate a random MAC for each Network and associate the two permanently.
     ethernet.cloned-mac-address=stable
-    wifi.cloned-mac-address=stable
+    wifi.cloned-mac-address=$randomization_level
     EOL
         echo "MAC randomization enabled."
         systemctl restart NetworkManager

--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -260,3 +260,27 @@ toggle-container-domain-userns-creation:
         semodule --enable="$MODULE_NAME"
         echo "Module $MODULE_NAME enabled."
     fi
+
+# Toggle MAC Randomization
+toggle-mac-randomization:
+    #! /bin/run0 /bin/bash
+    RAND_MAC_FILE="/etc/NetworkManager/conf.d/rand_mac.conf"
+
+    if test -e $RAND_MAC_FILE; then
+        rm -f $RAND_MAC_FILE
+        echo "MAC randomization disabled."
+        systemctl restart NetworkManager
+    else
+        cat <<EOL > $RAND_MAC_FILE
+    [device-mac-randomization]
+    # "yes" is already the default for scanning
+    wifi.scan-rand-mac-address=yes
+
+    [connection-mac-randomization]
+    # Generate a random MAC for each Network and associate the two permanently.
+    ethernet.cloned-mac-address=stable
+    wifi.cloned-mac-address=stable
+    EOL
+        echo "MAC randomization enabled."
+        systemctl restart NetworkManager
+    fi

--- a/files/system/etc/NetworkManager/conf.d/rand_mac.conf
+++ b/files/system/etc/NetworkManager/conf.d/rand_mac.conf
@@ -1,8 +1,0 @@
-[device-mac-randomization]
-# "yes" is already the default for scanning
-wifi.scan-rand-mac-address=yes
- 
-[connection-mac-randomization]
-# Generate a random MAC for each Network and associate the two permanently.
-ethernet.cloned-mac-address=stable
-wifi.cloned-mac-address=stable


### PR DESCRIPTION
Certain hypervisors like Hyper-V dislike MAC address randomization. This toggle allows the user the ability to disable it at their leisure.