### PR TITLE
fix: udev rule to disable binfmt_misc

### DIFF
--- a/files/system/etc/udev/rules.d/secureblue.rules
+++ b/files/system/etc/udev/rules.d/secureblue.rules
@@ -1,2 +1,2 @@
 # Disable binfmt_misc via sysctl when the module is loaded
-ACTION=="add", SUBSYSTEM=="kernel", KERNEL=="binfmt_misc", RUN+="/usr/bin/sysctl -w fs.binfmt_misc.status=0"
+ACTION=="add", SUBSYSTEM=="module", DEVPATH=="/module/binfmt_misc", RUN+="/usr/bin/sysctl -w fs.binfmt_misc.status=0"


### PR DESCRIPTION
Fixes #1032 (for real this time :sweat_smile:). I tested it in a VM running the `kinoite-main-hardened` image and made sure that the udev rule is being triggered and has the intended effect.