### PR TITLE
fix: disable kde splash screen for new users by setting initial config to none

### DIFF
--- a/files/system/kinoite/etc/skel/.config/ksplashrc
+++ b/files/system/kinoite/etc/skel/.config/ksplashrc
@@ -1,0 +1,3 @@
+[KSplash]
+Engine=none
+Theme=None


### PR DESCRIPTION
It seems like it is [impossible](https://discord.com/channels/1202086019298500629/1202086051578118184/1350335005041233960) to override the splash default to something else than the default theme as it appears to be hardcoded.

This PR works around that by simply setting the initial `~/.config/ksplashrc` config for new users through `/etc/skel/`.

I had also tried doing the same for `~/.config/kdedefaults/ksplashrc` to still have this as a user-default, but that file got overwritten with the theme-default splash when the user loaded into the desktop.

Not really a perfect solution, as it would have been better/cleaner to have this as a default (so resetting settings in the GUI doesn't enable the splash screen again), but better than nothing.

Closes #926.