### PR TITLE
feat: add a guardrail for distrobox assembling.

### DIFF
--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -135,17 +135,14 @@ distrobox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/distrobox/distr
     MODULE_NAME="harden_container_userns"
 
     if semodule -l | grep -q "$MODULE_NAME"; then
-        echo "Module $MODULE_NAME is currently enabled."
-        echo "We will need to allow container usernamespaces to be created."
-        read -p "Would you like to disable the module now? [y/N] " disable_module_now
-        disable_module_now=${disable_module_now:-n}
-        if [[ "$disable_module_now" == [Yy]* ]]; then
-            echo "Disabling module $MODULE_NAME..."
-            semodule --disable="$MODULE_NAME"
-            echo "Module $MODULE_NAME disabled."
+        echo "Module $MODULE_NAME is currently enabled."  
+        echo "This must be disabled to use containers."  
+        read -p "Would you like to proceed? [Y/n] " disable_module_now  
+        disable_module_now=${disable_module_now:-y}  
+        if [[ "$disable_module_now" == [N/n]* ]]; then 
+            exit
         else
-            echo "Module $MODULE_NAME is still enabled. Exiting."
-            exit 1
+            ujust toggle-container-domain-userns-creation
         fi
     fi
 
@@ -159,17 +156,14 @@ toolbox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/toolbox/toolbox.i
     MODULE_NAME="harden_container_userns"
 
     if semodule -l | grep -q "$MODULE_NAME"; then
-        echo "Module $MODULE_NAME is currently enabled."
-        echo "We will need to allow container usernamespaces to be created."
-        read -p "Would you like to disable the module now? [y/N] " disable_module_now
-        disable_module_now=${disable_module_now:-n}
-        if [[ "$disable_module_now" == [Yy]* ]]; then
-            echo "Disabling module $MODULE_NAME..."
-            semodule --disable="$MODULE_NAME"
-            echo "Module $MODULE_NAME disabled."
+        echo "Module $MODULE_NAME is currently enabled."  
+        echo "This must be disabled to use containers."  
+        read -p "Would you like to proceed? [Y/n] " disable_module_now  
+        disable_module_now=${disable_module_now:-y}  
+        if [[ "$disable_module_now" == [N/n]* ]]; then 
+            exit
         else
-            echo "Module $MODULE_NAME is still enabled. Exiting."
-            exit 1
+            ujust toggle-container-domain-userns-creation
         fi
     fi
 

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -129,42 +129,26 @@ rerun-yafti:
 alias assemble := distrobox-assemble
 
 # Create distroboxes from a defined manifest
+[confirm("This will require harden_container_userns to be disabled. Are you sure you would like to make a distrobox container?")]
 distrobox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/distrobox/distrobox.ini":
     #!/usr/bin/bash
     # Distroboxes are gathered from distrobox.ini, please add them there
-    MODULE_NAME="harden_container_userns"
-
-    if semodule -l | grep -q "$MODULE_NAME"; then
-        echo "Module $MODULE_NAME is currently enabled."  
-        echo "This must be disabled to use containers."  
-        read -p "Would you like to proceed? [Y/n] " disable_module_now  
-        disable_module_now=${disable_module_now:-y}  
-        if [[ "$disable_module_now" == [N/n]* ]]; then 
-            exit
-        else
-            ujust toggle-container-domain-userns-creation
-        fi
+    
+    if ujust semodule-check "harden_container_userns"; then 
+        ujust toggle-container-domain-userns-creation
     fi
 
     source /usr/lib/ujust/ujust.sh
     AssembleList {{ FILE }} {{ ACTION }} {{ CONTAINER }}
 
 # Create toolbox containers from a defined manifest (this spec will not be expanded)
+[confirm("This will require harden_container_userns to be disabled. Are you sure you would like to make a toolbox container?")]
 toolbox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/toolbox/toolbox.ini":
     #!/usr/bin/bash
     # Toolboxes are gathered from toolbox.ini, please add them there
-    MODULE_NAME="harden_container_userns"
 
-    if semodule -l | grep -q "$MODULE_NAME"; then
-        echo "Module $MODULE_NAME is currently enabled."  
-        echo "This must be disabled to use containers."  
-        read -p "Would you like to proceed? [Y/n] " disable_module_now  
-        disable_module_now=${disable_module_now:-y}  
-        if [[ "$disable_module_now" == [N/n]* ]]; then 
-            exit
-        else
-            ujust toggle-container-domain-userns-creation
-        fi
+    if ujust semodule-check "harden_container_userns"; then 
+        ujust toggle-container-domain-userns-creation
     fi
 
     source /usr/lib/ujust/ujust.sh

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -132,6 +132,23 @@ alias assemble := distrobox-assemble
 distrobox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/distrobox/distrobox.ini":
     #!/usr/bin/bash
     # Distroboxes are gathered from distrobox.ini, please add them there
+    MODULE_NAME="harden_container_userns"
+
+    if semodule -l | grep -q "$MODULE_NAME"; then
+        echo "Module $MODULE_NAME is currently enabled."
+        echo "We will need to allow container usernamespaces to be created."
+        read -p "Would you like to disable the module now? [y/N] " disable_module_now
+        disable_module_now=${disable_module_now:-n}
+        if [[ "$disable_module_now" == [Yy]* ]]; then
+            echo "Disabling module $MODULE_NAME..."
+            semodule --disable="$MODULE_NAME"
+            echo "Module $MODULE_NAME disabled."
+        else
+            echo "Module $MODULE_NAME is still enabled. Exiting."
+            exit 1
+        fi
+    fi
+
     source /usr/lib/ujust/ujust.sh
     AssembleList {{ FILE }} {{ ACTION }} {{ CONTAINER }}
 
@@ -139,6 +156,23 @@ distrobox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/distrobox/distr
 toolbox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/toolbox/toolbox.ini":
     #!/usr/bin/bash
     # Toolboxes are gathered from toolbox.ini, please add them there
+    MODULE_NAME="harden_container_userns"
+
+    if semodule -l | grep -q "$MODULE_NAME"; then
+        echo "Module $MODULE_NAME is currently enabled."
+        echo "We will need to allow container usernamespaces to be created."
+        read -p "Would you like to disable the module now? [y/N] " disable_module_now
+        disable_module_now=${disable_module_now:-n}
+        if [[ "$disable_module_now" == [Yy]* ]]; then
+            echo "Disabling module $MODULE_NAME..."
+            semodule --disable="$MODULE_NAME"
+            echo "Module $MODULE_NAME disabled."
+        else
+            echo "Module $MODULE_NAME is still enabled. Exiting."
+            exit 1
+        fi
+    fi
+
     source /usr/lib/ujust/ujust.sh
     ToolboxAssembleList {{ FILE }} {{ ACTION }} {{ CONTAINER }}
 

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -129,27 +129,21 @@ rerun-yafti:
 alias assemble := distrobox-assemble
 
 # Create distroboxes from a defined manifest
-[confirm("This will require harden_container_userns to be disabled. Are you sure you would like to make a distrobox container?")]
 distrobox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/distrobox/distrobox.ini":
     #!/usr/bin/bash
     # Distroboxes are gathered from distrobox.ini, please add them there
     
-    if ujust semodule-check "harden_container_userns"; then 
-        ujust toggle-container-domain-userns-creation
-    fi
+    ujust prompt-for-container-userns
 
     source /usr/lib/ujust/ujust.sh
     AssembleList {{ FILE }} {{ ACTION }} {{ CONTAINER }}
 
 # Create toolbox containers from a defined manifest (this spec will not be expanded)
-[confirm("This will require harden_container_userns to be disabled. Are you sure you would like to make a toolbox container?")]
 toolbox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/toolbox/toolbox.ini":
     #!/usr/bin/bash
     # Toolboxes are gathered from toolbox.ini, please add them there
 
-    if ujust semodule-check "harden_container_userns"; then 
-        ujust toggle-container-domain-userns-creation
-    fi
+    ujust prompt-for-container-userns
 
     source /usr/lib/ujust/ujust.sh
     ToolboxAssembleList {{ FILE }} {{ ACTION }} {{ CONTAINER }}
@@ -169,6 +163,21 @@ semodule-check MODULE:
     #! /bin/run0 /bin/bash
     if [ -n "$( semodule -l | grep {{ MODULE }} )" ] ; then
         semodule -l | grep {{ MODULE }}
+    fi
+
+prompt-for-container-userns:
+    if semodule -l | grep -q "$MODULE_NAME"; then
+        echo "Module $MODULE_NAME is currently enabled."  
+        echo "This must be disabled to use containers."  
+        read -p "Would you like to proceed? [Y/n] " disable_module_now  
+        disable_module_now=${disable_module_now:-y}  
+        if [[ "$disable_module_now" == [N/n]* ]]; then 
+            exit 0
+        fi
+    fi
+
+    if ujust semodule-check "harden_container_userns"; then 
+        ujust toggle-container-domain-userns-creation   
     fi
 
 # Install Steam via choice of 3 methods


### PR DESCRIPTION
By default, harden_container_userns is active. This will prevent a user from making a distrobox container. As such, we should ask at runtime to disable it if it is running.