### PR TITLE
ci: add workflow to run Ruff on Python code

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,9 +1,5 @@
 name: ruff
 on:
-  push:
-    paths:
-      - '**.py'
-      - 'ruff.toml'
   pull_request:
     paths:
       - '**.py'

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,18 @@
+name: ruff
+on: [push, pull_request]
+jobs:
+  ruff:
+    name: Ruff (Python linter)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - name: Install Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+      - name: Run Ruff
+        run: ruff check --output-format=github .

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,9 +1,17 @@
 name: ruff
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - '**.py'
+      - 'ruff.toml'
+  pull_request:
+    paths:
+      - '**.py'
+      - 'ruff.toml'
 jobs:
   ruff:
     name: Ruff (Python linter)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Install Python
@@ -16,3 +24,5 @@ jobs:
           pip install ruff
       - name: Run Ruff
         run: ruff check --output-format=github .
+      - name: Check code formatting
+        run: ruff format --diff

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -876,10 +876,15 @@ def get_legend(width: int = 80) -> str:
     }
     for status, desc in flatpak_status_descriptions.items():
         legend += format_legend_entry(status, desc, width)
-    legend += "\n" + textwrap.fill(textwrap.dedent("""
-        Note that some flatpak apps require broad permissions to function. Permissions being
-        flagged by the audit script do not necessarily mean that action should be taken.
-    """.strip("\n")), width=width)
+    legend += "\n" + textwrap.fill(
+        textwrap.dedent(
+            """\
+            Note that some flatpak apps require broad permissions to function. Permissions being
+            flagged by the audit script do not necessarily mean that action should be taken.
+            """
+        ),
+        width=width,
+    )
     return legend
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,1 @@
+line-length = 100


### PR DESCRIPTION
This workflow runs [Ruff](https://docs.astral.sh/ruff/), a very fast Python linter, on all Python code in the repo anytime a pull request modifies Python files. This can catch a wide variety of coding errors; while it'd still be good to add unit tests as discussed in #1093, this makes partial progress on the same issue.

The added `ruff.toml` file configures Ruff's settings; currently the only change from the default is to set the maximum line length to 100 when formatting, which was already being used for the audit script. This helps ensure a consistent formatting standard for Python code. (The small change made to the audit script is such a formatting change, plus removing an unnecessary `.strip()`—I did check that the output is the same.)

I've also made `ruff format --diff` part of the workflow so it fails if any Python code hasn't been formatted how Ruff would format it.