### PR TITLE
feat: lock session when AC power is unplugged

### DIFF
--- a/files/scripts/lockonacdisconnect.sh
+++ b/files/scripts/lockonacdisconnect.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -oue pipefail
+
+# Locks all user sessions when AC is unplugged
+loginctl lock-sessions

--- a/files/system/etc/udev/rules.d/98-lock-on-power-remove.rules
+++ b/files/system/etc/udev/rules.d/98-lock-on-power-remove.rules
@@ -1,0 +1,2 @@
+# Lock sessions when AC power is unplugged
+ACTION=="change", SUBSYSTEM=="power_supply", ENV{POWER_SUPPLY_ONLINE}=="0", RUN+="/usr/libexec/secureblue/lockonacdisconnect.sh"

--- a/recipes/common/desktop-scripts.yml
+++ b/recipes/common/desktop-scripts.yml
@@ -10,3 +10,4 @@ scripts:
   - disablenfsdaemons.sh
   - disablesssd.sh
   - disableunconfinedrootfulservices.sh
+  - lockonacdisconnect.sh


### PR DESCRIPTION
Adds a udev rule that locks the session when AC power is unplugged.
Tested on Fedora, works fine.
Inspired by this post:
> “When using a laptop connected to power most of the time, you may want it to power off once it gets disconnected, this can be really useful if you use it in a public area like a bar or a train. The idea is to protect the laptop if it gets stolen while in use and unlocked.”  
> — [Solene'% : How to trigger a command on Linux when disconnected from power](https://dataswamp.org/~solene/2025-05-31-linux-killswitch-on-power-disconnect.html)