### PR TITLE
fix(audit): handle errors better; add rec for ld.so.preload check.

### DIFF
--- a/files/justfiles/audit.just
+++ b/files/justfiles/audit.just
@@ -3,4 +3,4 @@ set positional-arguments := true
 # Audit secureblue
 audit-secureblue *args:
     #!/bin/sh
-    python3 /usr/libexec/secureblue/audit_secureblue.py "$@"
+    /usr/bin/python3 /usr/libexec/secureblue/audit_secureblue.py "$@"

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 """
 Auditing script for secureblue. See https://secureblue.dev/ for more info.

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -12,6 +12,7 @@ import os.path
 import re
 import signal
 import sys
+import traceback
 
 # All subprocess calls we make have trusted inputs and do not use shell=True.
 import subprocess  # nosec
@@ -175,8 +176,8 @@ def audit_signed_image():
     else:
         status = FAILURE
         recs = """The current image is not signed.
-            To rebase to a signed image download and run or re-run install_secureblue.sh
-            from the secureblue github."""
+            To rebase to a signed image, download and run or re-run install_secureblue.sh
+            from the secureblue GitHub repository."""
     yield Report("Ensuring a signed image is in use", status, recs=recs)
 
 
@@ -316,7 +317,8 @@ def audit_chronyd():
         rec = None
     else:
         status = FAILURE
-        rec = """chronyd is not active. To enable, run:
+        rec = """chronyd is inactive.
+            To start and enable it, run:
             $ systemctl enable --now chronyd"""
     yield Report("Ensuring chronyd is active", status, recs=rec)
 
@@ -594,7 +596,15 @@ def audit_hardened_malloc():
         else:
             status = FAILURE
             warnings.append("hardened_malloc not set")
-    yield Report("Ensuring hardened_malloc is set in ld.so.preload", status, warnings=warnings)
+    if status == SUCCESS:
+        rec = None
+    else:
+        rec = """/etc/ld.so.preload has been modified.
+            To reset it and enable hardened_malloc system-wide, run:
+            $ run0 cp /usr/etc/ld.so.preload /etc/ld.so.preload"""
+    yield Report(
+        "Ensuring hardened_malloc is set in ld.so.preload", status, warnings=warnings, recs=rec
+    )
 
 
 @audit
@@ -841,8 +851,8 @@ async def audit_flatpak_permissions(state):
 
 
 def print_err(text: str):
-    """Print text to stderr in bold."""
-    print(bold(text), file=sys.stderr)
+    """Print text to stderr in bold and red."""
+    print(f"\x1b[1m\x1b[31m{text}\x1b[0m", file=sys.stderr)
 
 
 def handle_sigint(_sig, _frame):
@@ -860,7 +870,7 @@ def warn_if_root():
         print_err("*** Some results may be misleading or incomplete. ***\n")
 
 
-async def main():
+async def main() -> int:
     """Main entry point. Parse command-line arguments and run audit."""
     signal.signal(signal.SIGINT, handle_sigint)
     warn_if_root()
@@ -872,11 +882,20 @@ async def main():
     if any(cat not in global_audit.categories for cat in skip):
         print(f"Valid arguments to --skip are: {categories}", file=sys.stderr)
         sys.exit(1)
-    await global_audit.run(exclude=skip)
+    error_occurred = False
+    async for check, err in global_audit.run(exclude=skip):
+        print_err(f"\n*** Error in check '{check.name}' ***")
+        traceback.print_exception(err)
+        print_err("\n*** Continuing... ***")
+        error_occurred = True
     if "flatpak" not in skip:
         print(f"Use option '{bold('--skip flatpak')}' to skip flatpak recommendations.")
     warn_if_root()
+    if error_occurred:
+        print_err("\n*** WARNING: Unexpected error occurred. ***")
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    sys.exit(asyncio.run(main()))

--- a/files/system/usr/libexec/secureblue/auditor/__init__.py
+++ b/files/system/usr/libexec/secureblue/auditor/__init__.py
@@ -151,7 +151,9 @@ class Audit:
             self.categories.add(check.category)
         self.checks.append(check)
 
-    async def run(self, exclude: list[str] | None = None):
+    async def run(
+        self, exclude: list[str] | None = None
+    ) -> AsyncGenerator[tuple[Check, Exception]]:
         """Runs each stored check, prints their reports, then prints their recommendations."""
         if exclude is None:
             exclude = []
@@ -162,9 +164,13 @@ class Audit:
         for check in self.checks:
             if check.category in exclude:
                 continue
-            async for report in check.run(self.state):
-                print(report)
-            self.recs += check.recs
+            try:
+                async for report in check.run(self.state):
+                    print(report)
+            except Exception as e:
+                yield check, e
+            else:
+                self.recs += check.recs
         print_heading("Recommendations")
         for rec in self.recs:
             rec_lines = [line.strip() for line in rec.split("\n")]

--- a/files/system/usr/libexec/secureblue/auditor/__init__.py
+++ b/files/system/usr/libexec/secureblue/auditor/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 """
 Framework for system auditing.


### PR DESCRIPTION
This adds fallback error handling to the audit script so that an exception in one check doesn't cause the whole script to terminate early. Instead, the traceback is printed to stderr in place and the script then continues with the rest of the checks. This means that a bug in one check won't render the whole script unusable, but it will still be clearly visible as an unexpected error.

I also added a recommendation to the `/etc/ld.so.preload` check, and modified the shebang and `audit.just` to always use the system Python installation at `/usr/bin/python3`.