### PR TITLE
fix: MOTD broken after bluebuild rebase

### DIFF
--- a/files/system/usr/libexec/ublue-motd
+++ b/files/system/usr/libexec/ublue-motd
@@ -37,6 +37,6 @@ elif [ "$DIFFERENCE" -ge "$WEEK" ]; then
 else
     TIP='**For secureblue release notifications,** [subscribe:](https://secureblue.dev/faq#releases)'
 fi
-sed -e "s/%IMAGE_REF_NAME%/$IMAGE_REF_NAME/g" -e "s/%IMAGE_TAG%/$IMAGE_TAG/g" -e "s|%TIP%|$TIP|g" /usr/share/ublue-os/motd/secureblue.md | tr '~' '\n' | { command -v glow >/dev/null 2>&1 && glow -s auto -w 78 - || cat; }
+sed -e "s/%IMAGE_REF_NAME%/$IMAGE_REF_NAME/g" -e "s|%TIP%|$TIP|g" /usr/share/ublue-os/motd/secureblue.md | tr '~' '\n' | { command -v glow >/dev/null 2>&1 && glow -s auto -w 78 - || cat; }
 
 


### PR DESCRIPTION
After doing a bluebuild rebase (which I got working by creating a fake sudo script that simply calls run0), the MOTD breaks because the image is now a local tarball file.

But %IMAGE_TAG% is unused in the MOTD, so simply avoid substituting it in.