### PR TITLE
chore: pull cached kernels from new upstream location

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,31 +74,6 @@ jobs:
           registry: 'ghcr.io/wayblueorg'
           pubkey: 'https://raw.githubusercontent.com/wayblueorg/wayblue/live/cosign.pub'
 
-      - name: Validate server kernel and kmod versions
-        if: ${{ contains(env.IMAGE_NAME, 'securecore') }}
-        run: |
-            set -eo pipefail
-            linux=$(skopeo inspect docker://ghcr.io/ublue-os/coreos-testing-kernel:41 | jq -r '.Labels["ostree.linux"]')
-            AKMODS_KERNEL_VERSION=$(skopeo inspect docker://ghcr.io/ublue-os/akmods:coreos-testing-41 | jq -r '.Labels["ostree.linux"]')
-            if [[ "${linux}" != "${AKMODS_KERNEL_VERSION}" ]]; then
-              echo "Kernel Versions do not match between AKMODS and Cached-Kernel."
-              exit 1
-            fi
-            echo "KERNEL_VERSION=$linux" >> $GITHUB_ENV
-
-      - name: Validate desktop kernel and kmod versions
-        if: ${{ !contains(env.IMAGE_NAME, 'securecore') }}
-        run: |
-            set -eo pipefail
-            linux=$(skopeo inspect docker://ghcr.io/ublue-os/main-kernel:41 | jq -r '.Labels["ostree.linux"]')
-            AKMODS_KERNEL_VERSION=$(skopeo inspect docker://ghcr.io/ublue-os/akmods:main-41 | jq -r '.Labels["ostree.linux"]')
-            if [[ "${linux}" != "${AKMODS_KERNEL_VERSION}" ]]; then
-              echo "Kernel Versions do not match between AKMODS and Cached-Kernel."
-              exit 1
-            fi
-            echo "KERNEL_VERSION=$linux" >> $GITHUB_ENV
-
-
       - name: Build secureblue
         uses: blue-build/github-action@4d8b4df657ec923574611eec6fd7e959416c47f0 # v1.8.1
         with:          

--- a/recipes/common/desktop-modules.yml
+++ b/recipes/common/desktop-modules.yml
@@ -2,11 +2,9 @@ modules:
     - type: containerfile
       snippets:
         - COPY --from=ghcr.io/ublue-os/akmods:main-41 /rpms /tmp/rpms
+        - COPY --from=ghcr.io/ublue-os/akmods:main-41 /kernel-rpms /tmp/rpms/kernel
         - RUN find /tmp/rpms
         - RUN rpm -q ublue-os-akmods-addons || rpm-ostree install /tmp/rpms/ublue-os/ublue-os-akmods-addons*.rpm
-    - type: containerfile
-      snippets:
-        - COPY --from=ghcr.io/ublue-os/main-kernel:41 /tmp/rpms /tmp/rpms/kernel
     - type: script
       scripts:
         - installsignedkernel.sh

--- a/recipes/common/server-modules.yml
+++ b/recipes/common/server-modules.yml
@@ -2,11 +2,9 @@ modules:
     - type: containerfile
       snippets:
         - COPY --from=ghcr.io/ublue-os/akmods:coreos-testing-41 /rpms /tmp/rpms
+        - COPY --from=ghcr.io/ublue-os/akmods:coreos-testing-41 /kernel-rpms /tmp/rpms/kernel
         - RUN find /tmp/rpms
         - RUN rpm-ostree install /tmp/rpms/ucore/ublue-os-ucore-addons*.rpm    
-    - type: containerfile
-      snippets:
-        - COPY --from=ghcr.io/ublue-os/coreos-testing-kernel:41 /tmp/rpms /tmp/rpms/kernel
     - type: script
       scripts:
         - installsignedkernel.sh


### PR DESCRIPTION
cached kernels and akmods are both shipped in the same containers now