### PR TITLE
fix: temporarily pin kernel to 6.12.15 to shield users from a kernel regression

### DIFF
--- a/recipes/common/desktop-modules.yml
+++ b/recipes/common/desktop-modules.yml
@@ -1,8 +1,8 @@
 modules:
     - type: containerfile
       snippets:
-        - COPY --from=ghcr.io/ublue-os/akmods:main-41 /rpms /tmp/rpms
-        - COPY --from=ghcr.io/ublue-os/akmods:main-41 /kernel-rpms /tmp/rpms/kernel
+        - COPY --from=ghcr.io/ublue-os/akmods:main-41-6.12.15-200.fc41.x86_64 /rpms /tmp/rpms
+        - COPY --from=ghcr.io/ublue-os/akmods:main-41-6.12.15-200.fc41.x86_64 /kernel-rpms /tmp/rpms/kernel
         - RUN find /tmp/rpms
         - RUN rpm -q ublue-os-akmods-addons || rpm-ostree install /tmp/rpms/ublue-os/ublue-os-akmods-addons*.rpm
     - type: script

--- a/recipes/common/nvidia-modules.yml
+++ b/recipes/common/nvidia-modules.yml
@@ -1,7 +1,7 @@
 modules:
     - type: containerfile
       snippets:
-        - COPY --from=ghcr.io/ublue-os/akmods-nvidia:main-41 /rpms /tmp/rpms
+        - COPY --from=ghcr.io/ublue-os/akmods-nvidia:main-41-6.12.15-200.fc41.x86_64 /rpms /tmp/rpms
         - RUN find /tmp/rpms
         - RUN rpm-ostree install /tmp/rpms/ublue-os/ublue-os-nvidia*.rpm
         - RUN sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' /etc/yum.repos.d/nvidia-container-toolkit.repo

--- a/recipes/common/nvidia-open-modules.yml
+++ b/recipes/common/nvidia-open-modules.yml
@@ -1,7 +1,7 @@
 modules:
     - type: containerfile
       snippets:
-        - COPY --from=ghcr.io/ublue-os/akmods-nvidia-open:main-41 /rpms /tmp/rpms
+        - COPY --from=ghcr.io/ublue-os/akmods-nvidia-open:main-41-6.12.15-200.fc41.x86_64 /rpms /tmp/rpms
         - RUN find /tmp/rpms
         - RUN rpm-ostree install /tmp/rpms/ublue-os/ublue-os-nvidia*.rpm
         - RUN sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' /etc/yum.repos.d/nvidia-container-toolkit.repo


### PR DESCRIPTION
https://github.com/ublue-os/bluefin/pull/2226
https://lore.kernel.org/linux-mm/CAJnrk1ZFfb7p01nkN=+tTJFt925PEAQyB=zRcsUM7Ue+TV2pZA@mail.gmail.com/T/
https://bodhi.fedoraproject.org/updates/FEDORA-2025-f476a8c306