### PR TITLE
feat: enable stable MAC address randomization by default

### DIFF
--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -410,15 +410,12 @@ toggle-mac-randomization:
         randomization_choice=""
         read -rp "Do you want to use per-connection Wi-Fi MAC address randomization? [y/N] " randomization_choice
 
-        if [[ "$randomization_choice" == [Yy]* ]]; then
-            randomization_level=random
-            echo "Selected state: per-connection"
-        else
-            randomization_level=stable
-            echo "Selected state: per-network (stable)"
-        fi
         cp /usr$RAND_MAC_FILE $RAND_MAC_FILE
-        sed -i "s/wifi.cloned-mac-address=stable/wifi.cloned-mac-address=$randomization_level/" $RAND_MAC_FILE
-        echo "MAC randomization enabled."
+        if [[ "$randomization_choice" == [Yy]* ]]; then
+            sed -i 's/wifi.cloned-mac-address=stable/wifi.cloned-mac-address=random/g' $RAND_MAC_FILE
+            echo "Per-connection MAC randomization enabled."
+        else
+            echo "Stable MAC randomization enabled."
+        fi
         systemctl restart NetworkManager
     fi

--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -417,16 +417,8 @@ toggle-mac-randomization:
             randomization_level=stable
             echo "Selected state: per-network (stable)"
         fi
-        cat <<EOL > $RAND_MAC_FILE
-    [device-mac-randomization]
-    # "yes" is already the default for scanning
-    wifi.scan-rand-mac-address=yes
-
-    [connection-mac-randomization]
-    # Generate a random MAC for each Network and associate the two permanently.
-    ethernet.cloned-mac-address=stable
-    wifi.cloned-mac-address=$randomization_level
-    EOL
+        cp /usr$RAND_MAC_FILE $RAND_MAC_FILE
+        sed -i "s/wifi.cloned-mac-address=stable/wifi.cloned-mac-address=$randomization_level/" $RAND_MAC_FILE
         echo "MAC randomization enabled."
         systemctl restart NetworkManager
     fi

--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -412,7 +412,7 @@ toggle-mac-randomization:
 
         cp /usr$RAND_MAC_FILE $RAND_MAC_FILE
         if [[ "$randomization_choice" == [Yy]* ]]; then
-            sed -i 's/wifi.cloned-mac-address=stable/wifi.cloned-mac-address=random/g' $RAND_MAC_FILE
+            sed 's/wifi.cloned-mac-address=stable/wifi.cloned-mac-address=random/g' $RAND_MAC_FILE
             echo "Per-connection MAC randomization enabled."
         else
             echo "Stable MAC randomization enabled."

--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -412,7 +412,7 @@ toggle-mac-randomization:
 
         cp /usr$RAND_MAC_FILE $RAND_MAC_FILE
         if [[ "$randomization_choice" == [Yy]* ]]; then
-            sed 's/wifi.cloned-mac-address=stable/wifi.cloned-mac-address=random/g' $RAND_MAC_FILE
+            sed -i 's/wifi.cloned-mac-address=stable/wifi.cloned-mac-address=random/' $RAND_MAC_FILE
             echo "Per-connection MAC randomization enabled."
         else
             echo "Stable MAC randomization enabled."

--- a/files/system/etc/NetworkManager/conf.d/rand_mac.conf
+++ b/files/system/etc/NetworkManager/conf.d/rand_mac.conf
@@ -1,0 +1,8 @@
+[device-mac-randomization]
+# "yes" is already the default for scanning
+wifi.scan-rand-mac-address=yes
+
+[connection-mac-randomization]
+# Generate a random MAC for each Network and associate the two permanently.
+ethernet.cloned-mac-address=stable
+wifi.cloned-mac-address=stable


### PR DESCRIPTION
IMO there's no reason not to enable stable MAC address randomization. It functions identically to unobfuscated MAC address in all the use cases I am aware of. This PR adds the stable rand_mac.conf to images, so the randomization is enabled by default, instead of requiring the user to enable it with `toggle-mac-randomization`. Users can still use `toggle-mac-randomization` to disable MAC randomization or enable per-connection at their discretion.