### PR TITLE
fix: make shell script changes recommended by ShellCheck

### DIFF
--- a/docs/example.butane
+++ b/docs/example.butane
@@ -14,7 +14,7 @@ storage:
       contents:
         source: https://raw.githubusercontent.com/secureblue/secureblue/refs/heads/live/files/system/usr/share/secureblue/install_secureblue.sh
         verification:
-          hash: sha256-3b71dd267d921e35d25128a7caf49b02eeded1fb5c189c988e6c984c4bb20141
+          hash: sha256-411fbbc82a6d5bdd1e31c084cf475c70963d4a11755de284237d9e80a0671b6c
       mode: 0755
     - path: /opt/run_install_secureblue.sh
       contents:

--- a/files/justfiles/audit.just
+++ b/files/justfiles/audit.just
@@ -2,6 +2,7 @@
 audit-secureblue AUDIT_FLATPAKS="true":
     #!/bin/bash
     set -euo pipefail
+    source /usr/lib/ujust/libformatting.sh
 
     STATUS_SUCCESS="SUCCESS"
     STATUS_WARNING="WARNING"
@@ -463,7 +464,7 @@ audit-secureblue AUDIT_FLATPAKS="true":
     done
     # shellcheck disable=SC2050
     if [[ "{{ AUDIT_FLATPAKS }}" == "true" ]]; then
-        printf "Run '\033[1mujust audit-secureblue false\033[22m' to skip flatpak recommendations.\n"
+        echo "Run '${bold}ujust audit-secureblue false${unbold}' to skip flatpak recommendations."
     else
-        printf "Run '\033[1mujust audit-secureblue\033[22m' to audit flatpak settings as well.\n"
+        echo "Run '${bold}ujust audit-secureblue${unbold}' to audit flatpak settings as well."
     fi

--- a/files/justfiles/audit.just
+++ b/files/justfiles/audit.just
@@ -358,6 +358,7 @@ audit-secureblue AUDIT_FLATPAKS="true":
         print_status "$SECUREBOOT_TEST_STRING" "$STATUS_FAILURE"
     fi
 
+    # shellcheck disable=SC2050
     if [[ "{{ AUDIT_FLATPAKS }}" == "true" ]]; then
         if command -v flatpak &> /dev/null; then
             remotes="$(flatpak remotes -d)"
@@ -460,4 +461,9 @@ audit-secureblue AUDIT_FLATPAKS="true":
         done
         echo
     done
-    echo "Run '{{ BOLD }}ujust audit-secureblue false{{ NORMAL }}' to skip flatpak recommendations."
+    # shellcheck disable=SC2050
+    if [[ "{{ AUDIT_FLATPAKS }}" == "true" ]]; then
+        printf "Run '\033[1mujust audit-secureblue false\033[22m' to skip flatpak recommendations.\n"
+    else
+        printf "Run '\033[1mujust audit-secureblue\033[22m' to audit flatpak settings as well.\n"
+    fi

--- a/files/justfiles/audit.just
+++ b/files/justfiles/audit.just
@@ -460,4 +460,4 @@ audit-secureblue AUDIT_FLATPAKS="true":
         done
         echo
     done
-    echo "Run '{{BOLD}}ujust audit-secureblue false{{NORMAL}}' to skip flatpak recommendations."
+    echo "Run '{{ BOLD }}ujust audit-secureblue false{{ NORMAL }}' to skip flatpak recommendations."

--- a/files/justfiles/audit.just
+++ b/files/justfiles/audit.just
@@ -11,9 +11,9 @@ audit-secureblue AUDIT_FLATPAKS="true":
 
         local color_code
         case "$status" in
-            $STATUS_SUCCESS) color_code=32 ;; # Green
-            $STATUS_WARNING) color_code=33 ;; # Yellow
-            $STATUS_FAILURE) color_code=31 ;;    # Red
+            "$STATUS_SUCCESS") color_code=32 ;; # Green
+            "$STATUS_WARNING") color_code=33 ;; # Yellow
+            "$STATUS_FAILURE") color_code=31 ;;    # Red
             *) color_code=0 ;;
         esac
 
@@ -31,7 +31,7 @@ audit-secureblue AUDIT_FLATPAKS="true":
     fi
     print_heading() {
         echo
-        if [[ $HAS_GUM == true ]]; then 
+        if [[ "$HAS_GUM" == true ]]; then
             gum style --bold --background=63 --foreground=228 "$1"
         else
             echo "$1"
@@ -43,9 +43,10 @@ audit-secureblue AUDIT_FLATPAKS="true":
         local permissions=$1
         local prefix=$2
         local query=$3
-        local line=$(grep "^${prefix}=" <<< "$permissions" | sed -e "s/^${prefix}=//" -e "s/#.*//")
+        local line
+        line=$(grep "^${prefix}=" <<< "$permissions" | sed -e "s/^${prefix}=//" -e "s/#.*//")
         IFS=';' read -r -a list <<< "$line"
-        for p in ${list[@]}; do
+        for p in "${list[@]}"; do
             if [[ "$p" =~ ^$query$ ]]; then
                 return
             fi
@@ -116,7 +117,7 @@ audit-secureblue AUDIT_FLATPAKS="true":
             fi
         done
     done
-    if [[ "${#sysctl_errors}" == 0 ]] && diff /usr/etc/sysctl.d/60-hardening.conf /etc/sysctl.d/60-hardening.conf > /dev/null; then
+    if [[ "${#sysctl_errors}" == 0 ]] && cmp -s /usr/etc/sysctl.d/60-hardening.conf /etc/sysctl.d/60-hardening.conf; then
         print_status "$SYSCTL_TEST_STRING" "$STATUS_SUCCESS"
     else
         print_status "$SYSCTL_TEST_STRING" "$STATUS_FAILURE"
@@ -134,8 +135,8 @@ audit-secureblue AUDIT_FLATPAKS="true":
     fi
 
     MODPROBE_TEST_STRING="Ensuring no modprobe overrides"
-    readarray -t unwanted_modules < <(comm -12 <(lsmod | cut -f 1 -d " " | sort) <(cat /usr/etc/modprobe.d/blacklist.conf | grep -E '^(blacklist)|(install)' | cut -f 2 -d " " | sort))
-    if [[ "${#unwanted_modules[@]}" == 0 ]] && diff /usr/etc/modprobe.d/blacklist.conf /etc/modprobe.d/blacklist.conf > /dev/null; then
+    readarray -t unwanted_modules < <(comm -12 <(lsmod | cut -f 1 -d " " | sort) <(grep -E '^(blacklist)|(install)' /usr/etc/modprobe.d/blacklist.conf | cut -f 2 -d " " | sort))
+    if [[ "${#unwanted_modules[@]}" == 0 ]] && cmp -s /usr/etc/modprobe.d/blacklist.conf /etc/modprobe.d/blacklist.conf; then
         print_status "$MODPROBE_TEST_STRING" "$STATUS_SUCCESS"
     else
         print_status "$MODPROBE_TEST_STRING" "$STATUS_FAILURE"
@@ -163,7 +164,7 @@ audit-secureblue AUDIT_FLATPAKS="true":
     fi
 
     CONTAINER_POLICY_TEST_STRING="Ensuring no container policy overrides"
-    if diff /usr/etc/containers/policy.json /etc/containers/policy.json > /dev/null && [ ! -f $HOME/.config/containers/policy.json ]; then
+    if cmp -s /usr/etc/containers/policy.json /etc/containers/policy.json && [ ! -f "$HOME/.config/containers/policy.json" ]; then
         print_status "$CONTAINER_POLICY_TEST_STRING" "$STATUS_SUCCESS"
     else
         print_status "$CONTAINER_POLICY_TEST_STRING" "$STATUS_FAILURE"
@@ -201,8 +202,8 @@ audit-secureblue AUDIT_FLATPAKS="true":
 
     SECUREDNS_TEST_STRING="Ensuring system DNS resolution is secure"
     if systemctl is-active --quiet systemd-resolved; then
-        DNSSEC_STATUS="$(cat /etc/systemd/resolved.conf.d/10-securedns.conf | grep "DNSSEC")"
-        DOT_STATUS="$(cat /etc/systemd/resolved.conf.d/10-securedns.conf | grep "DNSOverTLS")"
+        DNSSEC_STATUS="$(grep "DNSSEC" /etc/systemd/resolved.conf.d/10-securedns.conf)"
+        DOT_STATUS="$(grep "DNSOverTLS" /etc/systemd/resolved.conf.d/10-securedns.conf)"
         if [[ "$DNSSEC_STATUS" == "DNSSEC=true" && "$DOT_STATUS" == "DNSOverTLS=true" ]]; then
             print_status "$SECUREDNS_TEST_STRING" "$STATUS_SUCCESS"
         else
@@ -326,7 +327,7 @@ audit-secureblue AUDIT_FLATPAKS="true":
     fi
 
     ENVIRONMENT_TEST_STRING="Ensuring no environment file overrides"
-    if diff /usr/etc/environment /etc/environment > /dev/null; then
+    if cmp -s /usr/etc/environment /etc/environment; then
         print_status "$ENVIRONMENT_TEST_STRING" "$STATUS_SUCCESS"
     else
         print_status "$ENVIRONMENT_TEST_STRING" "$STATUS_WARNING"
@@ -334,9 +335,9 @@ audit-secureblue AUDIT_FLATPAKS="true":
 
     GHNS_TEST_STRING="Ensuring KDE GHNS is disabled"
     KDE_GLOBALS_FILE="/etc/xdg/kdeglobals"
-    if test -e $KDE_GLOBALS_FILE; then
-        GHNS_STRING="$(grep 'ghns=false' $KDE_GLOBALS_FILE)"
-        if [[ $GHNS_STRING == "ghns=false" ]]; then
+    if [ -e "$KDE_GLOBALS_FILE" ]; then
+        GHNS_STRING="$(grep 'ghns=false' "$KDE_GLOBALS_FILE")"
+        if [[ "$GHNS_STRING" == "ghns=false" ]]; then
             print_status "$GHNS_TEST_STRING" "$STATUS_SUCCESS"
         else
             print_status "$GHNS_TEST_STRING" "$STATUS_FAILURE"
@@ -344,7 +345,7 @@ audit-secureblue AUDIT_FLATPAKS="true":
     fi
 
     HARDENED_MALLOC_TEST_STRING="Ensuring hardened_malloc is set in ld.so.preload"
-    if diff /usr/etc/ld.so.preload /etc/ld.so.preload > /dev/null; then
+    if cmp -s /usr/etc/ld.so.preload /etc/ld.so.preload; then
         print_status "$HARDENED_MALLOC_TEST_STRING" "$STATUS_SUCCESS"
     else
         print_status "$HARDENED_MALLOC_TEST_STRING" "$STATUS_FAILURE"
@@ -381,7 +382,7 @@ audit-secureblue AUDIT_FLATPAKS="true":
                 flatpaks+=(["${ref}"]="${ref}//${version}")
             done < <(flatpak list | sort -k 1 | cut --fields 2,4)
 
-            for f in ${!flatpaks[@]}; do
+            for f in "${!flatpaks[@]}"; do
                 warnings=()
                 status="$STATUS_SUCCESS"
                 fullref=${flatpaks["$f"]}
@@ -448,7 +449,7 @@ audit-secureblue AUDIT_FLATPAKS="true":
 
     print_heading Recommendations
     for suggestion in "${suggestions[@]}"; do
-        readarray -t -d '	' list < <(printf "$suggestion")
+        readarray -t -d '	' list < <(printf '%s' "$suggestion")
         echo "${list[0]}"
         for (( i=1; i < ${#list[@]}; i++ )); do
             if [[ ${list[i]} =~ ^"$" ]]; then
@@ -459,4 +460,4 @@ audit-secureblue AUDIT_FLATPAKS="true":
         done
         echo
     done
-    echo "${b}Run 'ujust audit-secureblue false' to skip flatpak recommendations.${n}"
+    echo "Run '{{BOLD}}ujust audit-secureblue false{{NORMAL}}' to skip flatpak recommendations."

--- a/files/justfiles/audit.just
+++ b/files/justfiles/audit.just
@@ -1,6 +1,7 @@
 # Audit secureblue
 audit-secureblue AUDIT_FLATPAKS="true":
     #!/bin/bash
+    set -euo pipefail
 
     STATUS_SUCCESS="SUCCESS"
     STATUS_WARNING="WARNING"
@@ -104,20 +105,18 @@ audit-secureblue AUDIT_FLATPAKS="true":
         value="$(sed -E "s/.* = (.*)/\1/" <<<"$line")"
         sysctl_hardening["$parameter"]+="$value"
     done
-    sysctl_results="$(sysctl -a 2> >(grep -v "sysctl: permission denied on key "))"
     sysctl_errors=()
-    for sysctl_parameter in "${!hardening[@]}"; do
-        hardened_parameter_value="${hardening["$sysctl_parameter"]}"
-        parameter_name="$(sed -E -e "s/\./\\\./g" -e "s/\*/\.\*/" <<<"$sysctl_parameter")"
-        readarray -t sysctl_parameter_values < <(grep -E "^$key = " <<<"$sysctl_results")
-        for parameter_value in "${sysctl_parameter_values[@]}"; do
-            parameter_value="$(sed -E  -e "s/.* = (.*)/\1/" -e "s/\/ /g" <<<"$result" | tr -s " " )"
-            if [[ "$parameter_value" != "$hardened_parameter_value" && ("$hardened_parameter_value" != 0 && "$parameter_value" != disabled) ]]; then
-                sysctl_errors+=("$sysctl_parameter should be $hardened_parameter_value, found $parameter_value")
-            fi
-        done
+    failure_occurred=0
+    for sysctl_parameter in "${!sysctl_hardening[@]}"; do
+        hardened_parameter_value="${sysctl_hardening["$sysctl_parameter"]}"
+        parameter_value="$(sysctl -bn "$sysctl_parameter" 2>/dev/null)" || continue
+        parameter_value="$(tr -s '[:blank:]' ' ' <<< "$parameter_value")"
+        if [[ "$parameter_value" != "$hardened_parameter_value" && ("$hardened_parameter_value" != 0 && "$parameter_value" != disabled) ]]; then
+            sysctl_errors+=("$sysctl_parameter should be $hardened_parameter_value, found $parameter_value")
+            failure_occurred=1
+        fi
     done
-    if [[ "${#sysctl_errors}" == 0 ]] && cmp -s /usr/etc/sysctl.d/60-hardening.conf /etc/sysctl.d/60-hardening.conf; then
+    if [ "$failure_occurred" = 0 ] && cmp -s /usr/etc/sysctl.d/60-hardening.conf /etc/sysctl.d/60-hardening.conf; then
         print_status "$SYSCTL_TEST_STRING" "$STATUS_SUCCESS"
     else
         print_status "$SYSCTL_TEST_STRING" "$STATUS_FAILURE"
@@ -151,6 +150,7 @@ audit-secureblue AUDIT_FLATPAKS="true":
     PTRACE_TEST_STRING="Ensuring ptrace is forbidden"
     if [[ "$(cat /proc/sys/kernel/yama/ptrace_scope)" == 3 ]]; then
         print_status "$PTRACE_TEST_STRING" "$STATUS_SUCCESS"
+        ptrace_allowed=false
     else
         print_status "$PTRACE_TEST_STRING" "$STATUS_FAILURE"
         ptrace_allowed=true
@@ -202,8 +202,8 @@ audit-secureblue AUDIT_FLATPAKS="true":
 
     SECUREDNS_TEST_STRING="Ensuring system DNS resolution is secure"
     if systemctl is-active --quiet systemd-resolved; then
-        DNSSEC_STATUS="$(grep "DNSSEC" /etc/systemd/resolved.conf.d/10-securedns.conf)"
-        DOT_STATUS="$(grep "DNSOverTLS" /etc/systemd/resolved.conf.d/10-securedns.conf)"
+        DNSSEC_STATUS="$(grep "DNSSEC" /etc/systemd/resolved.conf.d/10-securedns.conf || echo '')"
+        DOT_STATUS="$(grep "DNSOverTLS" /etc/systemd/resolved.conf.d/10-securedns.conf || echo '')"
         if [[ "$DNSSEC_STATUS" == "DNSSEC=true" && "$DOT_STATUS" == "DNSOverTLS=true" ]]; then
             print_status "$SECUREDNS_TEST_STRING" "$STATUS_SUCCESS"
         else

--- a/files/justfiles/dns.just
+++ b/files/justfiles/dns.just
@@ -31,7 +31,7 @@ dns-selector:
     echo "    4) DNSForge - powerful filtering but can be very slow"
     echo "    5) Custom Resolver - use a custom resolver (must support DoT/DoQ, ideally also supports DNSSEC, DoH support is also required to set a browser policy should that be desired)"
     while [[ "$valid_input" == "0" ]]; do
-        read -p "Selection [0-5]: " resolver_selection
+        read -rp "Selection [0-5]: " resolver_selection
         if [[ "$resolver_selection" == [012345]* ]]; then
             valid_input="1"
         else
@@ -65,7 +65,7 @@ dns-selector:
             echo "    3) Social: Standard + social media filtering"
             echo "    4) Family: Social + adult content filtering (also enables safe search in major search engines)"
             while [[ "$valid_input" == "0" ]]; do
-                read -p "Selection [0-4]: " resolver_subselection
+                read -rp "Selection [0-4]: " resolver_subselection
                 if [[ "$resolver_subselection" == [01234]* ]]; then
                     valid_input="1"
                 else
@@ -130,7 +130,7 @@ dns-selector:
             echo "    4) Family: Base + gambling and adult content filtering"
             echo "    5) All: Family + social media filtering"
             while [[ "$valid_input" == "0" ]]; do
-                read -p "Selection [0-5]: " resolver_subselection
+                read -rp "Selection [0-5]: " resolver_subselection
                 if [[ "$resolver_subselection" == [012345]* ]]; then
                     valid_input="1"
                 else
@@ -183,7 +183,7 @@ dns-selector:
             echo "    1) Security: Malware filtering"
             echo "    2) Family: Security + adult content filtering"
             while [[ "$valid_input" == "0" ]]; do
-                read -p "Selection [0-2]: " resolver_subselection
+                read -rp "Selection [0-2]: " resolver_subselection
                 if [[ "$resolver_subselection" == [012]* ]]; then
                     valid_input="1"
                 else
@@ -227,7 +227,7 @@ dns-selector:
             echo "    1) Clean: Standard + adult content filtering"
             echo "    2) Hard: Clean + stricter ad, tracker, and malware filtering"
             while [[ "$valid_input" == "0" ]]; do
-                read -p "Selection [0-2]: " resolver_subselection
+                read -rp "Selection [0-2]: " resolver_subselection
                 if [[ "$resolver_subselection" == [012]* ]]; then
                     valid_input="1"
                 else
@@ -266,29 +266,29 @@ dns-selector:
             echo "NOTE: If the resolver does not support DoT/DoQ or DNSSEC, this process will not work."
             echo ""
             echo "Please provide the technical information."
-            read -p "Please enter the resolver's IP address (e.g. '1.1.1.2'): " resolver_ipv4_address
-            read -p "Does the resolver provide two distinct IP addresses (e.g. '1.1.1.2' and '1.0.0.2')? [Y/n] " resolver_has_second_ip
+            read -rp "Please enter the resolver's IP address (e.g. '1.1.1.2'): " resolver_ipv4_address
+            read -rp "Does the resolver provide two distinct IP addresses (e.g. '1.1.1.2' and '1.0.0.2')? [Y/n] " resolver_has_second_ip
             resolver_has_second_ip=${resolver_has_second_ip:-y}
             if [[ "$resolver_has_second_ip" == [Yy]* ]]; then
-                read -p "Please enter the resolver's second IP address: " resolver_ipv4_address_2
+                read -rp "Please enter the resolver's second IP address: " resolver_ipv4_address_2
             fi
-            read -p "Does the resolver support IPv6 (e.g. '2606:4700:4700::1112')? [Y/n] " resolver_supports_ipv6
+            read -rp "Does the resolver support IPv6 (e.g. '2606:4700:4700::1112')? [Y/n] " resolver_supports_ipv6
             resolver_supports_ipv6=${resolver_supports_ipv6:-y}
             if [[ "$resolver_supports_ipv6" == [Yy]* ]]; then
-                read -p "Please enter the resolver's IPv6 address: " resolver_ipv6_address
+                read -rp "Please enter the resolver's IPv6 address: " resolver_ipv6_address
                 if [[ "$resolver_has_second_ip" == [Yy]* ]]; then
-                    read -p "Please enter the resolver's second IPv6 address: " resolver_ipv6_address_2
+                    read -rp "Please enter the resolver's second IPv6 address: " resolver_ipv6_address_2
                 fi
             fi
-            read -p "Please enter the second resolver's hostname (e.g. 'security.cloudflare-dns.com'): " resolver_hostname
-            read -p "Do you want to enable DNSSEC (this can cause networking issues notably in virtual machines, it is recommended if you do not suffer issues)? [Y/n] " resolver_dnssec
+            read -rp "Please enter the second resolver's hostname (e.g. 'security.cloudflare-dns.com'): " resolver_hostname
+            read -rp "Do you want to enable DNSSEC (this can cause networking issues notably in virtual machines, it is recommended if you do not suffer issues)? [Y/n] " resolver_dnssec
             resolver_dnssec=${resolver_dnssec:-y}
             ;;
     esac
 
-    read -p "Would you like the resolver to be set in the default browser (Trivalent) via management policy? [y/N] " set_browser_policy
+    read -rp "Would you like the resolver to be set in the default browser (Trivalent) via management policy? [y/N] " set_browser_policy
     if [[ "$set_browser_policy" == [Yy]* && "$resolver_selection" == 5 ]]; then
-        read -p "Please enter the second resolver's HTTPS address (e.g. 'https://security.cloudflare-dns.com/dns-query'): " resolver_https_address
+        read -rp "Please enter the second resolver's HTTPS address (e.g. 'https://security.cloudflare-dns.com/dns-query'): " resolver_https_address
     fi
 
     resolved_conf_dns_string=""

--- a/files/justfiles/hardening.just
+++ b/files/justfiles/hardening.just
@@ -3,15 +3,15 @@ harden-flatpak FLATPAK="":
     #!/usr/bin/bash
     var1={{ FLATPAK }}
     flatpak_id="${var1:-}"
-    flatpak override --user --filesystem=host-os:ro $flatpak_id
+    flatpak override --user --filesystem=host-os:ro "$flatpak_id"
     uarches="$(/usr/lib64/ld-linux-x86-64.so.2 --help | grep '(supported, searched)' | cut -d'v' -f2 || echo '')"
     bestuarch="${uarches:0:1}"
     if [ -z "$bestuarch" ] ; then
         echo "No microarchitecture support detected. Using default x86-64-v1 architecture${flatpak_id:+" for $flatpak_id's malloc"}."
-        flatpak override --user --env=LD_PRELOAD=/var/run/host/usr/lib64/libhardened_malloc.so $flatpak_id
+        flatpak override --user --env=LD_PRELOAD=/var/run/host/usr/lib64/libhardened_malloc.so "$flatpak_id"
     else
         echo "x86-64-v$bestuarch support detected. Using x86-64-v$bestuarch microarchitecture${flatpak_id:+" for $flatpak_id's malloc"}."
-        flatpak override --user --env=LD_PRELOAD=/var/run/host/usr/lib64/glibc-hwcaps/x86-64-v"$bestuarch"/libhardened_malloc.so $flatpak_id
+        flatpak override --user --env=LD_PRELOAD=/var/run/host/usr/lib64/glibc-hwcaps/x86-64-v"$bestuarch"/libhardened_malloc.so "$flatpak_id"
     fi
 
 # Harden Flatpaks further by disabling all permissions by default and rejecting known arbitrary DBus names, applies only to the current user
@@ -34,57 +34,57 @@ flatpak-permissions-lockdown:
     echo "NOTE: This will break just about all Flatpaks by default, it is ON YOU to configure them to work with this configuration."
     echo "NOTE 2: This DOES NOT enable hardened_malloc, use the harden-flatpak ujust command."
     echo ""
-    read -p "Would you like to proceed? [y/N] " confirmation
+    read -rp "Would you like to proceed? [y/N] " confirmation
     if [[ "$confirmation" == [Yy]* ]]; then
         echo "-- Share Permissions --"
-        for i in ${kSharePermissions[@]}; do
+        for i in "${kSharePermissions[@]}"; do
             echo "	Rejecting $i..."
-            $kCommand --unshare=$i
+            $kCommand --unshare="$i"
         done
         echo ""
         echo "-- Socket Permissions --"
-        for i in ${kSocketPermissions[@]}; do
+        for i in "${kSocketPermissions[@]}"; do
             echo "	Rejecting $i..."
-            $kCommand --nosocket=$i
+            $kCommand --nosocket="$i"
         done
         echo ""
         echo "-- Device Permissions --"
-        for i in ${kDevicePermissions[@]}; do
+        for i in "${kDevicePermissions[@]}"; do
             echo "	Rejecting $i..."
-            $kCommand --nodevice=$i
+            $kCommand --nodevice="$i"
         done
         echo ""
         echo "-- Feature Permissions --"
-        for i in ${kFeaturePermissions[@]}; do
+        for i in "${kFeaturePermissions[@]}"; do
             echo "	Rejecting $i..."
-            $kCommand --disallow=$i
+            $kCommand --disallow="$i"
         done
         echo ""
         echo "-- Filesystem Permissions --"
-        for i in ${kFilesystemPermissions[@]}; do
+        for i in "${kFilesystemPermissions[@]}"; do
             echo "	Rejecting $i..."
-            $kCommand --nofilesystem=$i
+            $kCommand --nofilesystem="$i"
         done
         echo ""
         echo "-- Dangerous Filesystem Permissions --"
         echo "Note: This is a VERY flawed implementation but it does cover a few blatant sandbox escape methods (such as the .bashrc escape or mounted drive access)"
         echo "It is not possible to cover all files since each file can be requested manually and therefore must be rejected manually"
-        for i in ${kDangerousFilesystemPermissions[@]}; do
+        for i in "${kDangerousFilesystemPermissions[@]}"; do
             echo "	Rejecting $i..."
-            $kCommand --nofilesystem=$i
+            $kCommand --nofilesystem="$i"
         done
         echo ""
         echo "NOTE: The next 2 lockdowns are NOT complete and only cover a list of known names, this can be expanded at any time"
         echo "-- Session Bus Name Access --"
-        for i in ${kKnownSessionBusNames[@]}; do
+        for i in "${kKnownSessionBusNames[@]}"; do
             echo "	Rejecting $i..."
-            $kCommand --no-talk-name=$i
+            $kCommand --no-talk-name="$i"
         done
         echo ""
         echo "-- System Bus Name Access --"
-        for i in ${kKnownSystemBusNames[@]}; do
+        for i in "${kKnownSystemBusNames[@]}"; do
             echo "	Rejecting $i..."
-            $kCommand --system-no-talk-name=$i
+            $kCommand --system-no-talk-name="$i"
         done
         echo ""
         echo "-- Persistent Filesystem Grant --"
@@ -98,9 +98,9 @@ flatpak-permissions-lockdown:
         $kCommand --socket=wayland --device=dri
         echo ""
         echo "-- Granting Flatseal Access to Bus Names --"
-        for i in ${kFlatsealNameAccess[@]}; do
+        for i in "${kFlatsealNameAccess[@]}"; do
             echo "	Granting $i..."
-            $kCommand --talk-name=$i com.github.tchx84.Flatseal
+            $kCommand --talk-name="$i" com.github.tchx84.Flatseal
         done
         echo ""
         echo "Done"
@@ -112,24 +112,25 @@ flatpak-reset-global-overrides:
     GLOBAL_OVERRIDES="$HOME/.local/share/flatpak/overrides/global"
     echo "This will undo the flatpak-harden command, the flatpak-permissions-lockdown command, as well as any other global overrides (individual app overrides will not be affected)."
     echo "It will not delete the file, but simply move it from $GLOBAL_OVERRIDES to $GLOBAL_OVERRIDES.save"
-    mv $GLOBAL_OVERRIDES $GLOBAL_OVERRIDES.save
+    mv "$GLOBAL_OVERRIDES" "$GLOBAL_OVERRIDES.save"
 
 # Setup USBGuard
 setup-usbguard:
     #!/usr/bin/bash
     echo "Notice: This will generate a policy based on your existing connected USB devices."
+    # shellcheck disable=SC2016
     run0 sh -c '
         mkdir -p /var/log/usbguard
         mkdir -p /etc/usbguard
-        chmod 755 /etc/usbguard        
+        chmod 755 /etc/usbguard
         groupadd usbguard
-        usermod -aG usbguard $1
+        usermod -aG usbguard "$SUDO_USER"
         usbguard generate-policy > /etc/usbguard/rules.conf
-        sed -i "/IPCAllowedGroups=wheel/s/$/ usbguard/" /etc/usbguard/usbguard-daemon.conf
+        sed -i "/IPCAllowedGroups=wheel/s/\$/ usbguard/" /etc/usbguard/usbguard-daemon.conf
         restorecon -vR /var/log/usbguard
         systemctl enable --now usbguard.service
-        usbguard add-user $1
-    ' -- $USER
-    if ! [ -n "$(rpm-ostree status | grep '●' | grep 'securecore')" ] ; then
+        usbguard add-user "$SUDO_USER"
+    '
+    if ! rpm-ostree status | grep '●' | grep -q 'securecore'; then
         systemctl enable --user --now usbguard-notifier.service
     fi

--- a/files/justfiles/kargs.just
+++ b/files/justfiles/kargs.just
@@ -1,21 +1,21 @@
 # Add additional boot parameters for hardening (requires reboot)
 set-kargs-hardening:
     #!/usr/bin/bash
-    read -p "Do you need support for 32-bit processes/syscalls? (This is mostly used by legacy software, with some exceptions, such as Steam) [y/N]: " YES
+    read -rp "Do you need support for 32-bit processes/syscalls? (This is mostly used by legacy software, with some exceptions, such as Steam) [y/N]: " YES
     if [[ "$YES" == [Yy]* ]]; then
         echo "Keeping 32-bit support."
     else
         IAEMU_NO="--append-if-missing=ia32_emulation=0"
         echo "Disabling 32-bit support, for the next boot."
     fi
-    read -p "Do you want to force disable Simultaneous Multithreading (SMT) / Hyperthreading? (This can cause a reduction in the performance of certain tasks in favor of security) (Note that in most hardware SMT will be disabled anyways to mitigate a known vulnerability, this turns it off on all hardware regardless) [y/N]: " YES
+    read -rp "Do you want to force disable Simultaneous Multithreading (SMT) / Hyperthreading? (This can cause a reduction in the performance of certain tasks in favor of security) (Note that in most hardware SMT will be disabled anyways to mitigate a known vulnerability, this turns it off on all hardware regardless) [y/N]: " YES
     if [[ "$YES" == [Yy]* ]]; then
         NOSMT_YES="--append-if-missing=nosmt=force"
         echo "Force disabling SMT/Hyperthreading."
     else
         echo "Not force disabling SMT/Hyperthreading."
     fi
-    read -p "Would you like to set additional (unstable) hardening kargs? (Warning: Setting these kargs may lead to boot or stability issues on some hardware.) [y/N]: " YES
+    read -rp "Would you like to set additional (unstable) hardening kargs? (Warning: Setting these kargs may lead to boot or stability issues on some hardware.) [y/N]: " YES
     if [[ "$YES" == [Yy]* ]]; then
     UNSTABLE_YES="--append-if-missing=efi=disable_early_pci_dma \
         --append-if-missing=gather_data_sampling=force \

--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -157,7 +157,7 @@ toggle-xwayland ACTION="prompt":
       elif echo "$IMAGE" | grep -qE 'sericea|sway'; then
           OPTION=sway
       else
-        printf "\033[1mToggling Xwayland (requires logout)\033[22m\n"
+        echo "${bold}Toggling Xwayland (requires logout)${unbold}"
         echo 'For which DE/WM do you want to toggle Xwayland?'
         OPTION=$(ugum choose "GNOME" "KDE Plasma" "Sway")
       fi
@@ -205,10 +205,11 @@ toggle-xwayland ACTION="prompt":
 toggle-bash-environment-lockdown:
     #!/usr/bin/bash
     BASH_ENV_FILES=("$HOME/.bashrc" "$HOME/.bash_profile")
-    printf "\033[1mWARNING:\033[22m This will overwrite your .bashrc and .bash_profile.\n"
-    echo "This is needed to ensure the mitigation is effective."
-    echo "Do you understand?"
-    echo "Please type in \"YES I UNDERSTAND\" and press enter"
+    source /usr/lib/ujust/libformatting.sh
+    echo "${bold}WARNING:${unbold} This will overwrite your .bashrc and .bash_profile."
+    echo 'This is needed to ensure the mitigation is effective.'
+    echo 'Do you understand?'
+    echo 'Please type in "YES I UNDERSTAND" and press enter'
     read -r ACCEPT
     if [ "$ACCEPT" = "YES I UNDERSTAND" ]; then
       if lsattr "${BASH_ENV_FILES[0]}" 2>/dev/null | awk '{print $1}' | grep -q 'i'; then

--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -147,7 +147,7 @@ toggle-gnome-extensions:
 toggle-xwayland ACTION="prompt":
     #! /bin/run0 /bin/bash
     source /usr/lib/ujust/ujust.sh
-    OPTION="{{ACTION}}"
+    OPTION="{{ ACTION }}"
     if [ "$OPTION" = "prompt" ]; then
       IMAGE="$(rpm-ostree status | grep '●')"
       if echo "$IMAGE" | grep -q 'silverblue'; then
@@ -157,7 +157,7 @@ toggle-xwayland ACTION="prompt":
       elif echo "$IMAGE" | grep -qE 'sericea|sway'; then
           OPTION=sway
       else
-        echo "{{BOLD}}Toggling Xwayland (requires logout){{NORMAL}}"
+        echo "{{ BOLD }}Toggling Xwayland (requires logout){{ NORMAL }}"
         echo 'For which DE/WM do you want to toggle Xwayland?'
         OPTION=$(ugum choose "GNOME" "KDE Plasma" "Sway")
       fi
@@ -205,7 +205,7 @@ toggle-xwayland ACTION="prompt":
 toggle-bash-environment-lockdown:
     #!/usr/bin/bash
     BASH_ENV_FILES=("$HOME/.bashrc" "$HOME/.bash_profile")
-    echo "{{BOLD}}WARNING{{NORMAL}} This will overwrite your .bashrc and .bash_profile."
+    echo "{{ BOLD }}WARNING{{ NORMAL }} This will overwrite your .bashrc and .bash_profile."
     echo "This is needed to ensure the mitigation is effective."
     echo "Do you understand?"
     echo "Please type in \"YES I UNDERSTAND\" and press enter"

--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -204,11 +204,14 @@ toggle-xwayland ACTION="prompt":
 # Toggle bash environment lockdown (mitigates LD_PRELOAD attacks)
 toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prompt":
     #!/bin/run0 /bin/bash
-    set -eou pipefail
+    set -euo pipefail
+    source /usr/lib/ujust/libformatting.sh
 
-    # The below function fetch the minimium and maximium UIDS as configured in /etc/login.defs. Any UIDs within this change are true user ids
-    # rather than system agents, and therefore should be locked down. The user_string variable uses this fetched UID range to find all existing
-    # users and their home directory along with formatting this data for later use. The IFS line simply converts this data into a bash array.
+    # The below function fetches the minimium and maximium UIDS as configured in /etc/login.defs.
+    # Any UIDs within this change are true user ids rather than system agents, and therefore
+    # should be locked down. The user_string variable uses this fetched UID range to find all
+    # existing users and their home directory along with formatting this data for later use.
+    # The IFS line simply converts this data into a bash array.
     function user_list_lookup() {
         uid_min="$(grep -Po '^\s*UID_MIN\s+\K\d+' /etc/login.defs)"
         uid_max="$(grep -Po '^\s*UID_MAX\s+\K\d+' /etc/login.defs)"
@@ -216,8 +219,9 @@ toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prom
         IFS=',' read -ra user_list <<< "$user_string"
     }
 
-    # $SUDO_USER is the user who started the script instead of whichever authorized it via polkit or the root home. From there this 
-    # $USER_HOME uses getent to lookup their home directory to later check if they have an existing .bashrc file.
+    # $SUDO_USER is the user who started the script instead of whichever authorized it via polkit
+    # or the root home. From there this $USER_HOME uses getent to lookup their home directory to
+    # later check if they have an existing .bashrc file.
     user_home="$(getent passwd "$SUDO_USER" | cut -d: -f6)"
     if lsattr "$user_home/.bashrc" 2>/dev/null | awk '{print $1}' | grep -q 'i'; then
         pending_status="unlocked"
@@ -225,40 +229,43 @@ toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prom
         pending_status="locked"
     fi
 
-    # Below variable is created to only call date once and use the same time across the script despite execution time.
+    # Below variable is created to only call date once and use the same time across the script
+    # despite execution time.
     current_time="$(date | tr ' ' '_')"
 
-    if [ "$pending_status" == "locked" ]; then
-        echo "${b}WARNING${n} This will change your ~/.bashrc, ~/.bash_profile, ~/.config/bash-completion, ~/.profile, ~/.bash_logout, ~/.bash_login, ~/.bashrc.d/, and ~/.config/environment.d/"
+    if [[ "$pending_status" == "locked" ]]; then
+        echo "${bold}WARNING${unbold} This will change your ~/.bashrc, ~/.bash_profile, ~/.config/bash-completion, ~/.profile, ~/.bash_logout, ~/.bash_login, ~/.bashrc.d/, and ~/.config/environment.d/"
         echo "This is needed to ensure the mitigation (see LD_PRELOAD attacks) is effective."
         echo "This script will create backups of the old versions in ~/bash_env_files/$current_time."
     else
-        echo "${b}WARNING${n} .bashrc, .bash_profile, and more will be unlocked and made editable by non-root users. This represents a security risk (see LD_PRELOAD attacks)"
+        echo "${bold}WARNING${unbold} .bashrc, .bash_profile, and more will be unlocked and made editable by non-root users. This represents a security risk (see LD_PRELOAD attacks)"
     fi
 
-    if [ "{{ skip_approval }}" == "false" ]; then
+    # shellcheck disable=SC2050
+    if [[ "{{ skip_approval }}" == "false" ]]; then
         echo "Do you understand?"
         echo 'Please type in "YES I UNDERSTAND" and press enter'
         read -r accept
-        if [ "$accept" != "YES I UNDERSTAND" ]; then
+        if [[ "$accept" != "YES I UNDERSTAND" ]]; then
             exit
         fi
-    elif [ "{{ skip_approval }}" != "true" ]; then
+    elif [[ "{{ skip_approval }}" != "true" ]]; then
         echo 'Invalid skip_approval arguement, only "true", "false", or empty allowed.'
         exit
     fi
 
-    if [ "{{ apply_for_all_users }}" == "prompt" ]; then
+    # shellcheck disable=SC2050
+    if [[ "{{ apply_for_all_users }}" == "prompt" ]]; then
         user_list_lookup
-        echo "Do you want this change to apply to ""${b}""all""${n}"" users (""${user_list[@]}"")? [y/N]"
+        echo "Do you want this change to apply to ${bold}all${unbold} users (${user_list[*]})? [y/N]"
         echo "Otherwise, it will only apply to the user who launched this script ($SUDO_USER)."
         read -r reply
         if [[ "$reply" != [yY]* ]]; then
             user_list=("$SUDO_USER")
         fi
-    elif [ "{{ apply_for_all_users }}" == "false" ]; then
+    elif [[ "{{ apply_for_all_users }}" == "false" ]]; then
         user_list=("$SUDO_USER")
-    elif [ "{{ apply_for_all_users }}" == "true" ]; then
+    elif [[ "{{ apply_for_all_users }}" == "true" ]]; then
         user_list_lookup
     else
         echo 'Invalid apply_for_all_users arguement, only "true", "false", or empty allowed.'
@@ -281,20 +288,21 @@ toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prom
             "$user_home/.config/environment.d/"
         )
 
-        # Purpose of the below block is to actually lock or unlock the current selected user across the configured BASH_ENV_FILES 
-        #    If the script is locking: 
-        #        to copy the old env files and directories to folder with the time appended to its name 
+        # Purpose of the below block is to actually lock or unlock the current selected user
+        # across the configured BASH_ENV_FILES
+        #    If the script is locking:
+        #        to copy the old env files and directories to folder with the time appended to its name
         #        remove immutability (to allow the script to overwrite any existing immutable environment files)
         #        create default or blank copies (deleting the old versions)
         #        add immutability
 
-        if [ "$pending_status" == "locked" ]; then
+        if [[ "$pending_status" == "locked" ]]; then
             backup_dest="$user_home/bash_env_files/$current_time/"
             mkdir -p "$backup_dest"
 
             for file in "${BASH_ENV_FILES[@]}"; do
-                # skel_file converts "$user_home/.bashrc" to ".bashrc" 
-                skel_file="$(echo "$file" | sed 's|'"${user_home}"'/||')"
+                # skel_file converts "$user_home/.bashrc" to ".bashrc"
+                skel_file="${file#"${user_home}/"}"
                 if [ ! -f "$file" ] && [ ! -d "$file" ] && [ -e "$file" ]; then
                     echo "Special file detected on absolute filepath ($file) from BASH_ENV_FILES. It will not be modified."
                 elif [ -f "$file" ]; then
@@ -302,7 +310,7 @@ toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prom
                     rsync -a --mkpath "$file" "$backup_dest$skel_file"
                     rm "$file"
                 elif [ -d "$file" ]; then
-                    chattr -R -i "$file" 
+                    chattr -R -i "$file"
                     rsync -a --mkpath "$file" "$backup_dest$skel_file"
                     rm -r "$file"
                 fi
@@ -329,20 +337,20 @@ toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prom
                 elif [ -f "$file" ]; then
                     chattr -i "$file"
                 elif [ -d "$file" ]; then
-                    chattr -R -i "$file" 
+                    chattr -R -i "$file"
                 fi
             done
         fi
     done
 
     echo "${user_list[@]}" "$pending_status."
-    echo "${b}WARNING${n}: until a reboot, any process with an open file descriptor will continue to have the access they had before this script was run."
+    echo "${bold}WARNING${unbold}: until a reboot, any process with an open file descriptor will continue to have the access they had before this script was run."
     echo ""
     echo "Optional Arguments:"
     echo "ujust toggle-bash-environment-lockdown skip_approval apply_for_all_users"
     echo "    skip_approval: [true/false]          'true' the user is not prompted to respond 'YES I UNDERSTAND'; 'false' user is prompted."
     echo ""
-    echo "    apply_for_all_users: [true/false]    'true' change is applied to all users (without prompting); 'false' change is only applied" 
+    echo "    apply_for_all_users: [true/false]    'true' change is applied to all users (without prompting); 'false' change is only applied"
     echo "                                          to user currently logged in (without prompting)."
     echo ""
     echo "Invalid optional arguments are treated as errors."

--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -157,7 +157,7 @@ toggle-xwayland ACTION="prompt":
       elif echo "$IMAGE" | grep -qE 'sericea|sway'; then
           OPTION=sway
       else
-        echo "{{ BOLD }}Toggling Xwayland (requires logout){{ NORMAL }}"
+        printf "\033[1mToggling Xwayland (requires logout)\033[22m\n"
         echo 'For which DE/WM do you want to toggle Xwayland?'
         OPTION=$(ugum choose "GNOME" "KDE Plasma" "Sway")
       fi
@@ -205,7 +205,7 @@ toggle-xwayland ACTION="prompt":
 toggle-bash-environment-lockdown:
     #!/usr/bin/bash
     BASH_ENV_FILES=("$HOME/.bashrc" "$HOME/.bash_profile")
-    echo "{{ BOLD }}WARNING{{ NORMAL }} This will overwrite your .bashrc and .bash_profile."
+    printf "\033[1mWARNING:\033[22m This will overwrite your .bashrc and .bash_profile.\n"
     echo "This is needed to ensure the mitigation is effective."
     echo "Do you understand?"
     echo "Please type in \"YES I UNDERSTAND\" and press enter"

--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -62,11 +62,11 @@ override-enable-module mod_name:
     #! /bin/run0 /bin/bash
     MOD_NAME="{{ mod_name }}"
     MOD_FILE="/etc/modprobe.d/99-$MOD_NAME.conf"
-    if test -e $MOD_FILE; then
+    if [ -e "$MOD_FILE" ]; then
       echo "$MOD_NAME module is already enabled."
     else
       sh -c 'echo "install $1 /sbin/modprobe --ignore-install $1" >> "$2"' _ "$MOD_NAME" "$MOD_FILE"
-      chmod 644 $MOD_FILE
+      chmod 644 "$MOD_FILE"
       echo "Override created to enable $MOD_NAME module. Reboot to take effect."
     fi
 
@@ -75,8 +75,8 @@ override-reset-module mod_name:
     #! /bin/run0 /bin/bash
     MOD_NAME="{{ mod_name }}"
     MOD_FILE="/etc/modprobe.d/99-$MOD_NAME.conf"
-    if test -e $MOD_FILE; then
-      rm -f $MOD_FILE
+    if [ -e "$MOD_FILE" ]; then
+      rm -f "$MOD_FILE"
       echo "The override for $MOD_NAME module has been reset. Reboot to take effect."
     else
       echo "No override found for $MOD_NAME module."
@@ -147,21 +147,21 @@ toggle-gnome-extensions:
 toggle-xwayland ACTION="prompt":
     #! /bin/run0 /bin/bash
     source /usr/lib/ujust/ujust.sh
-    OPTION={{ ACTION }}
-    if [ "$OPTION" == "prompt" ]; then
+    OPTION="{{ACTION}}"
+    if [ "$OPTION" = "prompt" ]; then
       IMAGE="$(rpm-ostree status | grep '●')"
-      if [ -n "$(echo $IMAGE | grep 'silverblue')" ] ; then
+      if echo "$IMAGE" | grep -q 'silverblue'; then
           OPTION=gnome
-      elif [ -n "$(echo $IMAGE | grep 'kinoite')" ] ; then
+      elif echo "$IMAGE" | grep -q 'kinoite'; then
           OPTION=plasma
-      elif [ -n "$(echo $IMAGE | grep 'sericea')" ] || [ -n "$(echo $IMAGE | grep 'sway')" ] ; then
+      elif echo "$IMAGE" | grep -qE 'sericea|sway'; then
           OPTION=sway
       else
-        echo "${bold}Toggling Xwayland (requires logout)${normal}"
+        echo "{{BOLD}}Toggling Xwayland (requires logout){{NORMAL}}"
         echo 'For which DE/WM do you want to toggle Xwayland?'
         OPTION=$(ugum choose "GNOME" "KDE Plasma" "Sway")
       fi
-    elif [ "$OPTION" == "help" ]; then
+    elif [ "$OPTION" = "help" ]; then
       echo "Usage: ujust toggle-xwayland <option>"
       echo "  <option>: Specify the quick option - 'gnome', 'plasma', or 'sway'"
       echo "  Use 'gnome' to Toggle Xwayland for GNOME."
@@ -169,34 +169,34 @@ toggle-xwayland ACTION="prompt":
       echo "  Use 'sway' to Toggle Xwayland for Sway."
       exit 0
     fi
-    if [ "${OPTION,,}" == "gnome" ]; then
-      GNOME_XWAYLAND_FILE="/etc/systemd/user/org.gnome.Shell@wayland.service.d/override.conf"
-      if test -e $GNOME_XWAYLAND_FILE; then
-        rm -f $GNOME_XWAYLAND_FILE
-        echo "Xwayland for GNOME has been enabled."
+    if [ "${OPTION,,}" = "gnome" ]; then
+      GNOME_XWAYLAND_FILE='/etc/systemd/user/org.gnome.Shell@wayland.service.d/override.conf'
+      if [ -e "$GNOME_XWAYLAND_FILE" ]; then
+        rm -f "$GNOME_XWAYLAND_FILE"
+        echo 'Xwayland for GNOME has been enabled.'
       else
-        cp /usr$GNOME_XWAYLAND_FILE $GNOME_XWAYLAND_FILE
-        chmod 644 $GNOME_XWAYLAND_FILE
-        echo "Xwayland for GNOME has been disabled."
+        cp "/usr$GNOME_XWAYLAND_FILE" "$GNOME_XWAYLAND_FILE"
+        chmod 644 "$GNOME_XWAYLAND_FILE"
+        echo 'Xwayland for GNOME has been disabled.'
       fi
-    elif [ "$OPTION" == "KDE Plasma" ] || [ "${OPTION,,}" == "plasma" ]; then
-      PLASMA_XWAYLAND_FILE="/etc/systemd/user/plasma-kwin_wayland.service.d/override.conf"
-      if test -e $PLASMA_XWAYLAND_FILE; then
-        rm -f $PLASMA_XWAYLAND_FILE
-        echo "Xwayland for KDE Plasma has been enabled."
+    elif [ "$OPTION" = "KDE Plasma" ] || [ "${OPTION,,}" = "plasma" ]; then
+      PLASMA_XWAYLAND_FILE='/etc/systemd/user/plasma-kwin_wayland.service.d/override.conf'
+      if [ -e "$PLASMA_XWAYLAND_FILE" ]; then
+        rm -f "$PLASMA_XWAYLAND_FILE"
+        echo 'Xwayland for KDE Plasma has been enabled.'
       else
-        cp /usr$PLASMA_XWAYLAND_FILE $PLASMA_XWAYLAND_FILE
-        chmod 644 $PLASMA_XWAYLAND_FILE
-        echo "Xwayland for KDE Plasma has been disabled."
+        cp "/usr$PLASMA_XWAYLAND_FILE" "$PLASMA_XWAYLAND_FILE"
+        chmod 644 "$PLASMA_XWAYLAND_FILE"
+        echo 'Xwayland for KDE Plasma has been disabled.'
       fi
-    elif [ "${OPTION,,}" == "sway" ]; then
-      SWAY_XWAYLAND_FILE="/etc/sway/config.d/99-noxwayland.conf"
-      if test -e $SWAY_XWAYLAND_FILE; then
-        rm -f $SWAY_XWAYLAND_FILE
-        echo "Xwayland for Sway has been enabled."
+    elif [ "${OPTION,,}" = "sway" ]; then
+      SWAY_XWAYLAND_FILE='/etc/sway/config.d/99-noxwayland.conf'
+      if [ -e "$SWAY_XWAYLAND_FILE" ]; then
+        rm -f "$SWAY_XWAYLAND_FILE"
+        echo 'Xwayland for Sway has been enabled.'
       else
-        cp /usr$SWAY_XWAYLAND_FILE $SWAY_XWAYLAND_FILE
-        chmod 644 $SWAY_XWAYLAND_FILE
+        cp "/usr$SWAY_XWAYLAND_FILE" "$SWAY_XWAYLAND_FILE"
+        chmod 644 "$SWAY_XWAYLAND_FILE"
         echo "Xwayland for Sway has been disabled."
       fi
     fi
@@ -205,20 +205,20 @@ toggle-xwayland ACTION="prompt":
 toggle-bash-environment-lockdown:
     #!/usr/bin/bash
     BASH_ENV_FILES=("$HOME/.bashrc" "$HOME/.bash_profile")
-    echo "${b}WARNING${n} This will overwrite your .bashrc and .bash_profile."
+    echo "{{BOLD}}WARNING{{NORMAL}} This will overwrite your .bashrc and .bash_profile."
     echo "This is needed to ensure the mitigation is effective."
     echo "Do you understand?"
     echo "Please type in \"YES I UNDERSTAND\" and press enter"
-    read ACCEPT
-    if [ "$ACCEPT" == "YES I UNDERSTAND" ]; then
+    read -r ACCEPT
+    if [ "$ACCEPT" = "YES I UNDERSTAND" ]; then
       if lsattr "${BASH_ENV_FILES[0]}" 2>/dev/null | awk '{print $1}' | grep -q 'i'; then
-        echo "Bash environment '(${BASH_ENV_FILES[@]})' is locked down. Unlocking it."
+        echo "Bash environment '(${BASH_ENV_FILES[*]})' is locked down. Unlocking it."
         for file in "${BASH_ENV_FILES[@]}"; do
             run0 chattr -i "$file"
         done
       else
-        echo "Bash environment '(${BASH_ENV_FILES[@]})' is unlocked. Locking it."
-        echo "
+        echo "Bash environment '(${BASH_ENV_FILES[*]})' is unlocked. Locking it."
+        cat << 'EOF' > ~/.bashrc
     # .bashrc
 
     # Source global definitions
@@ -227,8 +227,8 @@ toggle-bash-environment-lockdown:
     fi
 
     # User specific environment
-    if ! [[ "\$PATH" =~ "\$HOME/.local/bin:\$HOME/bin:" ]]; then
-        PATH="\$HOME/.local/bin:\$HOME/bin:\$PATH"
+    if ! [[ "$PATH" =~ "$HOME/.local/bin:$HOME/bin:" ]]; then
+        PATH="$HOME/.local/bin:$HOME/bin:$PATH"
     fi
     export PATH
 
@@ -236,9 +236,9 @@ toggle-bash-environment-lockdown:
     # export SYSTEMD_PAGER=
 
     unset rc
-          " > ~/.bashrc
+    EOF
 
-        echo "
+        cat << 'EOF' > ~/.bash_profile
     # .bash_profile
 
     # Get the aliases and functions
@@ -247,7 +247,7 @@ toggle-bash-environment-lockdown:
     fi
 
     # User specific environment and startup programs
-        " > ~/.bash_profile
+    EOF
 
         for file in "${BASH_ENV_FILES[@]}"; do
             run0 chattr +i "$file"
@@ -287,7 +287,7 @@ toggle-container-domain-userns-creation:
         echo "Module $MODULE_NAME is not currently enabled. Enabling the hardening, disabling container domain userns (e.g. for distrobox)."
 
         echo 'Warning: This will stop ALL containers and shut down podman.'
-        read -p 'Are you sure you want to do this? (y/N) ' proceed
+        read -rp 'Are you sure you want to do this? (y/N) ' proceed
         if ! [[ "$proceed" == [Yy]* ]]; then
             echo "Aborting..."
             exit 0
@@ -319,7 +319,7 @@ toggle-mac-randomization:
         echo "MAC randomization can be stable (persisting the same random MAC per access point across disconnects/reboots),"
         echo "or it can be randomized per-connection (every time it connects to the same access point it uses a new MAC)."
         randomization_choice=""
-        read -p "Do you want to use per-connection Wi-Fi MAC address randomization? [y/N] " randomization_choice
+        read -rp "Do you want to use per-connection Wi-Fi MAC address randomization? [y/N] " randomization_choice
 
         if [[ "$randomization_choice" == [Yy]* ]]; then
             randomization_level=random

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -148,7 +148,7 @@ distrobox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/distrobox/distr
     fi
     # Distroboxes are gathered from distrobox.ini, please add them there
     source /usr/lib/ujust/ujust.sh
-    AssembleList "{{FILE}}" "{{ACTION}}" "{{CONTAINER}}"
+    AssembleList "{{ FILE }}" "{{ ACTION }}" "{{ CONTAINER }}"
 
 # Create toolbox containers from a defined manifest (this spec will not be expanded)
 toolbox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/toolbox/toolbox.ini":
@@ -166,12 +166,12 @@ toolbox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/toolbox/toolbox.i
     fi
     # Toolboxes are gathered from toolbox.ini, please add them there
     source /usr/lib/ujust/ujust.sh
-    ToolboxAssembleList "{{FILE}}" "{{ACTION}}" "{{CONTAINER}}"
+    ToolboxAssembleList "{{ FILE }}" "{{ ACTION }}" "{{ CONTAINER }}"
 
 # Run a non-flatpak application with standard memory allocator (needs an argument!)
 with-standard-malloc APP:
     #!/usr/bin/bash
-    bwrap --dev-bind / / --ro-bind /dev/null /etc/ld.so.preload "{{APP}}"
+    bwrap --dev-bind / / --ro-bind /dev/null /etc/ld.so.preload "{{ APP }}"
 
 # Add the unfiltered Flathub flatpak repo
 enable-flathub-unfiltered:

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -48,7 +48,8 @@ enroll-secure-boot-key:
     run0 mokutil --timeout -1
     echo 'The next line will prompt for a MOK password. Then, input "universalblue"'
     run0 mokutil --import /etc/pki/akmods/certs/akmods-ublue.der
-    echo -e "At next reboot, the mokutil UEFI menu UI will be displayed (*QWERTY* keyboard input and navigation).\nThen, select "Enroll MOK", and input "universalblue" as the password"
+    echo 'At next reboot, the mokutil UEFI menu UI will be displayed (*QWERTY* keyboard input and navigation).'
+    echo 'Then, select "Enroll MOK", and input "universalblue" as the password.'
 
 # Toggle display of the user-motd in terminal
 toggle-user-motd:
@@ -138,7 +139,7 @@ distrobox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/distrobox/distr
         echo "Distrobox requires container domain user namespaces to work, which are disabled by default for security reasons."
         echo "You need to run 'ujust toggle-container-domain-userns-creation' to allow this."
         container_userns_now=""
-        read -p "Would you like to run 'ujust toggle-container-domain-userns-creation' now? [Y/n] " container_userns_now
+        read -rp "Would you like to run 'ujust toggle-container-domain-userns-creation' now? [Y/n] " container_userns_now
         container_userns_now=${container_userns_now:-y}
         if [[ "$container_userns_now" == [Yy]* ]]; then
             echo "Running 'ujust toggle-container-domain-userns-creation'"
@@ -147,7 +148,7 @@ distrobox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/distrobox/distr
     fi
     # Distroboxes are gathered from distrobox.ini, please add them there
     source /usr/lib/ujust/ujust.sh
-    AssembleList {{ FILE }} {{ ACTION }} {{ CONTAINER }}
+    AssembleList "{{FILE}}" "{{ACTION}}" "{{CONTAINER}}"
 
 # Create toolbox containers from a defined manifest (this spec will not be expanded)
 toolbox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/toolbox/toolbox.ini":
@@ -156,7 +157,7 @@ toolbox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/toolbox/toolbox.i
         echo "Toolbox requires container domain user namespaces to work, which are disabled by default for security reasons."
         echo "You need to run 'ujust toggle-container-domain-userns-creation' to allow this."
         container_userns_now=""
-        read -p "Would you like to run 'ujust toggle-container-domain-userns-creation' now? [Y/n] " container_userns_now
+        read -rp "Would you like to run 'ujust toggle-container-domain-userns-creation' now? [Y/n] " container_userns_now
         container_userns_now=${container_userns_now:-y}
         if [[ "$container_userns_now" == [Yy]* ]]; then
             echo "Running 'ujust toggle-container-domain-userns-creation'"
@@ -165,12 +166,12 @@ toolbox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/toolbox/toolbox.i
     fi
     # Toolboxes are gathered from toolbox.ini, please add them there
     source /usr/lib/ujust/ujust.sh
-    ToolboxAssembleList {{ FILE }} {{ ACTION }} {{ CONTAINER }}
+    ToolboxAssembleList "{{FILE}}" "{{ACTION}}" "{{CONTAINER}}"
 
 # Run a non-flatpak application with standard memory allocator (needs an argument!)
 with-standard-malloc APP:
     #!/usr/bin/bash
-    bwrap --dev-bind / / --ro-bind /dev/null /etc/ld.so.preload {{ APP }}
+    bwrap --dev-bind / / --ro-bind /dev/null /etc/ld.so.preload "{{APP}}"
 
 # Add the unfiltered Flathub flatpak repo
 enable-flathub-unfiltered:
@@ -196,13 +197,13 @@ install-steam:
         echo "Steam requires X or Xwayland, which your variant of secureblue has disabled by default."
         echo "Please run 'ujust toggle-xwayland' to re-enable it."
         toggle_xwayland_now=""
-        read -p "Would you like to run 'ujust toggle-xwayland' now? [Y/n] " toggle_xwayland_now
+        read -rp "Would you like to run 'ujust toggle-xwayland' now? [Y/n] " toggle_xwayland_now
         toggle_xwayland_now=${toggle_xwayland_now:-y}
         if [[ "$toggle_xwayland_now" == [Yy]* ]]; then
             echo "Running 'ujust toggle-xwayland'"
             ujust toggle-xwayland
             reboot_now=""
-            read -p "Would you like to reboot now? [y/N] " reboot_now
+            read -rp "Would you like to reboot now? [y/N] " reboot_now
             if [[ "$reboot_now" == [Yy]* ]]; then
                 echo "Rebooting"
                 systemctl reboot
@@ -215,7 +216,7 @@ install-steam:
     echo "    1) Flatpak - will install the steam flatpak from flathub-unverified"
     echo "    2) Distrobox - will set up steam via the bazzite-arch distrobox image"
     while [[ "$valid_input" == "0" ]]; do
-        read -p "Selection [1-2]: " method_selection
+        read -rp "Selection [1-2]: " method_selection
         if [[ "$method_selection" == [12]* ]]; then
             valid_input="1"
         else
@@ -240,7 +241,7 @@ install-steam:
                 echo "Distrobox requires container domain user namespaces to work, which are disabled by default for security reasons."
                 echo "You need to run 'ujust toggle-container-domain-userns-creation' to allow this."
                 container_userns_now=""
-                read -p "Would you like to run 'ujust toggle-container-domain-userns-creation' now? [Y/n] " container_userns_now
+                read -rp "Would you like to run 'ujust toggle-container-domain-userns-creation' now? [Y/n] " container_userns_now
                 container_userns_now=${container_userns_now:-y}
                 if [[ "$container_userns_now" == [Yy]* ]]; then
                     echo "Running 'ujust toggle-container-domain-userns-creation'"
@@ -255,7 +256,7 @@ install-steam:
     esac
 
     echo "Steam requires support for 32-bit processes/syscalls."
-    if [ -n "$(rpm-ostree kargs | grep 'ia32_emulation=0')" ] ; then
+    if rpm-ostree kargs | grep -q 'ia32_emulation=0'; then
         echo "This script will now remove the 'ia32_emulation=0' kernel argument."
         rpm-ostree kargs --delete-if-present="ia32_emulation=0"
     else
@@ -295,7 +296,7 @@ label-external-drives:
     fi
     echo "Warning: This will label your drives mounted on \"$media_path\" such that they are treated as an extension to your home directory. (You can select which ones to label)"
     echo 'If you do not want Trivalent to have access to these drives, do not proceed.'
-    read -p 'Are you sure you want to do this? [y/N] ' warning_proceed
+    read -rp 'Are you sure you want to do this? [y/N] ' warning_proceed
     if ! [[ "$warning_proceed" == [Yy]* ]]; then
         echo 'Aborting.'
         exit 0
@@ -317,7 +318,7 @@ label-external-drives:
             echo "SELinux support is unknown for filesystem $detected_fs, skipping drive \"$dir\"..."
             continue
         fi
-        read -p "Do you want to label \"$dir\"? [y/N] " proceed
+        read -rp "Do you want to label \"$dir\"? [y/N] " proceed
         if ! [[ "$proceed" == [Yy]* ]]; then
             echo 'Skipping...'
             continue

--- a/files/scripts/addchromiumdesktopfile.sh
+++ b/files/scripts/addchromiumdesktopfile.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.

--- a/files/scripts/createmissingdirectories.sh
+++ b/files/scripts/createmissingdirectories.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.

--- a/files/scripts/installsignedkernel.sh
+++ b/files/scripts/installsignedkernel.sh
@@ -6,7 +6,13 @@ set -oue pipefail
 find /tmp/rpms
 
 QUALIFIED_KERNEL="$(rpm -qa | grep -P 'kernel-(\d+\.\d+\.\d+)' | sed -E 's/kernel-//')"
-INCOMING_KERNEL_VERSION="$(basename -s .rpm $(ls /tmp/rpms/kernel/kernel-[0-9]*.rpm 2>/dev/null | grep -P 'kernel-(\d+\.\d+\.\d+)' | sed -E 's/kernel-//'))"
+INCOMING_KERNEL_VERSION="$(find '/tmp/rpms/kernel' \
+    -maxdepth 1 \
+    -name 'kernel-[0-9]*.rpm' \
+    -regextype posix-egrep \
+    -regex '.*/kernel-([0-9]+\.[0-9]+\.[0-9]+).*' \
+    -printf '%f' \
+    -quit | sed -e 's/^kernel-//' -e 's/.rpm$//')"
 
 echo "Qualified kernel: $QUALIFIED_KERNEL"
 echo "Incoming kernel version: $INCOMING_KERNEL_VERSION"

--- a/files/scripts/setswaynvidiaenvironment.sh
+++ b/files/scripts/setswaynvidiaenvironment.sh
@@ -5,6 +5,7 @@ set -oue pipefail
 
 rm /etc/sway/environment
 
+# shellcheck disable=SC2016
 echo '
 
 # This file is a part of Fedora configuration for Sway and will be sourced

--- a/files/system/usr/bin/run0edit
+++ b/files/system/usr/bin/run0edit
@@ -1,7 +1,7 @@
 #!/bin/sh
 # ------------------------------------------------------------------------------
 # run0edit - edit a single file as root.
-# version 0.3.2-sb
+# version 0.3.3-sb
 #
 # Please report issues at: https://github.com/HastD/run0edit/issues
 #
@@ -20,10 +20,14 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-set -euo pipefail
+# Set pipefail if it's supported by the shell, disregard if unsupported.
+# shellcheck disable=SC3040
+( set -o pipefail 2> /dev/null ) && set -o pipefail
+set -eu
 
 # Reset $PATH to a default value to ensure command invocations point to
 # standard utilities.
+# shellcheck disable=SC2016
 PATH=$(command -p env -i sh -c 'echo "$PATH"')
 
 if [ "$#" = 0 ] || [ "$1" = '--help' ]; then
@@ -49,16 +53,16 @@ fi
 editor=''
 etc_conf_path='/etc/run0edit/editor.conf'
 usr_conf_path='/usr/etc/run0edit/editor.conf'
-if [ -f "$etc_conf_path" -a -r "$etc_conf_path" ]; then
+if [ -f "$etc_conf_path" ] && [ -r "$etc_conf_path" ]; then
     editor="$(cat "$etc_conf_path")"
-elif [ -f "$usr_conf_path" -a -r "$usr_conf_path" ]; then
+elif [ -f "$usr_conf_path" ] && [ -r "$usr_conf_path" ]; then
     editor="$(cat "$usr_conf_path")"
 fi
-if [ -f "$editor" -a -x "$editor" ]; then
+if [ -f "$editor" ] && [ -x "$editor" ]; then
     :
-elif [ -f '/usr/bin/nano' -a -x '/usr/bin/nano' ]; then
+elif [ -f '/usr/bin/nano' ] && [ -x '/usr/bin/nano' ]; then
     editor='/usr/bin/nano'
-elif [ -f '/usr/bin/vi' -a -x '/usr/bin/vi' ]; then
+elif [ -f '/usr/bin/vi' ] && [ -x '/usr/bin/vi' ]; then
     editor='/usr/bin/vi'
 else
     echo "Editor not found. Please install either nano or vi, or write the path to" >&2
@@ -73,6 +77,7 @@ trunc_filename=$(basename "$filename" | head -c 64)
 temp_filename=$(mktemp --tmpdir "${trunc_filename}.XXXXXXXXXX")
 
 # Inner script to be run with elevated privileges:
+# shellcheck disable=SC2016
 script='\
     filename="$1"
     tmpfile="$2"

--- a/files/system/usr/bin/securebluecleanup
+++ b/files/system/usr/bin/securebluecleanup
@@ -9,7 +9,7 @@ cp /usr/etc/authselect/authselect.conf /etc/authselect/authselect.conf
 
 # Ensure we are on signed
 RPM_OSTREE_STATUS=$(rpm-ostree status --json --booted)
-IMAGE_BASE_STRING=$(echo $RPM_OSTREE_STATUS | jq -r '.deployments[0]."container-image-reference" // empty')
+IMAGE_BASE_STRING=$(echo "$RPM_OSTREE_STATUS" | jq -r '.deployments[0]."container-image-reference" // empty')
 echo "Current image base: $IMAGE_BASE_STRING"
 if [[ "$IMAGE_BASE_STRING" == *"signed"* ]]; then
     echo "Already on signed. Exiting..."
@@ -18,5 +18,5 @@ fi
 
 IMAGE_REF_NAME=${IMAGE_BASE_STRING##*/}
 echo "Rebasing to $IMAGE_REF_NAME"
-rpm-ostree rebase ostree-image-signed:docker://ghcr.io/secureblue/$IMAGE_REF_NAME
+rpm-ostree rebase "ostree-image-signed:docker://ghcr.io/secureblue/$IMAGE_REF_NAME"
 

--- a/files/system/usr/lib/ujust/libformatting.sh
+++ b/files/system/usr/lib/ujust/libformatting.sh
@@ -20,7 +20,7 @@ declare -r hidden=$'\033[8m'
 ########
 declare -r normal=$'\033[0m'
 declare -r n="$normal"
-declare -r unbold=$'\033[21m'
+declare -r unbold=$'\033[22m'
 declare -r undim=$'\033[22m'
 declare -r nounderline=$'\033[24m'
 declare -r unblink=$'\033[25m'
@@ -38,5 +38,5 @@ function Urllink (){
     TEXT=$2
 
     # Generate a clickable hyperlink
-    printf "\e]8;;%s\e\\%s\e]8;;\e\\" "$URL" "$TEXT${n}"
+    printf "\033]8;;%s\033\\%s\033]8;;\033\\" "$URL" "$TEXT${n}"
 }

--- a/files/system/usr/libexec/luks-enable-tpm2-autounlock
+++ b/files/system/usr/libexec/luks-enable-tpm2-autounlock
@@ -67,7 +67,7 @@ SET_PIN_ARG=""
 read -p "Would you like to set a PIN? (y/N): " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-  SET_PIN_ARG=" --tpm2-with-pin=yes "
+  SET_PIN_ARG="--tpm2-with-pin=yes"
 fi
 
 # Specify Crypt Disk by-uuid
@@ -81,7 +81,7 @@ if [[ ! -L "$CRYPT_DISK" ]]; then
 fi
 
 if cryptsetup luksDump "$CRYPT_DISK" | grep systemd-tpm2 > /dev/null; then
-  KEYSLOT=$(cryptsetup luksDump "$CRYPT_DISK" | sed -n '/systemd-tpm2$/,/Keyslot:/p' | grep Keyslot|awk '{print $2}')
+  KEYSLOT=$(cryptsetup luksDump "$CRYPT_DISK" | sed -n '/systemd-tpm2$/,/Keyslot:/p' | grep Keyslot | awk '{print $2}')
   echo "TPM2 already present in LUKS keyslot $KEYSLOT of $CRYPT_DISK."
   read -p "Wipe it and re-enroll? (y/N): " -n 1 -r
   echo
@@ -97,7 +97,7 @@ fi
 
 ## Run crypt enroll
 echo "Enrolling TPM2 unlock requires your existing LUKS2 unlock password"
-systemd-cryptenroll --tpm2-device=auto --tpm2-pcrs=7+14 $SET_PIN_ARG "$CRYPT_DISK"
+systemd-cryptenroll --tpm2-device=auto --tpm2-pcrs=7+14 "$SET_PIN_ARG" "$CRYPT_DISK"
 
 
 if lsinitrd 2>&1 | grep -q tpm2-tss > /dev/null; then

--- a/files/system/usr/libexec/luks-enable-tpm2-autounlock
+++ b/files/system/usr/libexec/luks-enable-tpm2-autounlock
@@ -97,11 +97,7 @@ fi
 
 ## Run crypt enroll
 echo "Enrolling TPM2 unlock requires your existing LUKS2 unlock password"
-if [ "$SET_PIN" = 'yes' ]; then
-    systemd-cryptenroll --tpm2-device=auto --tpm2-pcrs=7+14 --tpm2-with-pin=yes "$CRYPT_DISK"
-else
-    systemd-cryptenroll --tpm2-device=auto --tpm2-pcrs=7+14 "$CRYPT_DISK"
-fi
+systemd-cryptenroll --tpm2-device=auto --tpm2-pcrs=7+14 --tpm2-with-pin="$SET_PIN" "$CRYPT_DISK"
 
 
 if lsinitrd 2>&1 | grep -q tpm2-tss > /dev/null; then

--- a/files/system/usr/libexec/luks-enable-tpm2-autounlock
+++ b/files/system/usr/libexec/luks-enable-tpm2-autounlock
@@ -63,11 +63,11 @@ else
   exit 1
 fi
 
-SET_PIN_ARG=""
+SET_PIN='no'
 read -p "Would you like to set a PIN? (y/N): " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-  SET_PIN_ARG="--tpm2-with-pin=yes"
+  SET_PIN='yes'
 fi
 
 # Specify Crypt Disk by-uuid
@@ -97,7 +97,11 @@ fi
 
 ## Run crypt enroll
 echo "Enrolling TPM2 unlock requires your existing LUKS2 unlock password"
-systemd-cryptenroll --tpm2-device=auto --tpm2-pcrs=7+14 "$SET_PIN_ARG" "$CRYPT_DISK"
+if [ "$SET_PIN" = 'yes' ]; then
+    systemd-cryptenroll --tpm2-device=auto --tpm2-pcrs=7+14 --tpm2-with-pin=yes "$CRYPT_DISK"
+else
+    systemd-cryptenroll --tpm2-device=auto --tpm2-pcrs=7+14 "$CRYPT_DISK"
+fi
 
 
 if lsinitrd 2>&1 | grep -q tpm2-tss > /dev/null; then

--- a/files/system/usr/libexec/ublue-motd
+++ b/files/system/usr/libexec/ublue-motd
@@ -3,15 +3,15 @@
 # Modified from https://github.com/ublue-os/bazzite/blob/main/system_files/desktop/shared/usr/libexec/ublue-motd
 
 RPM_OSTREE_STATUS=$(rpm-ostree status --json --booted)
-IMAGE_REF_NAME=$(echo $RPM_OSTREE_STATUS | jq -r '.deployments[0]."container-image-reference" // empty | split("/")[-1]')
-if [ -n "$(echo $RPM_OSTREE_STATUS | grep 'hardened:')" ] ; then
-    IMAGE_TAG=$(echo $RPM_OSTREE_STATUS | jq -r '.deployments[0]."container-image-reference" // empty | split(":")[-1]')
+IMAGE_REF_NAME=$(echo "$RPM_OSTREE_STATUS" | jq -r '.deployments[0]."container-image-reference" // empty | split("/")[-1]')
+if echo "$RPM_OSTREE_STATUS" | grep -q 'hardened:'; then
+    IMAGE_TAG=$(echo "$RPM_OSTREE_STATUS" | jq -r '.deployments[0]."container-image-reference" // empty | split(":")[-1]')
 else
     IMAGE_TAG='ERROR-IMAGE-TAG-MISSING'
 fi
 TIP=""
 
-IMAGE_DATE=$(echo $RPM_OSTREE_STATUS | jq -r '.deployments[0].timestamp')
+IMAGE_DATE=$(echo "$RPM_OSTREE_STATUS" | jq -r '.deployments[0].timestamp')
 CURRENT_SECONDS=$(date +%s)
 DIFFERENCE=$((CURRENT_SECONDS - IMAGE_DATE))
 WEEK=$((7 * 24 * 60 * 60))

--- a/files/system/usr/share/secureblue/install_secureblue.sh
+++ b/files/system/usr/share/secureblue/install_secureblue.sh
@@ -45,7 +45,7 @@ printf "%s\n\n" \
     "After answering the following questions, your system will be rebased to secureblue."
 
 # Determine if it's a server or desktop
-read -p "Is this for a CoreOS server? (yes/No): " is_server
+read -rp "Is this for a CoreOS server? (yes/No): " is_server
 if is_yes "$is_server"; then
     if ! grep VARIANT=\"CoreOS\" /etc/os-release >/dev/null; then
         echo "The current operating system is based on Fedora Atomic."
@@ -53,7 +53,7 @@ if is_yes "$is_server"; then
         echo "Refusing to proceed."
         exit 1
     fi
-    read -p "Do you need ZFS support? (yes/No): " use_zfs
+    read -rp "Do you need ZFS support? (yes/No): " use_zfs
     image_name=$(is_yes "$use_zfs" && echo "securecore-zfs" || echo "securecore")
 else
     if grep VARIANT=\"CoreOS\" /etc/os-release >/dev/null; then
@@ -79,10 +79,10 @@ else
 fi
 
 # Ask about Nvidia for all options
-read -p "Do you have Nvidia? (yes/No): " use_nvidia
+read -rp "Do you have Nvidia? (yes/No): " use_nvidia
 if is_yes "$use_nvidia"; then
     additional_params+="-nvidia" 
-    read -p "Do you need Nvidia's open drivers? (yes/No): " use_open
+    read -rp "Do you need Nvidia's open drivers? (yes/No): " use_open
     is_yes "$use_open" && additional_params+="-open"
 else
     additional_params+="-main"
@@ -92,7 +92,7 @@ image_name+="$additional_params-hardened"
 
 rebase_command="rpm-ostree rebase ostree-unverified-registry:ghcr.io/secureblue/$image_name:latest"
 
-if [ -n "$(rpm-ostree status | grep '● ostree-image-signed:docker://ghcr.io/secureblue/')" ] ; then
+if rpm-ostree status | grep -q '● ostree-image-signed:docker://ghcr.io/secureblue/'; then
     rebase_command="rpm-ostree rebase ostree-image-signed:docker://ghcr.io/secureblue/$image_name:latest"
 else
     echo "Note: Automatic rebasing to the equivalent signed image will occur on first run."
@@ -100,7 +100,7 @@ fi
 
 printf "Command to execute:\n%s\n\n" "$rebase_command"
 
-read -p "Proceed? (yes/No): " rebase_proceed
+read -rp "Proceed? (yes/No): " rebase_proceed
 if is_yes "$rebase_proceed"; then
     $rebase_command
 fi


### PR DESCRIPTION
This PR contains various minor changes to shell scripts suggested by [ShellCheck](https://www.shellcheck.net/). None of these changes should substantively change script behavior except to fix outright errors. The only major errors I found are in the part of `audit.just` that checks for sysctl overrides (which was completely broken and now works, at least on my system)—reviewers, please double-check my work on that.