### PR TITLE
feat: toggle-mac-randomization: clarify the "per-connection" choice

### DIFF
--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -271,7 +271,7 @@ toggle-mac-randomization:
         echo "MAC randomization disabled."
         systemctl restart NetworkManager
     else
-        echo "MAC randomization can be stable (persisting the same random MAC per access point across disconnects/reboots,"
+        echo "MAC randomization can be stable (persisting the same random MAC per access point across disconnects/reboots),"
         echo "or it can be randomized per-connection (every time it connects to the same access point it uses a new MAC)."
         read -p "Do you want to use per-connection Wi-Fi MAC address randomization? [y/N]" randomization_level
         randomization_level=${randomization_level:-n}

--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -271,6 +271,8 @@ toggle-mac-randomization:
         echo "MAC randomization disabled."
         systemctl restart NetworkManager
     else
+        echo "MAC randomization can be stable (persisting the same random MAC per access point across disconnects/reboots,"
+        echo "or it can be randomized per-connection (every time it connects to the same access point it uses a new MAC)."
         read -p "Do you want to use per-connection Wi-Fi MAC address randomization? [y/N]" randomization_level
         randomization_level=${randomization_level:-n}
 


### PR DESCRIPTION
Currently toggle-mac-randomization asks users enabling randomization if they want `per-connection Wi-Fi MAC address randomization`. This wording is unclear, because some might understand "connection" to mean access point (which would invert the meaning of this choice). This PR adds some messages before the prompt which elaborate on the offered option.