### PR TITLE
fix: add udev rule to disable binfmt_misc sysctl when module loads

### DIFF
--- a/files/system/etc/udev/rules.d/secureblue.rules
+++ b/files/system/etc/udev/rules.d/secureblue.rules
@@ -1,0 +1,2 @@
+# Disable binfmt_misc via sysctl when the module is loaded
+ACTION=="add", SUBSYSTEM=="kernel", KERNEL=="binfmt_misc", RUN+="/usr/bin/sysctl -w fs.binfmt_misc.status=0"


### PR DESCRIPTION
Fixes #1032, which I believe is caused by the binfmt_misc kernel module not being loaded yet when the sysctl configuration is loaded during boot.