### PR TITLE
feat: disable unconfined rootful services

### DIFF
--- a/files/scripts/disableunconfinedrootfulservices.sh
+++ b/files/scripts/disableunconfinedrootfulservices.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Tell build process to exit if there are any errors.
+set -oue pipefail
+
+systemctl disable uresourced.service
+systemctl mask uresourced.service
+
+systemctl disable low-memory-monitor.service
+systemctl mask low-memory-monitor.service

--- a/recipes/common/desktop-scripts.yml
+++ b/recipes/common/desktop-scripts.yml
@@ -8,3 +8,4 @@ scripts:
   - disablemodemmanager.sh
   - disablenfsdaemons.sh
   - disablesssd.sh
+  - disableunconfinedrootfulservices.sh


### PR DESCRIPTION
systemd-oomd already takes action based on memory pressure information, while not running as root, running confined by selinux, and running strictly sandboxed by systemd.

None of these can be said for either of these services.