### PR TITLE
fix: Unbreak gvfsd-admin (#781)

### DIFF
--- a/files/system/usr/share/gvfs/mounts/admin.mount
+++ b/files/system/usr/share/gvfs/mounts/admin.mount
@@ -1,0 +1,7 @@
+[Mount]
+Type=admin
+# Add a dummy argument after pkexec, or '/bin/sh -c' will eat the first argument in '$@'
+Exec=/bin/sh -c 'run0 --setenv=PKEXEC_UID="$UID" /usr/libexec/gvfsd-admin "$@" --address $DBUS_SESSION_BUS_ADDRESS --dir $XDG_RUNTIME_DIR' gvfsd-admin
+AutoMount=false
+DBusName=org.gtk.vfs.mountpoint_admin
+MountPerClient=true


### PR DESCRIPTION
See https://github.com/secureblue/secureblue/issues/781#issuecomment-2586475173 for the description of the changes.

Test build is available at https://github.com/nihil-admirari/secureblue/pkgs/container/silverblue-main-hardened.

Flatpak's GNOME TextEditor works with `admin:///` only when started from a command line:
```bash
flatpak run org.gnome.TextEditor admin:///etc/fstab
```
`admin:///` files can't be selected in a GUI. The problem is [reproducible in vanilla Silverblue](https://github.com/flathub/org.gnome.TextEditor/issues/34), so it has nothing to do with these changes. Layered `gnome-text-editor` doesn't have this problem.

On opening the first `admin:///` file, the password will be asked twice. The version with `pkexec` asked for password only once. I don't know what's causing this discrepancy. Subsequently opened files ask for a password only once.

The entire `admin.mount` is committed to the repository. I'm afraid that if the file is changed upstream, the build process will not incorporate upstream changes. Seems more reasonable to commit only diffs and apply them during build; if the upstream has changed in an incompatible way the build would fail instead of applying an old configuration file. Haven't seen pull requests doing it that way though.