### PR TITLE
feat: add a check to the MOTD in case KDE splash is enabled

### DIFF
--- a/files/system/usr/libexec/ublue-motd
+++ b/files/system/usr/libexec/ublue-motd
@@ -42,7 +42,7 @@ if [ grep 'kinoite' "$IMAGE_REF_NAME" ]; then
     if [ -f ~/.config/ksplashrc ]; then
         if [ -f /etc/systemd/user/plasma-kwin_wayland.service.d/override.conf]; then
             if [ ! grep 'Engine=none' ~/.config/ksplashrc ] || [ ! grep 'Theme=None' ~/.config/ksplashrc ]; then
-                TIP='**KDE's splash screen does not support disabling xWayland. We recommend disabling the splash screen to avoid needless slowdown.**'
+                TIP='**KDE\'s splash screen does not support disabling xWayland. We recommend disabling the splash screen to avoid needless slowdown.**'
             fi
         fi
     fi

--- a/files/system/usr/libexec/ublue-motd
+++ b/files/system/usr/libexec/ublue-motd
@@ -37,6 +37,16 @@ elif [ "$DIFFERENCE" -ge "$WEEK" ]; then
 else
     TIP='**For secureblue release notifications,** [subscribe:](https://secureblue.dev/faq#releases)'
 fi
-sed -e "s/%IMAGE_REF_NAME%/$IMAGE_REF_NAME/g" -e "s/%IMAGE_TAG%/$IMAGE_TAG/g" -e "s|%TIP%|$TIP|g" /usr/share/ublue-os/motd/secureblue.md | tr '~' '\n' | { command -v glow >/dev/null 2>&1 && glow -s auto -w 78 - || cat; }
 
+if [ grep 'kinoite' "$IMAGE_REF_NAME" ]; then
+    if [ -f ~/.config/ksplashrc ]; then
+        if [ -f /etc/systemd/user/plasma-kwin_wayland.service.d/override.conf]; then
+            if [ ! grep 'Engine=none' ~/.config/ksplashrc && grep 'Theme=None' ~/.config/ksplashrc ]; then
+                TIP='**KDE's splash screen does not support disabling xWayland. We recommend disabling the splash screen to avoid needless slowdown.**'
+            fi
+        fi
+    fi
+fi
+
+sed -e "s/%IMAGE_REF_NAME%/$IMAGE_REF_NAME/g" -e "s/%IMAGE_TAG%/$IMAGE_TAG/g" -e "s|%TIP%|$TIP|g" /usr/share/ublue-os/motd/secureblue.md | tr '~' '\n' | { command -v glow >/dev/null 2>&1 && glow -s auto -w 78 - || cat; }
 

--- a/files/system/usr/libexec/ublue-motd
+++ b/files/system/usr/libexec/ublue-motd
@@ -41,7 +41,7 @@ fi
 if [ grep 'kinoite' "$IMAGE_REF_NAME" ]; then
     if [ -f ~/.config/ksplashrc ]; then
         if [ -f /etc/systemd/user/plasma-kwin_wayland.service.d/override.conf]; then
-            if [ ! grep 'Engine=none' ~/.config/ksplashrc ] && [ ! grep 'Theme=None' ~/.config/ksplashrc ]; then
+            if [ ! grep 'Engine=none' ~/.config/ksplashrc ] || [ ! grep 'Theme=None' ~/.config/ksplashrc ]; then
                 TIP='**KDE's splash screen does not support disabling xWayland. We recommend disabling the splash screen to avoid needless slowdown.**'
             fi
         fi

--- a/files/system/usr/libexec/ublue-motd
+++ b/files/system/usr/libexec/ublue-motd
@@ -41,7 +41,7 @@ fi
 if [ grep 'kinoite' "$IMAGE_REF_NAME" ]; then
     if [ -f ~/.config/ksplashrc ]; then
         if [ -f /etc/systemd/user/plasma-kwin_wayland.service.d/override.conf]; then
-            if [ ! grep 'Engine=none' ~/.config/ksplashrc && grep 'Theme=None' ~/.config/ksplashrc ]; then
+            if [ ! grep 'Engine=none' ~/.config/ksplashrc ] && [ ! grep 'Theme=None' ~/.config/ksplashrc ]; then
                 TIP='**KDE's splash screen does not support disabling xWayland. We recommend disabling the splash screen to avoid needless slowdown.**'
             fi
         fi

--- a/files/system/usr/libexec/ublue-motd
+++ b/files/system/usr/libexec/ublue-motd
@@ -42,7 +42,7 @@ if [ grep 'kinoite' "$IMAGE_REF_NAME" ]; then
     if [ -f ~/.config/ksplashrc ]; then
         if [ -f /etc/systemd/user/plasma-kwin_wayland.service.d/override.conf]; then
             if [ ! grep 'Engine=none' ~/.config/ksplashrc ] || [ ! grep 'Theme=None' ~/.config/ksplashrc ]; then
-                TIP='**KDE\'s splash screen does not support disabling xWayland. We recommend disabling the splash screen to avoid needless slowdown.**'
+                TIP='**KDEs splash screen does not support disabling xWayland. We recommend disabling the splash screen to avoid needless slowdown.**'
             fi
         fi
     fi

--- a/files/system/usr/libexec/ublue-motd
+++ b/files/system/usr/libexec/ublue-motd
@@ -42,7 +42,7 @@ if [ grep 'kinoite' "$IMAGE_REF_NAME" ]; then
     if [ -f ~/.config/ksplashrc ]; then
         if [ -f /etc/systemd/user/plasma-kwin_wayland.service.d/override.conf]; then
             if [ ! grep 'Engine=none' ~/.config/ksplashrc ] || [ ! grep 'Theme=None' ~/.config/ksplashrc ]; then
-                TIP='**KDEs splash screen does not support disabling xWayland. We recommend disabling the splash screen to avoid needless slowdown.**'
+                TIP='**The KDE splash screen does not support disabling xWayland. We recommend disabling the splash screen to avoid needless slowdown.**'
             fi
         fi
     fi


### PR DESCRIPTION
Supplement for #926 and #939
This checks if the image is KDE based, then if the user splash config exists (which overrides our fixed default), then it checks if xWayland is disabled (because if it isn't, this fix is unneeded), then it checks if the splash screen isn't disabled. If all of the above is true, it recommends disabling the splash screen.