### PR TITLE
fix: remove netfs from kernel module blacklist

### DIFF
--- a/files/system/etc/modprobe.d/blacklist.conf
+++ b/files/system/etc/modprobe.d/blacklist.conf
@@ -61,7 +61,6 @@ install coda /bin/false
 install ecryptfs /bin/false
 install jfs /bin/false
 install minix /bin/false
-install netfs /bin/false
 install nilfs2 /bin/false
 install ocfs2 /bin/false
 install romfs /bin/false


### PR DESCRIPTION
netfs is a dependency of erofs, which is needed as of Fedora 42 (see #533). erofs was removed from blacklist.conf earlier (#951) but its dependency netfs wasn't.