### PR TITLE
fix: unbreak and optimize harden-flatpak script

### DIFF
--- a/files/justfiles/hardening.just
+++ b/files/justfiles/hardening.just
@@ -1,8 +1,7 @@
 # Harden flatpaks by preloading hardened_malloc (highest supported hwcap). When called with a flatpak application ID as an argument, applies the overrides to that application instead of globally.
-harden-flatpak FLATPAK="":
+harden-flatpak FLATPAK_APPID="":
     #!/usr/bin/bash
-    var1={{ FLATPAK }}
-    flatpak_id="${var1:-}"
+    flatpak_id="{{ FLATPAK_APPID }}"
     if [[ "$flatpak_id" =~ "'" ]]; then
         echo 'WARNING: Single quotes in the argument are forbidden to avoid command execution'
         exit 1

--- a/files/justfiles/hardening.just
+++ b/files/justfiles/hardening.just
@@ -3,8 +3,8 @@ harden-flatpak FLATPAK="":
     #!/usr/bin/bash
     var1={{ FLATPAK }}
     flatpak_id="${var1:-}"
-    if [[ $flatpak_id =~ "'" ]]; then
-        echo 'Warning: To avoid command execution the flatpak app ID may not contain single quotes.'
+    if [[ "$flatpak_id" =~ "'" ]]; then
+        echo 'WARNING: Single quotes in the argument are forbidden to avoid command execution'
         exit 1
     fi
 

--- a/files/justfiles/hardening.just
+++ b/files/justfiles/hardening.just
@@ -3,16 +3,31 @@ harden-flatpak FLATPAK="":
     #!/usr/bin/bash
     var1={{ FLATPAK }}
     flatpak_id="${var1:-}"
-    flatpak override --user --filesystem=host-os:ro "$flatpak_id"
+    if [[ $flatpak_id =~ "'" ]]; then
+        echo 'Warning: To avoid command execution the flatpak app ID may not contain single quotes.'
+        exit 1
+    fi
+
+    hostro_cmd="flatpak override --user --filesystem=host-os:ro"
+    if [[ -n "$flatpak_id" ]]; then
+        hostro_cmd="$hostro_cmd '$flatpak_id'"
+    fi
+    sh -c "$hostro_cmd"
+
     uarches="$(/usr/lib64/ld-linux-x86-64.so.2 --help | grep '(supported, searched)' | cut -d'v' -f2 || echo '')"
     bestuarch="${uarches:0:1}"
+    malloc_cmd="flatpak override --user --env=LD_PRELOAD=/var/run/host/usr/lib64"
     if [ -z "$bestuarch" ] ; then
         echo "No microarchitecture support detected. Using default x86-64-v1 architecture${flatpak_id:+" for $flatpak_id's malloc"}."
-        flatpak override --user --env=LD_PRELOAD=/var/run/host/usr/lib64/libhardened_malloc.so "$flatpak_id"
+        malloc_cmd="$malloc_cmd/libhardened_malloc.so"
     else
         echo "x86-64-v$bestuarch support detected. Using x86-64-v$bestuarch microarchitecture${flatpak_id:+" for $flatpak_id's malloc"}."
-        flatpak override --user --env=LD_PRELOAD=/var/run/host/usr/lib64/glibc-hwcaps/x86-64-v"$bestuarch"/libhardened_malloc.so "$flatpak_id"
+        malloc_cmd="$malloc_cmd/glibc-hwcaps/x86-64-v$bestuarch/libhardened_malloc.so"
     fi
+    if [[ -n "$flatpak_id" ]]; then
+        malloc_cmd="$malloc_cmd '$flatpak_id'"
+    fi
+    sh -c "$malloc_cmd"
 
 # Harden Flatpaks further by disabling all permissions by default and rejecting known arbitrary DBus names, applies only to the current user
 flatpak-permissions-lockdown:


### PR DESCRIPTION
The `harden-flatpak` script is broken since the [ShellCheck PR](https://github.com/secureblue/secureblue/pull/948), due to it previously relying on the `$flatpak_id` variable being unquoted for applying the hardening globally. With the variable now quoted, it is passed as an empty argument (instead of none at all) to the flatpak command, which expects a valid app ID and trips because `''` (empty) is not a valid app ID.

Discord support thread for reference:
https://discord.com/channels/1202086019298500629/1353322889578942574

This PR makes it work again and also optimizes it a bit.

Note: The ujust variable `{{ FLATPAK }}` wasn't quoted before, because ShellCheck can't understand them, but as far as I'm aware they should be quoted as well to prevent the same issues as with bash-native variables.