### PR TITLE
fix: toggle-mac-randomization: correct logic to allow "random" option

### DIFF
--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -310,6 +310,7 @@ toggle-container-domain-userns-creation:
 toggle-mac-randomization:
     #! /bin/run0 /bin/bash
     RAND_MAC_FILE="/etc/NetworkManager/conf.d/rand_mac.conf"
+    randomization_choice=""
 
     if test -e $RAND_MAC_FILE; then
         rm -f $RAND_MAC_FILE
@@ -318,10 +319,9 @@ toggle-mac-randomization:
     else
         echo "MAC randomization can be stable (persisting the same random MAC per access point across disconnects/reboots),"
         echo "or it can be randomized per-connection (every time it connects to the same access point it uses a new MAC)."
-        read -p "Do you want to use per-connection Wi-Fi MAC address randomization? [y/N]" randomization_level
-        randomization_level=${randomization_level:-n}
+        read -p "Do you want to use per-connection Wi-Fi MAC address randomization? [y/N] " randomization_choice
 
-        if [ "$randomization_level" == [Yy]* ]; then
+        if [ "$randomization_choice" == [Yy]* ]; then
             randomization_level=random
             echo "Selected state: per-connection"
         else

--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -321,7 +321,7 @@ toggle-mac-randomization:
         echo "or it can be randomized per-connection (every time it connects to the same access point it uses a new MAC)."
         read -p "Do you want to use per-connection Wi-Fi MAC address randomization? [y/N] " randomization_choice
 
-        if [ "$randomization_choice" == [Yy]* ]; then
+        if [[ "$randomization_choice" == [Yy]* ]]; then
             randomization_level=random
             echo "Selected state: per-connection"
         else

--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -310,7 +310,6 @@ toggle-container-domain-userns-creation:
 toggle-mac-randomization:
     #! /bin/run0 /bin/bash
     RAND_MAC_FILE="/etc/NetworkManager/conf.d/rand_mac.conf"
-    randomization_choice=""
 
     if test -e $RAND_MAC_FILE; then
         rm -f $RAND_MAC_FILE
@@ -319,6 +318,7 @@ toggle-mac-randomization:
     else
         echo "MAC randomization can be stable (persisting the same random MAC per access point across disconnects/reboots),"
         echo "or it can be randomized per-connection (every time it connects to the same access point it uses a new MAC)."
+        randomization_choice=""
         read -p "Do you want to use per-connection Wi-Fi MAC address randomization? [y/N] " randomization_choice
 
         if [[ "$randomization_choice" == [Yy]* ]]; then


### PR DESCRIPTION
Currently the user's choice is ignored, and the `else` case always runs regardless of the user's choice. Using double brackets fixes the logic.