### PR TITLE
chore: remove setroubleshootd

### DIFF
--- a/files/scripts/createmissingdirectories.sh
+++ b/files/scripts/createmissingdirectories.sh
@@ -5,6 +5,3 @@ set -oue pipefail
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=2259249
 mkdir -p /var/log/usbguard
-
-mkdir -p /var/lib/setroubleshoot
-chmod 600 /var/lib/setroubleshoot

--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -11,7 +11,6 @@ install:
   - bubblejail
   - usbguard-notifier
   - usbguard
-  - setroubleshoot
   - setools
   - fscrypt
   - vim


### PR DESCRIPTION
setroubleshootd adds attack surface, can cause CPU spikes, and is generally unneeded. Users can layer it back if needed

it can also mislead users, e.g.

```
SELinux is preventing podman from create access on the user_namespace labeled container_runtime_t.
```