### PR TITLE
chore: remove unused packages

### DIFF
--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -30,9 +30,11 @@ remove:
   - firefox
   - firefox-langpacks
   - fuse
+  - passim
   - fedora-chromium-config
   - fedora-flathub-remote
-  - passim
+  - fedora-third-party
+  - fedora-workstation-repositories
 
 
 


### PR DESCRIPTION
`fedora-third-party` installs a service that pops up asking users to enable rpmfusion, which we don't ship with. This is a negative UX.

`fedora-workstation-repositories` installs repos we don't use, like rpmfusion, chrome, pycharm