### PR TITLE
feat: disable switcheroo on silverblue-main images

### DIFF
--- a/files/scripts/disableswitcheroo.sh
+++ b/files/scripts/disableswitcheroo.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Tell build process to exit if there are any errors.
+set -oue pipefail
+
+if [[ "$IMAGE_NAME" == *"main"* ]]; then
+    systemctl disable switcheroo-control.service
+    systemctl mask switcheroo-control.service
+fi

--- a/recipes/common/silverblue-modules.yml
+++ b/recipes/common/silverblue-modules.yml
@@ -27,3 +27,4 @@ modules:
     - type: script
       scripts:
         - removedkmshelper.sh
+        - disableswitcheroo.sh


### PR DESCRIPTION
There's relatively little reason for this service to be running if nvidia isn't present, and it adds significant attack surface since it runs unconfined as root. Can be reenabled if users desire. Only GNOME pulls this in as a dep