### PR TITLE
chore: include nvme-cli

### DIFF
--- a/recipes/common/common-packages.yml
+++ b/recipes/common/common-packages.yml
@@ -12,3 +12,4 @@ install:
   - distrobox
   - toolbox
   - podman
+  - nvme-cli


### PR DESCRIPTION
tiny (<1MB) and relevant package for securely erasing SSDs. `hdparm` is already included.

https://wiki.archlinux.org/title/Solid_state_drive/Memory_cell_clearing#NVMe_drive