### PR TITLE
feat: add MangoHud option to Steam flatpak installer

### DIFF
--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -235,6 +235,8 @@ install-steam:
             flatpak install -y flathub com.valvesoftware.Steam
             echo "Disabling hardened_malloc for Steam."
             flatpak override --user --unset-env=LD_PRELOAD --nofilesystem=host-os com.valvesoftware.Steam
+            install_mangohud=""
+            read -rp "Would you like to install MangoHud and enable it for all Steam games? [Y/n] " install_mangohud
             install_mangohud=${install_mangohud:-y}
             if [[ "$install_mangohud" == [Yy]* ]]; then
                 echo "Installing MangoHud flatpak"

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -239,7 +239,7 @@ install-steam:
             read -rp "Would you like to install MangoHud and enable it for all Steam games? [y/N] " install_mangohud
             if [[ "$install_mangohud" == [Yy]* ]]; then
                 echo "Installing MangoHud flatpak"
-                flatpak install org.freedesktop.Platform.VulkanLayer.MangoHud
+                flatpak install -y flathub-verified org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/24.08
                 echo "Setting --env=MANGOHUD=1 for Steam to enable MangoHud for all games"
                 flatpak override --user --env=MANGOHUD=1 com.valvesoftware.Steam
             fi

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -236,8 +236,7 @@ install-steam:
             echo "Disabling hardened_malloc for Steam."
             flatpak override --user --unset-env=LD_PRELOAD --nofilesystem=host-os com.valvesoftware.Steam
             install_mangohud=""
-            read -rp "Would you like to install MangoHud and enable it for all Steam games? [Y/n] " install_mangohud
-            install_mangohud=${install_mangohud:-y}
+            read -rp "Would you like to install MangoHud and enable it for all Steam games? [y/N] " install_mangohud
             if [[ "$install_mangohud" == [Yy]* ]]; then
                 echo "Installing MangoHud flatpak"
                 flatpak install org.freedesktop.Platform.VulkanLayer.MangoHud

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -235,6 +235,13 @@ install-steam:
             flatpak install -y flathub com.valvesoftware.Steam
             echo "Disabling hardened_malloc for Steam."
             flatpak override --user --unset-env=LD_PRELOAD --nofilesystem=host-os com.valvesoftware.Steam
+            install_mangohud=${install_mangohud:-y}
+            if [[ "$install_mangohud" == [Yy]* ]]; then
+                echo "Installing MangoHud flatpak"
+                flatpak install org.freedesktop.Platform.VulkanLayer.MangoHud
+                echo "Setting --env=MANGOHUD=1 for Steam to enable MangoHud for all games"
+                flatpak override --user --env=MANGOHUD=1 com.valvesoftware.Steam
+            fi
             ;;
         2)
             echo "Distrobox method selected."


### PR DESCRIPTION
#1013
Note the distrobox option (which this PR does not currently touch) already installs MangoHud (but idk if it enables it, so we may want to add that option).