### PR TITLE
chore: remove net.ipv4.tcp_fack=0

### DIFF
--- a/files/system/etc/sysctl.d/60-hardening.conf
+++ b/files/system/etc/sysctl.d/60-hardening.conf
@@ -35,7 +35,6 @@ net.ipv6.conf.*.accept_source_route = 0
 net.ipv6.conf.*.accept_ra = 0
 net.ipv4.tcp_sack=0
 net.ipv4.tcp_dsack=0
-net.ipv4.tcp_fack=0
 
 # Enable ipv6 privacy extension
 # https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt


### PR DESCRIPTION
This option no longer does anything in modern kernels