### PR TITLE
chore: remove stray 'the' from install-vpn ujust

### DIFF
--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -405,7 +405,7 @@ install-vpn:
                 REPO_NAME="mullvad"
 
                 if util_checkpackage "$PACKAGE_NAME"; then
-                    echo 'Error: The Mullvad VPN is already installed.'
+                    echo 'Error: Mullvad VPN is already installed.'
                     echo 'Aborting...'
                     exit 1
                 fi


### PR DESCRIPTION
This article doesn't really fit here and makes it sound weird.
Also neither IVPN nor Proton VPN have this for their respective "already installed" text.