### PR TITLE
chore: remove net.ipv6.conf.*.accept_ra = 0

### DIFF
--- a/files/system/etc/sysctl.d/60-hardening.conf
+++ b/files/system/etc/sysctl.d/60-hardening.conf
@@ -32,7 +32,6 @@ net.ipv6.conf.*.accept_redirects = 0
 # https://docs.kernel.org/networking/ip-sysctl.html
 net.ipv4.conf.*.accept_source_route = 0
 net.ipv6.conf.*.accept_source_route = 0
-net.ipv6.conf.*.accept_ra = 0
 net.ipv4.tcp_sack=0
 net.ipv4.tcp_dsack=0
 net.ipv4.tcp_fack=0


### PR DESCRIPTION
This discriminates against IPv6 - IPv4 still has DHCP as usual anyways. 

It makes more sense to let sysadmins decide whether to use DHCP/SLAAC or static routes through their network daemon.