### PR TITLE
fix: exclude securecore from desktop verification step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
           echo "BASE_IMAGE_NAME=$(echo $BASE_IMAGE | sed 's/.*\/.*\///')" >> $GITHUB_ENV
 
       - name: Verify base image
-        if: ${{ ! contains(env.IMAGE_NAME, 'wayblue') }}
+        if: ${{ ! contains(env.IMAGE_NAME, 'wayblue') &&  ! contains(env.IMAGE_NAME, 'securecore') }}
         uses: EyeCantCU/cosign-action/verify@58722a084c82190b57863002d494c91eabbe9e79 # v0.3.0
         with:
           containers: ${{ env.BASE_IMAGE_NAME }}:${{ env.IMAGE_MAJOR_VERSION }}

--- a/.github/workflows/checksum.yml
+++ b/.github/workflows/checksum.yml
@@ -5,7 +5,7 @@ on:
       - live
 jobs:
   verify-installer-checksum:
-    name: Linkspector
+    name: Verify Installer Checksum
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
coreos comes from a different registry that isn't yet signed
