### PR TITLE
feat: add euo pipefail to ujust scripts

### DIFF
--- a/files/justfiles/audit.just
+++ b/files/justfiles/audit.just
@@ -1,6 +1,7 @@
 # Audit secureblue
 audit-secureblue AUDIT_FLATPAKS="true":
     #!/bin/bash
+    set -euo pipefail
 
     STATUS_SUCCESS="SUCCESS"
     STATUS_WARNING="WARNING"
@@ -31,7 +32,7 @@ audit-secureblue AUDIT_FLATPAKS="true":
     fi
     print_heading() {
         echo
-        if [[ $HAS_GUM == true ]]; then 
+        if [[ $HAS_GUM == true ]]; then
             gum style --bold --background=63 --foreground=228 "$1"
         else
             echo "$1"

--- a/files/justfiles/dns.just
+++ b/files/justfiles/dns.just
@@ -1,6 +1,8 @@
 # setup system DNS resolution
 dns-selector:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
+
     # constants
     readonly resolved_conf="/etc/systemd/resolved.conf.d/10-securedns.conf"
     readonly policy_file="/etc/trivalent/policies/managed/10-securedns-browser.json"

--- a/files/justfiles/hardening.just
+++ b/files/justfiles/hardening.just
@@ -1,6 +1,8 @@
 # Harden flatpaks by preloading hardened_malloc (highest supported hwcap). When called with a flatpak application ID as an argument, applies the overrides to that application instead of globally.
 harden-flatpak FLATPAK="":
     #!/usr/bin/bash
+    set -euo pipefail
+
     var1={{ FLATPAK }}
     flatpak_id="${var1:-}"
     flatpak override --user --filesystem=host-os:ro $flatpak_id
@@ -17,6 +19,8 @@ harden-flatpak FLATPAK="":
 # Harden Flatpaks further by disabling all permissions by default and rejecting known arbitrary DBus names, applies only to the current user
 flatpak-permissions-lockdown:
     #!/usr/bin/bash
+    set -euo pipefail
+
     kCommand="flatpak override --user"
     kSharePermissions=("network" "ipc")
     kSocketPermissions=("inherit-wayland-socket" "gpg-agent" "cups" "pcsc" "ssh-auth" "system-bus" "session-bus" "pulseaudio" "fallback-x11" "x11")
@@ -105,6 +109,8 @@ flatpak-permissions-lockdown:
 # Resets Flatpak's global overrides
 flatpak-reset-global-overrides:
     #!/usr/bin/bash
+    set -euo pipefail
+
     GLOBAL_OVERRIDES="$HOME/.local/share/flatpak/overrides/global"
     echo "This will undo the flatpak-harden command, the flatpak-permissions-lockdown command, as well as any other global overrides (individual app overrides will not be affected)."
     echo "It will not delete the file, but simply move it from $GLOBAL_OVERRIDES to $GLOBAL_OVERRIDES.save"
@@ -113,11 +119,13 @@ flatpak-reset-global-overrides:
 # Setup USBGuard
 setup-usbguard:
     #!/usr/bin/bash
+    set -euo pipefail
+
     echo "Notice: This will generate a policy based on your existing connected USB devices."
     run0 sh -c '
         mkdir -p /var/log/usbguard
         mkdir -p /etc/usbguard
-        chmod 755 /etc/usbguard        
+        chmod 755 /etc/usbguard
         groupadd usbguard
         usermod -aG usbguard $1
         usbguard generate-policy > /etc/usbguard/rules.conf

--- a/files/justfiles/kargs.just
+++ b/files/justfiles/kargs.just
@@ -1,6 +1,8 @@
 # Add additional boot parameters for hardening (requires reboot)
 set-kargs-hardening:
     #!/usr/bin/bash
+    set -euo pipefail
+
     read -p "Do you need support for 32-bit processes/syscalls? (This is mostly used by legacy software, with some exceptions, such as Steam) [y/N]: " YES
     if [[ "$YES" == [Yy]* ]]; then
         echo "Keeping 32-bit support."
@@ -54,6 +56,8 @@ set-kargs-hardening:
 # Remove all hardening boot parameters (requires reboot)
 remove-kargs-hardening:
     #!/usr/bin/bash
+    set -euo pipefail
+
     rpm-ostree kargs \
       --delete-if-present="init_on_alloc=1" \
       --delete-if-present="init_on_free=1" \
@@ -87,6 +91,8 @@ remove-kargs-hardening:
 # Set nvidia kargs
 set-kargs-nvidia:
     #!/usr/bin/bash
+    set -euo pipefail
+
     rpm-ostree kargs \
       --append-if-missing=rd.driver.blacklist=nouveau \
       --append-if-missing=modprobe.blacklist=nouveau \

--- a/files/justfiles/luks.just
+++ b/files/justfiles/luks.just
@@ -14,19 +14,27 @@
 # Enable automatic LUKS unlock via TPM
 setup-luks-tpm-unlock:
     #!/usr/bin/bash
+    set -euo pipefail
+
     run0 /usr/libexec/luks-enable-tpm2-autounlock
 
 # Disable automatic LUKS unlock via TPM
 remove-luks-tpm-unlock:
     #!/usr/bin/bash
+    set -euo pipefail
+
     run0 /usr/libexec/luks-disable-tpm2-autounlock
 
 # Enabled automatic LUKS unlock via a FIDO2 hardware key
 setup-luks-fido2-unlock:
     #!/usr/bin/bash
+    set -euo pipefail
+
     run0 /usr/libexec/luks-enable-fido2-unlock
 
 # Disable automatic LUKS unlock via a FIDO2 hardware key
 remove-luks-fido2-unlock:
     #!/usr/bin/bash
+    set -euo pipefail
+
     run0 /usr/libexec/luks-disable-fido2-unlock

--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -1,6 +1,8 @@
 # Toggle the cups service on/off
 toggle-cups:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
+
     if systemctl is-enabled --quiet cups; then
       firewall-cmd --permanent --remove-port=631/tcp
       firewall-cmd --permanent --remove-port=631/udp
@@ -24,6 +26,8 @@ toggle-cups:
 # Toggle bluetooth kernel modules on/off (requires reboot)
 toggle-bluetooth-modules:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
+
     BLUE_MOD_FILE="/etc/modprobe.d/99-bluetooth.conf"
     if test -e $BLUE_MOD_FILE; then
       rm -f $BLUE_MOD_FILE
@@ -38,6 +42,8 @@ toggle-bluetooth-modules:
 # Toggle GHNS (KDE Get New Stuff)
 toggle-ghns:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
+
     KDE_GLOBALS_FILE="/etc/xdg/kdeglobals"
     if test -e $KDE_GLOBALS_FILE; then
       if grep -q "ghns=false" "$KDE_GLOBALS_FILE"; then
@@ -56,6 +62,8 @@ toggle-ghns:
 # enable a kernel module that is disabled by modprobe.d (requires restart)
 override-enable-module mod_name:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
+
     MOD_NAME="{{ mod_name }}"
     MOD_FILE="/etc/modprobe.d/99-$MOD_NAME.conf"
     if test -e $MOD_FILE; then
@@ -69,6 +77,8 @@ override-enable-module mod_name:
 # reset the override by `just override-enable-module`, i.e. disable the module again (requires restart)
 override-reset-module mod_name:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
+
     MOD_NAME="{{ mod_name }}"
     MOD_FILE="/etc/modprobe.d/99-$MOD_NAME.conf"
     if test -e $MOD_FILE; then
@@ -81,6 +91,8 @@ override-reset-module mod_name:
 # Toggle debug mode (requires restart)
 toggle-debug-mode:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
+
     if test -e /etc/sysctl.d/99-enable-coredump.conf; then
         cp /usr/etc/security/limits.d/60-disable-coredump.conf /etc/security/limits.d/60-disable-coredump.conf
         cp /usr/etc/systemd/system.conf.d/60-disable-coredump.conf /etc/systemd/system.conf.d/60-disable-coredump.conf
@@ -103,6 +115,8 @@ alias toggle-ptrace-scope := toggle-anticheat-support
 # Toggle anticheat support by changing ptrace scope (requires restart)
 toggle-anticheat-support:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
+
     SYSCTL_HARDENING_FILE="/etc/sysctl.d/60-hardening.conf"
     if grep -q "kernel.yama.ptrace_scope = 3" "$SYSCTL_HARDENING_FILE"; then
         sed -i "s/kernel.yama.ptrace_scope = 3/kernel.yama.ptrace_scope = 1/" "$SYSCTL_HARDENING_FILE"
@@ -117,6 +131,8 @@ toggle-anticheat-support:
 # Toggle Gnome JIT JavaScript for GJS and WebkitGTK (requires session restart)
 toggle-gnome-jit-js:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
+
     ENV_FILE="/etc/profile.d/gnome-disable-jit.sh"
     if test -e $ENV_FILE; then
         rm -f $ENV_FILE
@@ -130,6 +146,8 @@ toggle-gnome-jit-js:
 # Toggle support for using GNOME user extensions
 toggle-gnome-extensions:
     #!/usr/bin/bash
+    set -euo pipefail
+
     GSETTING="$(gsettings get org.gnome.shell allow-extension-installation)"
     if [[ "${GSETTING}" == "false" ]]; then
       gsettings set org.gnome.shell allow-extension-installation true
@@ -142,6 +160,8 @@ toggle-gnome-extensions:
 # Toggle Xwayland support
 toggle-xwayland ACTION="prompt":
     #! /bin/run0 /bin/bash
+    set -euo pipefail
+
     source /usr/lib/ujust/ujust.sh
     OPTION={{ ACTION }}
     if [ "$OPTION" == "prompt" ]; then
@@ -200,6 +220,8 @@ toggle-xwayland ACTION="prompt":
 # Toggle bash environment lockdown (mitigates LD_PRELOAD attacks)
 toggle-bash-environment-lockdown:
     #!/usr/bin/bash
+    set -euo pipefail
+
     BASH_ENV_FILES=("$HOME/.bashrc" "$HOME/.bash_profile")
     echo "${b}WARNING${n} This will overwrite your .bashrc and .bash_profile."
     echo "This is needed to ensure the mitigation is effective."
@@ -256,6 +278,8 @@ toggle-bash-environment-lockdown:
 # Toggle unconfined domain userns creation
 toggle-unconfined-domain-userns-creation:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
+
     MODULE_NAME="harden_userns"
 
     if semodule -l | grep -q "$MODULE_NAME"; then
@@ -271,6 +295,8 @@ toggle-unconfined-domain-userns-creation:
 # Toggle container domain userns creation
 toggle-container-domain-userns-creation:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
+
     MODULE_NAME="harden_container_userns"
 
     if semodule -l | grep -q "$MODULE_NAME"; then
@@ -286,6 +312,8 @@ toggle-container-domain-userns-creation:
 # Toggle MAC Randomization
 toggle-mac-randomization:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
+
     RAND_MAC_FILE="/etc/NetworkManager/conf.d/rand_mac.conf"
 
     if test -e $RAND_MAC_FILE; then

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -17,6 +17,8 @@ shell := `grep :$(id -u): /etc/passwd | cut -d: -f7`
 # Boot into this device's BIOS/UEFI screen
 bios:
     #!/usr/bin/bash
+    set -euo pipefail
+
     if [ -d /sys/firmware/efi ]; then
       systemctl reboot --firmware-setup
     else
@@ -26,16 +28,22 @@ bios:
 # Show all messages from this boot
 logs-this-boot:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
+
     journalctl -b 0
 
 # Show all messages from last boot
 logs-last-boot:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
+
     journalctl -b -1
 
 # Regenerate GRUB config, useful in dual-boot scenarios where a second operating system isn't listed
 regenerate-grub:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
+
     if [ -d /sys/firmware/efi ]; then
       grub2-mkconfig -o /etc/grub2-efi.cfg
     else
@@ -45,6 +53,8 @@ regenerate-grub:
 # Enroll Nvidia driver & KMOD signing key for secure boot - Enter password "universalblue" if prompted
 enroll-secure-boot-key:
     #! /usr/bin/bash
+    set -euo pipefail
+
     run0 mokutil --timeout -1
     echo 'The next line will prompt for a MOK password. Then, input "universalblue"'
     run0 mokutil --import /etc/pki/akmods/certs/akmods-ublue.der
@@ -53,6 +63,8 @@ enroll-secure-boot-key:
 # Toggle display of the user-motd in terminal
 toggle-user-motd:
     #!/usr/bin/bash
+    set -euo pipefail
+
     if test -e "${HOME}/.config/no-show-user-motd"; then
       rm -f "${HOME}/.config/no-show-user-motd"
     else
@@ -66,6 +78,8 @@ toggle-user-motd:
 [no-exit-message]
 update-firmware:
     #!/usr/bin/bash
+    set -euo pipefail
+
     fwupdmgr refresh --force
     fwupdmgr get-updates
     fwupdmgr update
@@ -73,6 +87,8 @@ update-firmware:
 # Clean up old up unused podman images, volumes, flatpak packages and rpm-ostree content
 clean-system:
     #!/usr/bin/bash
+    set -euo pipefail
+
     podman image prune -af
     podman volume prune -f
     flatpak uninstall --unused
@@ -81,6 +97,8 @@ clean-system:
 # Check for local overrides
 check-local-overrides:
     #!/usr/bin/bash
+    set -euo pipefail
+
     diff -r \
       --suppress-common-lines \
       --color="always" \
@@ -114,6 +132,8 @@ check-local-overrides:
 # Debug dump pastebin for issue reporting
 debug-info:
     #!/usr/bin/bash
+    set -euo pipefail
+
     rpm_ostree_status=$(echo -e "=== Rpm-Ostree Status ===\n"; rpm-ostree status --verbose)
     sysinfo=$(echo -e "\n"; fpaste --sysinfo --printonly)
     flatpaks=$(echo "=== Flatpaks Installed ==="; flatpak list --columns=application,version,options)
@@ -127,6 +147,8 @@ debug-info:
 # Rerun Yafti
 rerun-yafti:
     #!/usr/bin/bash
+    set -euo pipefail
+
     yafti -f /usr/share/ublue-os/firstboot/yafti.yml
 
 alias assemble := distrobox-assemble
@@ -134,6 +156,8 @@ alias assemble := distrobox-assemble
 # Create distroboxes from a defined manifest
 distrobox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/distrobox/distrobox.ini":
     #!/usr/bin/bash
+    set -euo pipefail
+
     # Distroboxes are gathered from distrobox.ini, please add them there
     source /usr/lib/ujust/ujust.sh
     AssembleList {{ FILE }} {{ ACTION }} {{ CONTAINER }}
@@ -141,6 +165,8 @@ distrobox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/distrobox/distr
 # Create toolbox containers from a defined manifest (this spec will not be expanded)
 toolbox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/toolbox/toolbox.ini":
     #!/usr/bin/bash
+    set -euo pipefail
+
     # Toolboxes are gathered from toolbox.ini, please add them there
     source /usr/lib/ujust/ujust.sh
     ToolboxAssembleList {{ FILE }} {{ ACTION }} {{ CONTAINER }}
@@ -148,16 +174,22 @@ toolbox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/toolbox/toolbox.i
 # Run a non-flatpak application with standard memory allocator (needs an argument!)
 with-standard-malloc APP:
     #!/usr/bin/bash
+    set -euo pipefail
+
     bwrap --dev-bind / / --ro-bind /dev/null /etc/ld.so.preload {{ APP }}
 
 # Add the unfiltered Flathub flatpak repo
 enable-flathub-unfiltered:
     #!/usr/bin/bash
+    set -euo pipefail
+
     flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
 
 # search for an installed SELinux module
 semodule-check MODULE:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
+
     if [ -n "$( semodule -l | grep {{ MODULE }} )" ] ; then
         semodule -l | grep {{ MODULE }}
     fi
@@ -165,6 +197,8 @@ semodule-check MODULE:
 # Install Steam via choice of 3 methods
 install-steam:
     #!/usr/bin/bash
+    set -euo pipefail
+
     if [ -z "$(pgrep Xwayland)" ] && [ -z "$(pgrep Xorg)" ] ; then
         echo "Steam requires X or Xwayland, which your variant of secureblue has disabled by default."
         echo "Please run 'ujust toggle-xwayland' to re-enable it."
@@ -238,6 +272,8 @@ install-steam:
 # Install the official docker packages
 install-docker:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
+
     curl -Lo /etc/yum.repos.d/docker-ce.repo https://download.docker.com/linux/fedora/docker-ce.repo
     rpm-ostree refresh-md
     rpm-ostree install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
@@ -245,6 +281,8 @@ install-docker:
 # Uninstall the official docker packages
 uninstall-docker:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
+
     rm /etc/yum.repos.d/docker-ce.repo
     rpm-ostree refresh-md
     rpm-ostree uninstall docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
@@ -252,4 +290,6 @@ uninstall-docker:
 # Rebase to a different secureblue Desktop Environment/Atomic Desktop
 rebase-secureblue:
     #!/usr/bin/bash
+    set -euo pipefail
+
     /usr/bin/bash /usr/share/secureblue/install_secureblue.sh


### PR DESCRIPTION
Close https://github.com/secureblue/secureblue/issues/475

Ujust scripts that are now broken (tested in a VM with Kinoite):

- ~~audit-secureblue (line 120)~~
- harden-flatpak: didn't break for me (https://github.com/secureblue/secureblue/pull/537#pullrequestreview-2424666201)
- setup-luks-tpm-unlock
- remove-luks-tpm-unlock
- setup-luks-fido2-unlock
- remove-luks-fido2-unlock
- toggle-gnome-extensions will test in gnome too, but it need a detection for absence of gnome
- toggle-bash-environment-lockdown (line 226)
- enroll-secure-boot-key : EFI variables are not supported on this system
- check-local-overrides
- debug-info: because of audit-secureblue
- ~~toolbox-assemble : failed to inspect container and to pull image registry redhat~~
- ~~with-standard-malloc: bwrap: Creating new namespace failed: Permission denied.~~
- rebase-secureblue : Couldn't test it in my custom image