### PR TITLE
feat: Sway security improvements, image deprecations, and minor fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Build secureblue
         uses: blue-build/github-action@4d8b4df657ec923574611eec6fd7e959416c47f0 # v1.8.1
         with:          
-          cli_version: v0.9.10
+          cli_version: v0.9.11
           recipe: ${{ matrix.recipe }}
           cosign_private_key: ${{ secrets.SIGNING_SECRET }}
           registry_token: ${{ github.token }}

--- a/.github/workflows/checksum.yml
+++ b/.github/workflows/checksum.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   verify-installer-checksum:
     name: Installer Checksum Verification
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/tests/install_script_tests.bats
+++ b/.github/workflows/tests/install_script_tests.bats
@@ -96,32 +96,8 @@ fi
   [[ "$output" == *"sericea-main-hardened"* ]]
 }
 
-@test "Test command for wayblue-wayfire-main-hardened" {
-  run bash -c "echo -e 'no\n4\nno\nno' | bash '$INSTALL_SCRIPT'"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"wayblue-wayfire-main-hardened"* ]]
-}
-
-@test "Test command for wayblue-sway-main-hardened" {
-  run bash -c "echo -e 'no\n5\nno\nno' | bash '$INSTALL_SCRIPT'"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"wayblue-sway-main-hardened"* ]]
-}
-
-@test "Test command for wayblue-river-main-hardened" {
-  run bash -c "echo -e 'no\n6\nno\nno' | bash '$INSTALL_SCRIPT'"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"wayblue-river-main-hardened"* ]]
-}
-
-@test "Test command for wayblue-hyprland-main-hardened" {
-  run bash -c "echo -e 'no\n7\nno\nno' | bash '$INSTALL_SCRIPT'"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"wayblue-hyprland-main-hardened"* ]]
-}
-
 @test "Test command for cosmic-main-hardened" {
-  run bash -c "echo -e 'no\n8\nno\nno' | bash '$INSTALL_SCRIPT'"
+  run bash -c "echo -e 'no\n4\nno\nno' | bash '$INSTALL_SCRIPT'"
   [ "$status" -eq 0 ]
   [[ "$output" == *"cosmic-main-hardened"* ]]
 }

--- a/docs/example.butane
+++ b/docs/example.butane
@@ -14,7 +14,7 @@ storage:
       contents:
         source: https://raw.githubusercontent.com/secureblue/secureblue/refs/heads/live/files/system/usr/share/secureblue/install_secureblue.sh
         verification:
-          hash: sha256-411fbbc82a6d5bdd1e31c084cf475c70963d4a11755de284237d9e80a0671b6c
+          hash: sha256-4a81d462f0f57cf3cac8959f34f768e298deadaa588fffb1738f70d950ffd5b5
       mode: 0755
     - path: /opt/run_install_secureblue.sh
       contents:

--- a/files/justfiles/kargs.just
+++ b/files/justfiles/kargs.just
@@ -92,3 +92,12 @@ set-kargs-nvidia:
       --append-if-missing=modprobe.blacklist=nouveau \
       --append-if-missing=nvidia-drm.modeset=1 \
       --append-if-missing=nvidia-drm.fbdev=1
+
+# Remove nvidia kargs
+remove-kargs-nvidia:
+    #!/usr/bin/bash
+    rpm-ostree kargs \
+      --delete-if-present=rd.driver.blacklist=nouveau \
+      --delete-if-present=modprobe.blacklist=nouveau \
+      --delete-if-present=nvidia-drm.modeset=1 \
+      --delete-if-present=nvidia-drm.fbdev=1

--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -442,8 +442,19 @@ toggle-wlr-screenshot-support:
     fi
 
     PACKAGE_NAME="wlr-screenshot-support"
-    if rpm -qa | grep -q "$PACKAGE_NAME"; then
+    if rpm -qa | grep -q "$PACKAGE_NAME" && ; then
+        echo "wlroots screenshot support is enabled. Disabling..."
         rpm-ostree uninstall "$PACKAGE_NAME"
+        echo "wlroots screenshot support disabled. Reboot to take effect."
     else 
+        echo "wlroots screenshot support is disabled."
+        read -rp "Enabling screenshot support on wlroots has negative security implications. Are you sure you want to do this? (y/N) " proceed
+        if ! [[ "$proceed" == [Yy]* ]]; then
+            echo "Aborting..."
+            exit 0
+        fi
+
+        echo "Enabling wlroots screenshot support..."
         rpm-ostree install "$PACKAGE_NAME"
+        echo "wlroots screenshot support enabled. Reboot to take effect."
     fi

--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -431,3 +431,19 @@ toggle-mac-randomization:
         echo "MAC randomization enabled."
         systemctl restart NetworkManager
     fi
+
+# Toggle support for screenshots on wlroots
+toggle-wlr-screenshot-support:
+    #!/usr/bin/bash
+    IMAGE="$(rpm-ostree status | grep '●')"
+    if ! echo "$IMAGE" | grep -qE 'sericea|sway'; then
+        echo "This toggle is only relevant on Sericea"
+        exit 0
+    fi
+
+    PACKAGE_NAME="wlr-screenshot-support"
+    if rpm -qa | grep -q "$PACKAGE_NAME"; then
+        rpm-ostree uninstall "$PACKAGE_NAME"
+    else 
+        rpm-ostree install "$PACKAGE_NAME"
+    fi

--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -442,7 +442,7 @@ toggle-wlr-screenshot-support:
     fi
 
     PACKAGE_NAME="wlr-screenshot-support"
-    if rpm -qa | grep -q "$PACKAGE_NAME" && ; then
+    if rpm -q "$PACKAGE_NAME" 1>/dev/null; then
         echo "wlroots screenshot support is enabled. Disabling..."
         rpm-ostree uninstall "$PACKAGE_NAME"
         echo "wlroots screenshot support disabled. Reboot to take effect."

--- a/files/system/usr/libexec/deprecated-images.json
+++ b/files/system/usr/libexec/deprecated-images.json
@@ -6,6 +6,10 @@
       "server",
       "bluefin",
       "aurora",
-      "userns"
+      "userns",
+      "wayblue-hyprland",
+      "wayblue-sway",
+      "wayblue-wayfire",
+      "wayblue-river"
     ]
 }

--- a/files/system/usr/libexec/deprecated-images.json.md
+++ b/files/system/usr/libexec/deprecated-images.json.md
@@ -2,6 +2,26 @@
 
 The following image types have been deprecated:
 
+## wayblue-hyprland
+
+Rationale: Our Hyprland images have low usage. More importantly though, Hyprland has a long history of antagonism towards security improvements. Please see https://bugs.gentoo.org/930831#c6 for more info.
+Rebase to: One of secureblue's `sericea` images.
+
+## wayblue-sway
+
+Rationale: Deduplication and supply chain improvements. We already have `sericea` images that pull directly from Fedora, without depending on ublue's akmods. Wayblue on the other hand still depends on ublue's akmods.
+Rebase to: One of secureblue's `sericea` images.
+
+## wayblue-wayfire
+
+Rationale: Lack of usage and consolidation. Stats report no usage.
+Rebase to: One of secureblue's `sericea` images.
+
+## wayblue-river
+
+Rationale: Low usage and consolidation. Stats report very low usage.
+Rebase to: One of secureblue's `sericea` images.
+
 ## userns
 
 Rationale: See https://github.com/secureblue/secureblue/releases/tag/v4.3.0

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -666,14 +666,15 @@ def audit_bash_env_lockdown():
 @audit
 def audit_wlroot_screenshot():
     """Ensure wlroots screenshot support is not present."""
-    if command_succeeds(*"rpm -qa | grep -q xdg-desktop-portal-wlr".split()):
+    if command_succeeds(*"rpm -q xdg-desktop-portal-wlr".split()):
         status = FAILURE
         rec = """wlroots screenshot support is enabled
             To disable, run:
             $ ujust toggle-wlr-screenshot-support"""
     else:
         status = SUCCESS
-    yield Report("Ensuring wlroots screenshot support is not present", status)
+        rec = None
+    yield Report("Ensuring wlroots screenshot support is not present", status, recs=rec)
 
 @audit
 @categorize("flatpak")

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -845,6 +845,15 @@ async def audit_flatpak_permissions(state):
         yield Report(f"Auditing {name} ({version})", status, warnings=warnings, recs=recs)
 
 
+@audit
+def audit_wlroot_screencopy():
+    """Ensure wlroots screencopy support is not present."""
+    if command_succeeds("rpm", "-qa", "|", "grep", "-q", "xdg-desktop-portal-wlr"):
+        status = FAILURE
+    else:
+        status = SUCCESS
+    yield Report("Ensuring wlroots screencopy support is not present", status)
+
 ###############################################################################
 # Checks to be run go above this line.
 ###############################################################################

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -664,6 +664,18 @@ def audit_bash_env_lockdown():
 
 
 @audit
+def audit_wlroot_screenshot():
+    """Ensure wlroots screenshot support is not present."""
+    if command_succeeds(*"rpm -qa | grep -q xdg-desktop-portal-wlr".split()):
+        status = FAILURE
+        rec = """wlroots screenshot support is enabled
+            To disable, run:
+            $ ujust toggle-wlr-screenshot-support"""
+    else:
+        status = SUCCESS
+    yield Report("Ensuring wlroots screenshot support is not present", status)
+
+@audit
 @categorize("flatpak")
 def audit_flatpak_remotes():
     """Audit flatpak remotes."""
@@ -843,16 +855,6 @@ async def audit_flatpak_permissions(state):
     for name, version in flatpaks:
         status, warnings, recs = await tasks[(name, version)]
         yield Report(f"Auditing {name} ({version})", status, warnings=warnings, recs=recs)
-
-
-@audit
-def audit_wlroot_screencopy():
-    """Ensure wlroots screencopy support is not present."""
-    if command_succeeds("rpm", "-qa", "|", "grep", "-q", "xdg-desktop-portal-wlr"):
-        status = FAILURE
-    else:
-        status = SUCCESS
-    yield Report("Ensuring wlroots screencopy support is not present", status)
 
 ###############################################################################
 # Checks to be run go above this line.

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -10,6 +10,7 @@ import filecmp
 import glob
 import os.path
 import re
+import rpm
 import signal
 import sys
 import traceback
@@ -666,7 +667,7 @@ def audit_bash_env_lockdown():
 @audit
 def audit_wlroot_screenshot():
     """Ensure wlroots screenshot support is not present."""
-    if command_succeeds(*"rpm -q xdg-desktop-portal-wlr".split()):
+    if is_rpm_package_installed("xdg-desktop-portal-wlr"):
         status = FAILURE
         rec = """wlroots screenshot support is enabled
             To disable, run:
@@ -860,6 +861,13 @@ async def audit_flatpak_permissions(state):
 ###############################################################################
 # Checks to be run go above this line.
 ###############################################################################
+
+
+def is_rpm_package_installed(name: str) -> bool:
+    """Checks if the given RPM package is installed."""
+    ts = rpm.TransactionSet()
+    matches = ts.dbMatch("name", name)
+    return len(matches) > 0
 
 
 def print_err(text: str):

--- a/files/system/usr/share/secureblue/install_secureblue.sh
+++ b/files/system/usr/share/secureblue/install_secureblue.sh
@@ -30,10 +30,6 @@ desktop_image_types=(
     "silverblue"
     "kinoite"
     "sericea"
-    "wayblue-wayfire"
-    "wayblue-sway"
-    "wayblue-river"
-    "wayblue-hyprland"
     "cosmic"
 )
 
@@ -64,8 +60,8 @@ else
     fi
     printf "%s\n" \
         "Select a desktop." \
-        "Silverblue is recommended." \
-        "Wayblue images are currently in beta." \
+        "Silverblue images are recommended." \
+        "Sericea images are recommended for tiling WM users." \
         "Cosmic images are considered experimental."
     PS3=$'Enter your desktop choice: '
     select image_name in "${desktop_image_types[@]}"; do
@@ -92,7 +88,7 @@ image_name+="$additional_params-hardened"
 
 rebase_command="rpm-ostree rebase ostree-unverified-registry:ghcr.io/secureblue/$image_name:latest"
 
-if rpm-ostree status | grep -q '● ostree-image-signed:docker://ghcr.io/secureblue/'; then
+if rpm-ostree status | grep -q '●.*ghcr\.io/secureblue/'; then
     rebase_command="rpm-ostree rebase ostree-image-signed:docker://ghcr.io/secureblue/$image_name:latest"
 else
     echo "Note: Automatic rebasing to the equivalent signed image will occur on first run."

--- a/recipes/common/sway-modules.yml
+++ b/recipes/common/sway-modules.yml
@@ -1,4 +1,6 @@
 modules:
     - type: rpm-ostree
+      repos:
+        - https://copr.fedorainfracloud.org/coprs/secureblue/wlr-screenshot-support/repo/fedora-%OS_VERSION%/secureblue-wlr-screenshot-support-fedora-%OS_VERSION%.repo
       remove:
         - xdg-desktop-portal-wlr

--- a/recipes/common/sway-modules.yml
+++ b/recipes/common/sway-modules.yml
@@ -1,0 +1,4 @@
+modules:
+    - type: rpm-ostree
+      remove:
+        - xdg-desktop-portal-wlr

--- a/recipes/general/recipe-sericea-main.yml
+++ b/recipes/general/recipe-sericea-main.yml
@@ -9,6 +9,7 @@ image-version: 42
 modules:
   - from-file: common/common-modules.yml
   - from-file: common/desktop-modules.yml
+  - from-file: common/sway-modules.yml
   - from-file: common/proprietary-modules.yml
   - from-file: common/selinux-modules.yml
   - from-file: common/final-modules.yml

--- a/recipes/general/recipe-sericea-nvidia-open.yml
+++ b/recipes/general/recipe-sericea-nvidia-open.yml
@@ -9,6 +9,7 @@ image-version: 42
 modules:
   - from-file: common/common-modules.yml
   - from-file: common/desktop-modules.yml
+  - from-file: common/sway-modules.yml
   - from-file: common/nvidia-install.yml 
   - from-file: common/proprietary-modules.yml
   - from-file: common/selinux-modules.yml

--- a/recipes/general/recipe-sericea-nvidia.yml
+++ b/recipes/general/recipe-sericea-nvidia.yml
@@ -9,6 +9,7 @@ image-version: 42
 modules:
   - from-file: common/common-modules.yml
   - from-file: common/desktop-modules.yml
+  - from-file: common/sway-modules.yml
   - from-file: common/nvidia-install.yml 
   - from-file: common/proprietary-modules.yml
   - from-file: common/selinux-modules.yml


### PR DESCRIPTION
- Adds all wayblue images to the deprecation notice, with explanations in deprecated-images.json.md
- Removes xdg-desktop-portal-wlr by default from sericea images, with a toggle to add it back via a [dummy rpm](https://github.com/secureblue/wlr-screenshot-support)
- Adds `remove-kargs-nvidia` toggle
- Fixes the rebase script to rebase to signed if the current image is secureblue