### PR TITLE
feat: Inform users that cups-browsed remains disabled when CUPS is toggled on.

### DIFF
--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -9,7 +9,7 @@ toggle-cups:
       systemctl disable cups
       systemctl stop cups
       systemctl daemon-reload
-      echo "Cups disabled."
+      echo "CUPS disabled."
     else
       firewall-cmd --permanent --add-port=631/tcp
       firewall-cmd --permanent --add-port=631/udp
@@ -18,7 +18,9 @@ toggle-cups:
       systemctl enable cups
       systemctl start cups
       systemctl daemon-reload
-      echo "Cups enabled."
+      echo "CUPS enabled."
+      echo "Note: cups-browsed, the printer discovery service, is still disabled for"
+      echo "security reasons. New network printers will need to be added manually."
     fi
 
 # Toggle bluetooth kernel modules on/off (requires reboot)

--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -20,7 +20,9 @@ toggle-cups:
       systemctl daemon-reload
       echo "CUPS enabled."
       echo "Note: cups-browsed, the printer discovery service, is still disabled for"
-      echo "security reasons. New network printers will need to be added manually."
+      echo "    security reasons. New network printers will need to be added manually."
+      echo "    If you absolutely need network discovery, you can enable the cups-browsed"
+      echo "    service at your own risk. Secureblue strongly recommends against this."
     fi
 
 # Toggle bluetooth kernel modules on/off (requires reboot)


### PR DESCRIPTION
Closes issue #925. Might need to workshop the phrasing a bit—should we give more detail on how to add a network printer manually (e.g. through searching for the IP address of the printer in GNOME's settings interface, or using `lpadmin`), or do you think this is good enough?