### PR TITLE
feat: update run0edit to v0.4.3 w/ support for immutable flag

### DIFF
--- a/files/system/usr/bin/run0edit
+++ b/files/system/usr/bin/run0edit
@@ -132,7 +132,7 @@ script='\
 
     ask_immutable() {
         if command -pv lsattr > /dev/null; then
-            immutable_flag=$(lsattr -- "$1" | cut -d " " -f1 | tr -d "-")
+            immutable_flag=$(lsattr -- "$1" 2>/dev/null | cut -d " " -f1 | tr -d "-" || echo "")
         else
             immutable_flag=""
         fi

--- a/files/system/usr/bin/run0edit
+++ b/files/system/usr/bin/run0edit
@@ -19,7 +19,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-readonly version=0.4.1-secureblue
+readonly version=0.4.2-secureblue
 
 # Set pipefail if it's supported by the shell, disregard if unsupported.
 # shellcheck disable=SC3040
@@ -150,28 +150,24 @@ script='\
         fi
     }
 
+    is_immutable() {
+        immutable_flag=$(lsattr -d -- "$1" 2>/dev/null | cut -d " " -f1 | tr -d "-" || echo "")
+        [ "$immutable_flag" = "i" ]
+    }
+
     ask_immutable() {
-        if command -v lsattr >/dev/null; then
-            immutable_flag=$(lsattr -d -- "$1" 2>/dev/null | cut -d " " -f1 | tr -d "-" || echo "")
+        echo "WARNING: $1 has the immutable flag."
+        if [ -d "$1" ]; then
+            printf "Temporarily remove the flag to create a file in the directory? [y/N] "
         else
-            immutable_flag=""
+            printf "Temporarily remove the flag to edit the file? [y/N] "
         fi
-        if [ "$immutable_flag" = i ]; then
-            echo "WARNING: $1 has the immutable flag."
-            if [ -d "$1" ]; then
-                printf "Temporarily remove the flag to create a file in the directory? [y/N] "
-            else
-                printf "Temporarily remove the flag to edit the file? [y/N] "
-            fi
-            ask_immutable_response=""
-            read -r ask_immutable_response
-            case "$ask_immutable_response" in
-                y*|Y*) true ;;
-                *) false ;;
-            esac
-        else
-            false
-        fi
+        ask_immutable_response=""
+        read -r ask_immutable_response
+        case "$ask_immutable_response" in
+            y*|Y*) true ;;
+            *) false ;;
+        esac
     }
 
     # If the file does not exist, ensure the directory exists and is writable.
@@ -184,11 +180,14 @@ script='\
             if readonly_filesystem "$directory"; then
                 echo "run0edit: $directory is on a read-only filesystem."
                 exit 1
-            fi
-            if ask_immutable "$directory"; then
-                edit_immutable="yes"
-            fi
-            if [ "$edit_immutable" = "no" ]; then
+            elif is_immutable "$directory"; then
+                if ask_immutable "$directory"; then
+                    edit_immutable="yes"
+                else
+                    echo "run0edit: user declined to remove immutable flag; exiting."
+                    exit
+                fi
+            else
                 echo "run0edit: $directory is read-only."
                 exit 1
             fi
@@ -205,11 +204,14 @@ script='\
             if readonly_filesystem "$filename"; then
                 echo "run0edit: $filename is on a read-only filesystem."
                 exit 1
-            fi
-            if ask_immutable "$filename"; then
-                edit_immutable="yes"
-            fi
-            if [ "$edit_immutable" = "no" ]; then
+            elif is_immutable "$filename"; then
+                if ask_immutable "$filename"; then
+                    edit_immutable="yes"
+                else
+                    echo "run0edit: user declined to remove immutable flag; exiting."
+                    exit
+                fi
+            else
                 echo "run0edit: $filename is read-only."
                 exit 1
             fi
@@ -230,14 +232,19 @@ script='\
     # if this is a new file that is non-empty, copy temp file to target.
     if [ -f "$filename" ]; then
         if ! cmp -s -- "$tmpfile" "$filename"; then
-            [ "$edit_immutable" = "yes" ] && chattr -i -- "$filename"
-            set +e
-            cp -- "$tmpfile" "$filename"
-            cp_exit_status="$?"
-            set -e
             if [ "$edit_immutable" = "yes" ]; then
+                chattr -i -- "$filename"
+                set +e
+                cp -- "$tmpfile" "$filename"
+                cp_exit_status="$?"
+                set -e
                 chattr +i -- "$filename"
                 echo "File edited and immutable flag reapplied."
+            else
+                set +e
+                cp -- "$tmpfile" "$filename"
+                cp_exit_status="$?"
+                set -e
             fi
             if [ "$cp_exit_status" != 0 ]; then
                 echo "run0edit: unable to write temporary file at $tmpfile to $filename"
@@ -252,15 +259,21 @@ script='\
         fi
     else
         if [ -s "$tmpfile" ]; then
-            [ "$edit_immutable" = "yes" ] && chattr -i -- "$directory"
-            touch -- "$filename"
-            set +e
-            cp -- "$tmpfile" "$filename"
-            cp_exit_status="$?"
-            set -e
             if [ "$edit_immutable" = "yes" ]; then
+                chattr -i -- "$directory"
+                touch -- "$filename"
+                set +e
+                cp -- "$tmpfile" "$filename"
+                cp_exit_status="$?"
+                set -e
                 chattr +i -- "$directory"
                 echo "File created and immutable flag reapplied to directory."
+            else
+                touch -- "$filename"
+                set +e
+                cp -- "$tmpfile" "$filename"
+                cp_exit_status="$?"
+                set -e
             fi
             if [ "$cp_exit_status" != 0 ]; then
                 echo "run0edit: unable to write temporary file at $tmpfile to $filename"

--- a/files/system/usr/bin/run0edit
+++ b/files/system/usr/bin/run0edit
@@ -19,7 +19,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-readonly version=0.4.0-secureblue
+readonly version=0.4.1-secureblue
 
 # Set pipefail if it's supported by the shell, disregard if unsupported.
 # shellcheck disable=SC3040
@@ -109,13 +109,25 @@ elif [ -f '/usr/bin/nano' ] && [ -x '/usr/bin/nano' ]; then
 elif [ -f '/usr/bin/vi' ] && [ -x '/usr/bin/vi' ]; then
     editor='/usr/bin/vi'
 else
-    echo "Editor not found. Please install either nano or vi, or write the path to" >&2
-    echo "the text editor of your choice to /etc/run0edit/editor.conf" >&2
+    echo 'Editor not found. Please install either nano or vi, or write the path to' >&2
+    echo 'the text editor of your choice to /etc/run0edit/editor.conf' >&2
     exit 1
 fi
 
+readonly_filesystem() {
+    if [ -r "$1" ] && command -pv findmnt >/dev/null; then
+        command -p findmnt -nru -o OPTIONS --target "$1" | tr ',' '\n' | grep -q '^ro$'
+    else
+        false
+    fi
+}
+
 # Create a temporary file with a random suffix appended to the filename.
 directory=$(dirname -- "$filename")
+if readonly_filesystem "$filename" || readonly_filesystem "$directory"; then
+    echo "run0edit: $filename is on a read-only filesystem." >&2
+    exit 1
+fi
 trunc_filename=$(basename -- "$filename" | head -c 64)
 temp_filename=$(mktemp --tmpdir -- "${trunc_filename}.XXXXXXXXXX")
 
@@ -128,19 +140,32 @@ script='\
     filename="$1"
     tmpfile="$2"
     editor="$3"
-    edit_immutable=no
+    edit_immutable="no"
+
+    readonly_filesystem() {
+        if command -v findmnt >/dev/null; then
+            findmnt -nru -o OPTIONS --target "$1" | tr "," "\n" | grep -q "^ro\$"
+        else
+            false
+        fi
+    }
 
     ask_immutable() {
-        if command -pv lsattr > /dev/null; then
-            immutable_flag=$(lsattr -- "$1" 2>/dev/null | cut -d " " -f1 | tr -d "-" || echo "")
+        if command -v lsattr >/dev/null; then
+            immutable_flag=$(lsattr -d -- "$1" 2>/dev/null | cut -d " " -f1 | tr -d "-" || echo "")
         else
             immutable_flag=""
         fi
         if [ "$immutable_flag" = i ]; then
             echo "WARNING: $1 has the immutable flag."
-            printf "Temporarily remove the flag to edit the file? [y/N] "
-            read -r edit_immutable
-            case "$edit_immutable" in
+            if [ -d "$1" ]; then
+                printf "Temporarily remove the flag to create a file in the directory? [y/N] "
+            else
+                printf "Temporarily remove the flag to edit the file? [y/N] "
+            fi
+            ask_immutable_response=""
+            read -r ask_immutable_response
+            case "$ask_immutable_response" in
                 y*|Y*) true ;;
                 *) false ;;
             esac
@@ -156,8 +181,17 @@ script='\
             echo "run0edit: invalid argument: directory does not exist"
             exit 1
         elif [ ! -w "$directory" ]; then
-            echo "run0edit: $directory is read-only."
-            exit 1
+            if readonly_filesystem "$directory"; then
+                echo "run0edit: $directory is on a read-only filesystem."
+                exit 1
+            fi
+            if ask_immutable "$directory"; then
+                edit_immutable="yes"
+            fi
+            if [ "$edit_immutable" = "no" ]; then
+                echo "run0edit: $directory is read-only."
+                exit 1
+            fi
         fi
     fi
 
@@ -168,10 +202,14 @@ script='\
             echo "run0edit: invalid argument: not a regular file"
             exit 1
         elif [ ! -w "$filename" ]; then
-            if ask_immutable "$filename"; then
-                edit_immutable=yes
+            if readonly_filesystem "$filename"; then
+                echo "run0edit: $filename is on a read-only filesystem."
+                exit 1
             fi
-            if [ "$edit_immutable" != yes ]; then
+            if ask_immutable "$filename"; then
+                edit_immutable="yes"
+            fi
+            if [ "$edit_immutable" = "no" ]; then
                 echo "run0edit: $filename is read-only."
                 exit 1
             fi
@@ -192,17 +230,19 @@ script='\
     # if this is a new file that is non-empty, copy temp file to target.
     if [ -f "$filename" ]; then
         if ! cmp -s -- "$tmpfile" "$filename"; then
-            [ "$edit_immutable" = yes ] && chattr -i -- "$filename"
+            [ "$edit_immutable" = "yes" ] && chattr -i -- "$filename"
+            set +e
             cp -- "$tmpfile" "$filename"
             cp_exit_status="$?"
-            if [ "$edit_immutable" = yes ]; then
+            set -e
+            if [ "$edit_immutable" = "yes" ]; then
                 chattr +i -- "$filename"
                 echo "File edited and immutable flag reapplied."
             fi
             if [ "$cp_exit_status" != 0 ]; then
                 echo "run0edit: unable to write temporary file at $tmpfile to $filename"
                 exit 1
-            elif [ "$edit_immutable" != yes ] && ! cmp -s -- "$tmpfile" "$filename"; then
+            elif [ "$edit_immutable" = "yes" ] && ! cmp -s -- "$tmpfile" "$filename"; then
                 echo "WARNING: contents of $filename does not match contents of edited tempfile."
                 echo "File contents may be corrupted!"
                 exit 1
@@ -212,9 +252,22 @@ script='\
         fi
     else
         if [ -s "$tmpfile" ]; then
+            [ "$edit_immutable" = "yes" ] && chattr -i -- "$directory"
             touch -- "$filename"
-            if ! cp -- "$tmpfile" "$filename"; then
+            set +e
+            cp -- "$tmpfile" "$filename"
+            cp_exit_status="$?"
+            set -e
+            if [ "$edit_immutable" = "yes" ]; then
+                chattr +i -- "$directory"
+                echo "File created and immutable flag reapplied to directory."
+            fi
+            if [ "$cp_exit_status" != 0 ]; then
                 echo "run0edit: unable to write temporary file at $tmpfile to $filename"
+                exit 1
+            elif [ "$edit_immutable" = "yes" ] && ! cmp -s -- "$tmpfile" "$filename"; then
+                echo "WARNING: contents of $filename does not match contents of tempfile."
+                echo "File contents may be corrupted!"
                 exit 1
             fi
         else

--- a/files/system/usr/bin/run0edit
+++ b/files/system/usr/bin/run0edit
@@ -115,11 +115,7 @@ else
 fi
 
 readonly_filesystem() {
-    if [ -r "$1" ] && command -pv findmnt >/dev/null; then
-        command -p findmnt -nru -o OPTIONS --target "$1" | tr ',' '\n' | grep -q '^ro$'
-    else
-        false
-    fi
+    findmnt -nru -o OPTIONS --target "$1" 2>/dev/null | tr ',' '\n' | grep -q '^ro$'
 }
 
 # Create a temporary file with a random suffix appended to the filename.
@@ -145,11 +141,7 @@ readonly tmpfile="$2"
 readonly editor="$3"
 
 readonly_filesystem() {
-    if command -v findmnt >/dev/null; then
-        findmnt -nru -o OPTIONS --target "$1" | tr ',' '\n' | grep -q '^ro$'
-    else
-        false
-    fi
+    findmnt -nru -o OPTIONS --target "$1" 2>/dev/null | tr ',' '\n' | grep -q '^ro$'
 }
 
 is_immutable() {
@@ -195,19 +187,15 @@ copy_to_dest() {
     readonly edit_immutable="$2"
     if [ "$edit_immutable" = 'yes' ]; then
         chattr -i -- "$chattr_target_path"
-        touch -- "$filename"
-        set +e
-        cp -- "$tmpfile" "$filename"
-        cp_exit_status="$?"
-        set -e
+    fi
+    touch -- "$filename"
+    set +e
+    cp -- "$tmpfile" "$filename"
+    cp_exit_status="$?"
+    set -e
+    if [ "$edit_immutable" = 'yes' ]; then
         chattr +i -- "$chattr_target_path"
         echo 'Immutable flag reapplied.'
-    else
-        touch -- "$filename"
-        set +e
-        cp -- "$tmpfile" "$filename"
-        cp_exit_status="$?"
-        set -e
     fi
     if [ "$cp_exit_status" != 0 ]; then
         echo "run0edit: unable to write temporary file at $tmpfile to $filename"

--- a/files/system/usr/bin/run0edit
+++ b/files/system/usr/bin/run0edit
@@ -1,7 +1,6 @@
 #!/bin/sh
 # ------------------------------------------------------------------------------
 # run0edit - edit a single file as root.
-# version 0.3.3-sb
 #
 # Please report issues at: https://github.com/HastD/run0edit/issues
 #
@@ -20,6 +19,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+readonly version=0.4.0-secureblue
+
 # Set pipefail if it's supported by the shell, disregard if unsupported.
 # shellcheck disable=SC3040
 ( set -o pipefail 2> /dev/null ) && set -o pipefail
@@ -30,29 +31,72 @@ set -eu
 # shellcheck disable=SC2016
 PATH=$(command -p env -i sh -c 'echo "$PATH"')
 
-if [ "$#" = 0 ] || [ "$1" = '--help' ]; then
-    echo 'run0edit allows a permitted user to edit a file as root.'
-    echo 'Usage: run0edit "path/to/file"'
-    echo 'To use another text editor, write the path to your text editor of choice to'
-    echo '    /etc/run0edit/editor.conf'
-    exit
-elif [ "$(id -u)" = 0 ]; then
-    echo 'run0edit should not be run as root.' >&2
+print_usage() {
+    cat <<-'EOF'
+run0edit allows a permitted user to edit a file as root.
+
+Usage: run0edit [--] FILE
+Usage: run0edit --help | -h | --version | -v
+
+To use another text editor, write the path to your text editor of choice to
+    /etc/run0edit/editor.conf
+EOF
+}
+
+filename=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -v|--version)
+            echo "run0edit $version"
+            exit
+            ;;
+        -h|--help)
+            print_usage
+            exit
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            echo "run0edit: unknown option $1"
+            exit 1
+            ;;
+        *)
+            if [ -n "$filename" ]; then
+                echo 'Error: too many positional arguments.' >&2
+                exit 1
+            fi
+            filename="$1"
+            shift
+            ;;
+    esac
+done
+
+# Handle positional arguments after --
+while [ "$#" -gt 0 ]; do
+    if [ -n "$filename" ]; then
+        echo 'run0edit: too many positional arguments.' >&2
+        echo 'Run with --help for usage info.' >&2
+        exit 1
+    fi
+    filename="$1"
+    shift
+done
+
+if [ -z "$filename" ]; then
+    echo 'run0edit: missing argument' >&2
     exit 1
-elif [ "$#" -ne 1 ]; then
-    echo 'Error: too many arguments.' >&2
-    echo 'run0edit allows a permitted user to edit a file as root.'
-    echo 'Usage: run0edit "path/to/file"'
-    exit 1
-elif [ -w "$1" ]; then
+elif [ -w "$filename" ]; then
     echo 'File is writable by the current user; run0edit is unnecessary.' >&2
     exit 1
 fi
 
 # Determine text editor to use.
 editor=''
-etc_conf_path='/etc/run0edit/editor.conf'
-usr_conf_path='/usr/etc/run0edit/editor.conf'
+readonly etc_conf_path='/etc/run0edit/editor.conf'
+readonly usr_conf_path='/usr/etc/run0edit/editor.conf'
 if [ -f "$etc_conf_path" ] && [ -r "$etc_conf_path" ]; then
     editor="$(cat "$etc_conf_path")"
 elif [ -f "$usr_conf_path" ] && [ -r "$usr_conf_path" ]; then
@@ -71,21 +115,43 @@ else
 fi
 
 # Create a temporary file with a random suffix appended to the filename.
-filename="$1"
-directory=$(dirname "$filename")
-trunc_filename=$(basename "$filename" | head -c 64)
-temp_filename=$(mktemp --tmpdir "${trunc_filename}.XXXXXXXXXX")
+directory=$(dirname -- "$filename")
+trunc_filename=$(basename -- "$filename" | head -c 64)
+temp_filename=$(mktemp --tmpdir -- "${trunc_filename}.XXXXXXXXXX")
 
 # Inner script to be run with elevated privileges:
 # shellcheck disable=SC2016
 script='\
+    ( set -o pipefail 2> /dev/null ) && set -o pipefail
+    set -eu
+    PATH=$(command -p env -i sh -c "echo \"\$PATH\"")
     filename="$1"
     tmpfile="$2"
     editor="$3"
+    edit_immutable=no
+
+    ask_immutable() {
+        if command -pv lsattr > /dev/null; then
+            immutable_flag=$(lsattr -- "$1" | cut -d " " -f1 | tr -d "-")
+        else
+            immutable_flag=""
+        fi
+        if [ "$immutable_flag" = i ]; then
+            echo "WARNING: $1 has the immutable flag."
+            printf "Temporarily remove the flag to edit the file? [y/N] "
+            read -r edit_immutable
+            case "$edit_immutable" in
+                y*|Y*) true ;;
+                *) false ;;
+            esac
+        else
+            false
+        fi
+    }
 
     # If the file does not exist, ensure the directory exists and is writable.
     if [ ! -e "$filename" ]; then
-        directory="$(dirname "$filename")"
+        directory="$(dirname -- "$filename")"
         if [ ! -d "$directory" ]; then
             echo "run0edit: invalid argument: directory does not exist"
             exit 1
@@ -102,16 +168,22 @@ script='\
             echo "run0edit: invalid argument: not a regular file"
             exit 1
         elif [ ! -w "$filename" ]; then
-            echo "run0edit: $filename is read-only."
-            exit 1
-        elif ! cp "$filename" "$tmpfile"; then
+            if ask_immutable "$filename"; then
+                edit_immutable=yes
+            fi
+            if [ "$edit_immutable" != yes ]; then
+                echo "run0edit: $filename is read-only."
+                exit 1
+            fi
+        fi
+        if ! cp -- "$filename" "$tmpfile"; then
             echo "run0edit: failed to copy $filename to temporary file at $tmpfile"
             exit 1
         fi
     fi
 
     # Attempt to edit the temp file as the original user.
-    if ! run0 --user="$SUDO_UID" "$editor" "$tmpfile"; then
+    if ! run0 --user="$SUDO_UID" -- "$editor" "$tmpfile"; then
         echo "run0edit: failed to edit temporary file at $tmpfile"
         exit 1
     fi
@@ -119,9 +191,20 @@ script='\
     # If the target file exists and has been modified in the temp file, or
     # if this is a new file that is non-empty, copy temp file to target.
     if [ -f "$filename" ]; then
-        if ! cmp -s "$tmpfile" "$filename"; then
-            if ! cp "$tmpfile" "$filename"; then
+        if ! cmp -s -- "$tmpfile" "$filename"; then
+            [ "$edit_immutable" = yes ] && chattr -i -- "$filename"
+            cp -- "$tmpfile" "$filename"
+            cp_exit_status="$?"
+            if [ "$edit_immutable" = yes ]; then
+                chattr +i -- "$filename"
+                echo "File edited and immutable flag reapplied."
+            fi
+            if [ "$cp_exit_status" != 0 ]; then
                 echo "run0edit: unable to write temporary file at $tmpfile to $filename"
+                exit 1
+            elif [ "$edit_immutable" != yes ] && ! cmp -s -- "$tmpfile" "$filename"; then
+                echo "WARNING: contents of $filename does not match contents of edited tempfile."
+                echo "File contents may be corrupted!"
                 exit 1
             fi
         else
@@ -129,8 +212,8 @@ script='\
         fi
     else
         if [ -s "$tmpfile" ]; then
-            touch "$filename"
-            if ! cp "$tmpfile" "$filename"; then
+            touch -- "$filename"
+            if ! cp -- "$tmpfile" "$filename"; then
                 echo "run0edit: unable to write temporary file at $tmpfile to $filename"
                 exit 1
             fi
@@ -145,13 +228,13 @@ if [ -e "$filename" ]; then
 else
     writable_path="$directory"
 fi
-escaped_path=$(realpath -m "$writable_path" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+escaped_path=$(realpath -m -- "$writable_path" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
 escaped_temp_path=$(echo "$temp_filename" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
 
 set +e
-run0 \
+SYSTEMD_ADJUST_TERMINAL_TITLE=false run0 \
     --description="run0edit \"$filename\"" \
-    --property="CapabilityBoundingSet=CAP_DAC_OVERRIDE" \
+    --property="CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_FOWNER CAP_LINUX_IMMUTABLE" \
     --property="DevicePolicy=closed" \
     --property="LockPersonality=yes" \
     --property="MemoryDenyWriteExecute=yes" \
@@ -186,17 +269,17 @@ status_code="$?"
 set -e
 case "$status_code" in
     0)
-        rm -f "$temp_filename"
+        rm -f -- "$temp_filename"
         ;;
     226)
         echo "run0edit: invalid argument: directory does not exist" >&2
-        rm -f "$temp_filename"
+        rm -f -- "$temp_filename"
         exit 1
         ;;
     *)
         # Clean up empty temporary file, but leave it if it's non-empty.
         if [ ! -s "$temp_filename" ]; then
-            rm -f "$temp_filename"
+            rm -f -- "$temp_filename"
         fi
         exit "$status_code"
         ;;

--- a/files/system/usr/bin/run0edit
+++ b/files/system/usr/bin/run0edit
@@ -140,10 +140,9 @@ script=$(cat <<-'END_OF_INNER_SCRIPT'
 set -eu
 # shellcheck disable=SC2016
 PATH=$(command -p env -i sh -c 'echo "$PATH"')
-filename="$1"
-tmpfile="$2"
-editor="$3"
-edit_immutable='no'
+readonly filename="$1"
+readonly tmpfile="$2"
+readonly editor="$3"
 
 readonly_filesystem() {
     if command -v findmnt >/dev/null; then
@@ -173,55 +172,77 @@ ask_immutable() {
     esac
 }
 
-# If the file does not exist, ensure the directory exists and is writable.
-if [ ! -e "$filename" ]; then
+handle_readonly() {
+    handle_readonly_retval='no'
+    if readonly_filesystem "$1"; then
+        echo "run0edit: $1 is on a read-only filesystem."
+        exit 1
+    elif is_immutable "$1"; then
+        if ask_immutable "$1"; then
+            handle_readonly_retval='yes'
+        else
+            echo 'run0edit: user declined to remove immutable flag; exiting.'
+            exit
+        fi
+    else
+        echo "run0edit: $1 is read-only."
+        exit 1
+    fi
+}
+
+copy_to_dest() {
+    readonly chattr_target_path="$1"
+    readonly edit_immutable="$2"
+    if [ "$edit_immutable" = 'yes' ]; then
+        chattr -i -- "$chattr_target_path"
+        touch -- "$filename"
+        set +e
+        cp -- "$tmpfile" "$filename"
+        cp_exit_status="$?"
+        set -e
+        chattr +i -- "$chattr_target_path"
+        echo 'Immutable flag reapplied.'
+    else
+        touch -- "$filename"
+        set +e
+        cp -- "$tmpfile" "$filename"
+        cp_exit_status="$?"
+        set -e
+    fi
+    if [ "$cp_exit_status" != 0 ]; then
+        echo "run0edit: unable to write temporary file at $tmpfile to $filename"
+        exit 1
+    elif [ "$edit_immutable" = 'yes' ] && ! cmp -s -- "$tmpfile" "$filename"; then
+        echo "WARNING: contents of $filename does not match contents of edited tempfile."
+        echo 'File contents may be corrupted!'
+        exit 1
+    fi
+}
+
+immutable='no'
+if [ -e "$filename" ]; then
+    # If the file exists, ensure it is a regular file and writable, then
+    # attempt to copy it to the temp file.
+    if [ ! -f "$filename" ]; then
+        echo 'run0edit: invalid argument: not a regular file'
+        exit 1
+    elif [ ! -w "$filename" ]; then
+        handle_readonly "$filename"
+        immutable="$handle_readonly_retval"
+    fi
+    if ! cp -- "$filename" "$tmpfile"; then
+        echo "run0edit: failed to copy $filename to temporary file at $tmpfile"
+        exit 1
+    fi
+else
+    # If the file does not exist, ensure the directory exists and is writable.
     directory="$(dirname -- "$filename")"
     if [ ! -d "$directory" ]; then
         echo 'run0edit: invalid argument: directory does not exist'
         exit 1
     elif [ ! -w "$directory" ]; then
-        if readonly_filesystem "$directory"; then
-            echo "run0edit: $directory is on a read-only filesystem."
-            exit 1
-        elif is_immutable "$directory"; then
-            if ask_immutable "$directory"; then
-                edit_immutable='yes'
-            else
-                echo 'run0edit: user declined to remove immutable flag; exiting.'
-                exit
-            fi
-        else
-            echo "run0edit: $directory is read-only."
-            exit 1
-        fi
-    fi
-fi
-
-# If the file exists, ensure it is a regular file and writable, then
-# attempt to copy it to the temp file.
-if [ -e "$filename" ]; then
-    if [ ! -f "$filename" ]; then
-        echo 'run0edit: invalid argument: not a regular file'
-        exit 1
-    elif [ ! -w "$filename" ]; then
-        if readonly_filesystem "$filename"; then
-            echo "run0edit: $filename is on a read-only filesystem."
-            exit 1
-        elif is_immutable "$filename"; then
-            if ask_immutable "$filename"; then
-                edit_immutable='yes'
-            else
-                echo 'run0edit: user declined to remove immutable flag; exiting.'
-                exit
-            fi
-        else
-            echo "run0edit: $filename is read-only."
-            exit 1
-        fi
-    fi
-    if ! cp -- "$filename" "$tmpfile"; then
-        echo "run0edit: failed to copy $filename to temporary file at $tmpfile"
-        exit 1
+        handle_readonly "$directory"
+        immutable="$handle_readonly_retval"
     fi
 fi
 
@@ -235,57 +256,13 @@ fi
 # if this is a new file that is non-empty, copy temp file to target.
 if [ -f "$filename" ]; then
     if ! cmp -s -- "$tmpfile" "$filename"; then
-        if [ "$edit_immutable" = 'yes' ]; then
-            chattr -i -- "$filename"
-            set +e
-            cp -- "$tmpfile" "$filename"
-            cp_exit_status="$?"
-            set -e
-            chattr +i -- "$filename"
-            echo 'File edited and immutable flag reapplied.'
-        else
-            set +e
-            cp -- "$tmpfile" "$filename"
-            cp_exit_status="$?"
-            set -e
-        fi
-        if [ "$cp_exit_status" != 0 ]; then
-            echo "run0edit: unable to write temporary file at $tmpfile to $filename"
-            exit 1
-        elif [ "$edit_immutable" = 'yes' ] && ! cmp -s -- "$tmpfile" "$filename"; then
-            echo "WARNING: contents of $filename does not match contents of edited tempfile."
-            echo 'File contents may be corrupted!'
-            exit 1
-        fi
+        copy_to_dest "$filename" "$immutable"
     else
         echo "run0edit: $filename unchanged"
     fi
 else
     if [ -s "$tmpfile" ]; then
-        if [ "$edit_immutable" = 'yes' ]; then
-            chattr -i -- "$directory"
-            touch -- "$filename"
-            set +e
-            cp -- "$tmpfile" "$filename"
-            cp_exit_status="$?"
-            set -e
-            chattr +i -- "$directory"
-            echo 'File created and immutable flag reapplied to directory.'
-        else
-            touch -- "$filename"
-            set +e
-            cp -- "$tmpfile" "$filename"
-            cp_exit_status="$?"
-            set -e
-        fi
-        if [ "$cp_exit_status" != 0 ]; then
-            echo "run0edit: unable to write temporary file at $tmpfile to $filename"
-            exit 1
-        elif [ "$edit_immutable" = 'yes' ] && ! cmp -s -- "$tmpfile" "$filename"; then
-            echo "WARNING: contents of $filename does not match contents of tempfile."
-            echo 'File contents may be corrupted!'
-            exit 1
-        fi
+        copy_to_dest "$directory" "$immutable"
     else
         echo "run0edit: $filename not created"
     fi

--- a/files/system/usr/bin/run0edit
+++ b/files/system/usr/bin/run0edit
@@ -19,7 +19,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-readonly version=0.4.2-secureblue
+readonly version=0.4.3-secureblue
 
 # Set pipefail if it's supported by the shell, disregard if unsupported.
 # shellcheck disable=SC3040
@@ -133,160 +133,166 @@ temp_filename=$(mktemp --tmpdir -- "${trunc_filename}.XXXXXXXXXX")
 
 # Inner script to be run with elevated privileges:
 # shellcheck disable=SC2016
-script='\
-    ( set -o pipefail 2> /dev/null ) && set -o pipefail
-    set -eu
-    PATH=$(command -p env -i sh -c "echo \"\$PATH\"")
-    filename="$1"
-    tmpfile="$2"
-    editor="$3"
-    edit_immutable="no"
+script=$(cat <<-'END_OF_INNER_SCRIPT'
+#!/bin/sh
+# shellcheck disable=SC3040
+( set -o pipefail 2> /dev/null ) && set -o pipefail
+set -eu
+# shellcheck disable=SC2016
+PATH=$(command -p env -i sh -c 'echo "$PATH"')
+filename="$1"
+tmpfile="$2"
+editor="$3"
+edit_immutable='no'
 
-    readonly_filesystem() {
-        if command -v findmnt >/dev/null; then
-            findmnt -nru -o OPTIONS --target "$1" | tr "," "\n" | grep -q "^ro\$"
-        else
-            false
-        fi
-    }
-
-    is_immutable() {
-        immutable_flag=$(lsattr -d -- "$1" 2>/dev/null | cut -d " " -f1 | tr -d "-" || echo "")
-        [ "$immutable_flag" = "i" ]
-    }
-
-    ask_immutable() {
-        echo "WARNING: $1 has the immutable flag."
-        if [ -d "$1" ]; then
-            printf "Temporarily remove the flag to create a file in the directory? [y/N] "
-        else
-            printf "Temporarily remove the flag to edit the file? [y/N] "
-        fi
-        ask_immutable_response=""
-        read -r ask_immutable_response
-        case "$ask_immutable_response" in
-            y*|Y*) true ;;
-            *) false ;;
-        esac
-    }
-
-    # If the file does not exist, ensure the directory exists and is writable.
-    if [ ! -e "$filename" ]; then
-        directory="$(dirname -- "$filename")"
-        if [ ! -d "$directory" ]; then
-            echo "run0edit: invalid argument: directory does not exist"
-            exit 1
-        elif [ ! -w "$directory" ]; then
-            if readonly_filesystem "$directory"; then
-                echo "run0edit: $directory is on a read-only filesystem."
-                exit 1
-            elif is_immutable "$directory"; then
-                if ask_immutable "$directory"; then
-                    edit_immutable="yes"
-                else
-                    echo "run0edit: user declined to remove immutable flag; exiting."
-                    exit
-                fi
-            else
-                echo "run0edit: $directory is read-only."
-                exit 1
-            fi
-        fi
+readonly_filesystem() {
+    if command -v findmnt >/dev/null; then
+        findmnt -nru -o OPTIONS --target "$1" | tr ',' '\n' | grep -q '^ro$'
+    else
+        false
     fi
+}
 
-    # If the file exists, ensure it is a regular file and writable, then
-    # attempt to copy it to the temp file.
-    if [ -e "$filename" ]; then
-        if [ ! -f "$filename" ]; then
-            echo "run0edit: invalid argument: not a regular file"
+is_immutable() {
+    immutable_flag=$(lsattr -d -- "$1" 2>/dev/null | cut -d ' ' -f1 | tr -d '-' || echo '')
+    [ "$immutable_flag" = 'i' ]
+}
+
+ask_immutable() {
+    echo "WARNING: $1 has the immutable flag."
+    if [ -d "$1" ]; then
+        printf 'Temporarily remove the flag to create a file in the directory? [y/N] '
+    else
+        printf 'Temporarily remove the flag to edit the file? [y/N] '
+    fi
+    ask_immutable_response=''
+    read -r ask_immutable_response
+    case "$ask_immutable_response" in
+        y*|Y*) true ;;
+        *) false ;;
+    esac
+}
+
+# If the file does not exist, ensure the directory exists and is writable.
+if [ ! -e "$filename" ]; then
+    directory="$(dirname -- "$filename")"
+    if [ ! -d "$directory" ]; then
+        echo 'run0edit: invalid argument: directory does not exist'
+        exit 1
+    elif [ ! -w "$directory" ]; then
+        if readonly_filesystem "$directory"; then
+            echo "run0edit: $directory is on a read-only filesystem."
             exit 1
-        elif [ ! -w "$filename" ]; then
-            if readonly_filesystem "$filename"; then
-                echo "run0edit: $filename is on a read-only filesystem."
-                exit 1
-            elif is_immutable "$filename"; then
-                if ask_immutable "$filename"; then
-                    edit_immutable="yes"
-                else
-                    echo "run0edit: user declined to remove immutable flag; exiting."
-                    exit
-                fi
+        elif is_immutable "$directory"; then
+            if ask_immutable "$directory"; then
+                edit_immutable='yes'
             else
-                echo "run0edit: $filename is read-only."
-                exit 1
+                echo 'run0edit: user declined to remove immutable flag; exiting.'
+                exit
             fi
-        fi
-        if ! cp -- "$filename" "$tmpfile"; then
-            echo "run0edit: failed to copy $filename to temporary file at $tmpfile"
+        else
+            echo "run0edit: $directory is read-only."
             exit 1
         fi
     fi
+fi
 
-    # Attempt to edit the temp file as the original user.
-    if ! run0 --user="$SUDO_UID" -- "$editor" "$tmpfile"; then
-        echo "run0edit: failed to edit temporary file at $tmpfile"
+# If the file exists, ensure it is a regular file and writable, then
+# attempt to copy it to the temp file.
+if [ -e "$filename" ]; then
+    if [ ! -f "$filename" ]; then
+        echo 'run0edit: invalid argument: not a regular file'
+        exit 1
+    elif [ ! -w "$filename" ]; then
+        if readonly_filesystem "$filename"; then
+            echo "run0edit: $filename is on a read-only filesystem."
+            exit 1
+        elif is_immutable "$filename"; then
+            if ask_immutable "$filename"; then
+                edit_immutable='yes'
+            else
+                echo 'run0edit: user declined to remove immutable flag; exiting.'
+                exit
+            fi
+        else
+            echo "run0edit: $filename is read-only."
+            exit 1
+        fi
+    fi
+    if ! cp -- "$filename" "$tmpfile"; then
+        echo "run0edit: failed to copy $filename to temporary file at $tmpfile"
         exit 1
     fi
+fi
 
-    # If the target file exists and has been modified in the temp file, or
-    # if this is a new file that is non-empty, copy temp file to target.
-    if [ -f "$filename" ]; then
-        if ! cmp -s -- "$tmpfile" "$filename"; then
-            if [ "$edit_immutable" = "yes" ]; then
-                chattr -i -- "$filename"
-                set +e
-                cp -- "$tmpfile" "$filename"
-                cp_exit_status="$?"
-                set -e
-                chattr +i -- "$filename"
-                echo "File edited and immutable flag reapplied."
-            else
-                set +e
-                cp -- "$tmpfile" "$filename"
-                cp_exit_status="$?"
-                set -e
-            fi
-            if [ "$cp_exit_status" != 0 ]; then
-                echo "run0edit: unable to write temporary file at $tmpfile to $filename"
-                exit 1
-            elif [ "$edit_immutable" = "yes" ] && ! cmp -s -- "$tmpfile" "$filename"; then
-                echo "WARNING: contents of $filename does not match contents of edited tempfile."
-                echo "File contents may be corrupted!"
-                exit 1
-            fi
+# Attempt to edit the temp file as the original user.
+if ! run0 --user="$SUDO_UID" -- "$editor" "$tmpfile"; then
+    echo "run0edit: failed to edit temporary file at $tmpfile"
+    exit 1
+fi
+
+# If the target file exists and has been modified in the temp file, or
+# if this is a new file that is non-empty, copy temp file to target.
+if [ -f "$filename" ]; then
+    if ! cmp -s -- "$tmpfile" "$filename"; then
+        if [ "$edit_immutable" = 'yes' ]; then
+            chattr -i -- "$filename"
+            set +e
+            cp -- "$tmpfile" "$filename"
+            cp_exit_status="$?"
+            set -e
+            chattr +i -- "$filename"
+            echo 'File edited and immutable flag reapplied.'
         else
-            echo "run0edit: $filename unchanged"
+            set +e
+            cp -- "$tmpfile" "$filename"
+            cp_exit_status="$?"
+            set -e
+        fi
+        if [ "$cp_exit_status" != 0 ]; then
+            echo "run0edit: unable to write temporary file at $tmpfile to $filename"
+            exit 1
+        elif [ "$edit_immutable" = 'yes' ] && ! cmp -s -- "$tmpfile" "$filename"; then
+            echo "WARNING: contents of $filename does not match contents of edited tempfile."
+            echo 'File contents may be corrupted!'
+            exit 1
         fi
     else
-        if [ -s "$tmpfile" ]; then
-            if [ "$edit_immutable" = "yes" ]; then
-                chattr -i -- "$directory"
-                touch -- "$filename"
-                set +e
-                cp -- "$tmpfile" "$filename"
-                cp_exit_status="$?"
-                set -e
-                chattr +i -- "$directory"
-                echo "File created and immutable flag reapplied to directory."
-            else
-                touch -- "$filename"
-                set +e
-                cp -- "$tmpfile" "$filename"
-                cp_exit_status="$?"
-                set -e
-            fi
-            if [ "$cp_exit_status" != 0 ]; then
-                echo "run0edit: unable to write temporary file at $tmpfile to $filename"
-                exit 1
-            elif [ "$edit_immutable" = "yes" ] && ! cmp -s -- "$tmpfile" "$filename"; then
-                echo "WARNING: contents of $filename does not match contents of tempfile."
-                echo "File contents may be corrupted!"
-                exit 1
-            fi
+        echo "run0edit: $filename unchanged"
+    fi
+else
+    if [ -s "$tmpfile" ]; then
+        if [ "$edit_immutable" = 'yes' ]; then
+            chattr -i -- "$directory"
+            touch -- "$filename"
+            set +e
+            cp -- "$tmpfile" "$filename"
+            cp_exit_status="$?"
+            set -e
+            chattr +i -- "$directory"
+            echo 'File created and immutable flag reapplied to directory.'
         else
-            echo "run0edit: $filename not created"
+            touch -- "$filename"
+            set +e
+            cp -- "$tmpfile" "$filename"
+            cp_exit_status="$?"
+            set -e
         fi
-    fi'
+        if [ "$cp_exit_status" != 0 ]; then
+            echo "run0edit: unable to write temporary file at $tmpfile to $filename"
+            exit 1
+        elif [ "$edit_immutable" = 'yes' ] && ! cmp -s -- "$tmpfile" "$filename"; then
+            echo "WARNING: contents of $filename does not match contents of tempfile."
+            echo 'File contents may be corrupted!'
+            exit 1
+        fi
+    else
+        echo "run0edit: $filename not created"
+    fi
+fi
+
+END_OF_INNER_SCRIPT
+)
 
 # Escape backslashes and double-quotes in paths to be passed to ReadWritePaths.
 if [ -e "$filename" ]; then


### PR DESCRIPTION
The new version of [`run0edit`](https://github.com/HastD/run0edit) checks for the immutable flag on the file to be edited (or the directory if the file doesn't exist), and if so, asks the user whether to temporarily remove it to edit/create the file. This makes editing immutable files less error-prone, as the immutable flag is only removed for the brief window necessary to overwrite the file contents and reapplied immediately afterward; the script also compares the file contents after the immutable flag has been reapplied to ensure it was not modified by another program during that window.

There are also miscellaneous improvements to the script's argument handling, which now parses arguments in a more conventional way and accepts both `--help` and `--version` arguments, and the inner privileged script has been refactored to reduce code duplication.