### PR TITLE
fix: container userns audit & podman shutdown

### DIFF
--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -260,6 +260,7 @@ toggle-bash-environment-lockdown:
 # Toggle unconfined domain userns creation
 toggle-unconfined-domain-userns-creation:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
     MODULE_NAME="harden_userns"
 
     if semodule -l | grep -q "$MODULE_NAME"; then
@@ -275,6 +276,7 @@ toggle-unconfined-domain-userns-creation:
 # Toggle container domain userns creation
 toggle-container-domain-userns-creation:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
     MODULE_NAME="harden_container_userns"
 
     if semodule -l | grep -q "$MODULE_NAME"; then
@@ -291,11 +293,13 @@ toggle-container-domain-userns-creation:
             exit 0
         fi
 
-        podman stop --all
-        killall -u "$USER" catatonit
-
         semodule --enable="$MODULE_NAME"
         echo "Module $MODULE_NAME enabled. Container domain userns disabled."
+
+        echo 'Stopping all containers and shutting down podman...'
+        run0 --user="$SUDO_USER" podman stop --all > /dev/null
+        killall -u "$SUDO_USER" catatonit || true
+        echo 'podman has been shut down.'
 
         if pgrep -u root -a -x catatonit &> /dev/null; then
             echo 'WARNING: Catatonit running as root detected, reboot your machine to reset podman state.'

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -181,13 +181,13 @@ enable-flathub-unfiltered:
 check-container-userns-state:
     #!/usr/bin/bash
     set -euo pipefail
-    [ podman unshare true &> /dev/null ] && echo 'enabled' || echo 'disabled'
+    podman unshare true &> /dev/null && echo 'enabled' || echo 'disabled'
 
 # Returns the state of unconfined domain user namespaces. (enabled/disabled)
 check-unconfined-userns-state:
     #!/usr/bin/bash
     set -euo pipefail
-    [ unshare -U true &> /dev/null ] && echo 'enabled' || echo 'disabled'
+    unshare -U true &> /dev/null && echo 'enabled' || echo 'disabled'
 
 # Install Steam via choice of 3 methods
 install-steam:


### PR DESCRIPTION
Fixes #936. Note that because `ujust toggle-container-domain-userns-creation` is run as root, we need to use `$SUDO_USER` to refer back to the user who called the script. I also moved the podman shutdown to *after* the SELinux module is re-enabled, because under some circumstances the catatonit process can get restarted in between when podman containers are shut down and the SELinux module blocks user namespace creation.