### PR TITLE
feat(audit): merge kargs checks into single report

### DIFF
--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -145,7 +145,7 @@ def audit_kargs():
     rec = None
 
     kargs_current = frozenset(command_stdout("rpm-ostree", "kargs").split())
-    kargs_expected = [
+    kargs_expected = (
         "init_on_alloc=1",
         "init_on_free=1",
         "intel_iommu=on",
@@ -168,11 +168,11 @@ def audit_kargs():
         "spec_store_bypass_disable=on",
         "spectre_v2=on",
         "vsyscall=none",
-    ]
-    kargs_missing = [karg for karg in kargs_expected if karg not in kargs_current]
-    for karg in kargs_missing:
-        status = status.downgrade_to(FAIL)
-        warnings.append(f"Missing kernel argument: {karg}")
+    )
+    for karg in kargs_expected:
+        if karg not in kargs_current:
+            status = status.downgrade_to(FAIL)
+            warnings.append(f"Missing kernel argument: {karg}")
 
     karg_32bit = "ia32_emulation=0"
     if karg_32bit not in kargs_current:
@@ -184,17 +184,17 @@ def audit_kargs():
         status = status.downgrade_to(WARN)
         warnings.append(f"Missing kernel argument: {karg_nosmt} (force-disable SMT)")
 
-    kargs_expected_warn = [
+    kargs_expected_unstable = (
         "amd_iommu=force_isolation",
         "debugfs=off",
         "efi=disable_early_pci_dma",
         "gather_data_sampling=force",
         "oops=panic",
-    ]
-    kargs_missing_warn = [karg for karg in kargs_expected_warn if karg not in kargs_current]
-    for karg in kargs_missing_warn:
-        status = status.downgrade_to(WARN)
-        warnings.append(f"Missing kernel argument (unstable): {karg}")
+    )
+    for karg in kargs_expected_unstable:
+        if karg not in kargs_current:
+            status = status.downgrade_to(WARN)
+            warnings.append(f"Missing kernel argument (unstable): {karg}")
 
     if status != PASS:
         rec = """To set hardened kernel arguments, run:

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -144,7 +144,7 @@ def audit_kargs():
     warnings = []
     rec = None
 
-    kargs_current = command_stdout("rpm-ostree", "kargs").split()
+    kargs_current = frozenset(command_stdout("rpm-ostree", "kargs").split())
     kargs_expected = [
         "init_on_alloc=1",
         "init_on_free=1",

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -138,9 +138,12 @@ class Image(enum.Enum):
 
 
 @audit
-@categorize("kargs")
 def audit_kargs():
     """Check for hardened kernel arguments."""
+    status = PASS
+    warnings = []
+    rec = None
+
     kargs_current = command_stdout("rpm-ostree", "kargs").split()
     kargs_expected = [
         "init_on_alloc=1",
@@ -166,21 +169,38 @@ def audit_kargs():
         "spectre_v2=on",
         "vsyscall=none",
     ]
-    for karg in kargs_expected:
-        status = PASS if karg in kargs_current else FAIL
-        yield Report(f"Checking for {karg} karg", status)
+    kargs_missing = [karg for karg in kargs_expected if karg not in kargs_current]
+    for karg in kargs_missing:
+        status = status.downgrade_to(FAIL)
+        warnings.append(f"Missing kernel argument: {karg}")
+
+    karg_32bit = "ia32_emulation=0"
+    if karg_32bit not in kargs_current:
+        status = status.downgrade_to(WARN)
+        warnings.append(f"Missing kernel argument: {karg_32bit} (32-bit support)")
+
+    karg_nosmt = "nosmt=force"
+    if karg_nosmt not in kargs_current:
+        status = status.downgrade_to(WARN)
+        warnings.append(f"Missing kernel argument: {karg_nosmt} (force-disable SMT)")
+
     kargs_expected_warn = [
         "amd_iommu=force_isolation",
         "debugfs=off",
         "efi=disable_early_pci_dma",
         "gather_data_sampling=force",
-        "ia32_emulation=0",
-        "nosmt=force",
         "oops=panic",
     ]
-    for karg in kargs_expected_warn:
-        status = PASS if karg in kargs_current else WARN
-        yield Report(f"Checking for {karg} karg", status)
+    kargs_missing_warn = [karg for karg in kargs_expected_warn if karg not in kargs_current]
+    for karg in kargs_missing_warn:
+        status = status.downgrade_to(WARN)
+        warnings.append(f"Missing kernel argument (unstable): {karg}")
+
+    if status != PASS:
+        rec = """To set hardened kernel arguments, run:
+            $ ujust set-kargs-hardening"""
+
+    yield Report("Checking for hardened kernel arguments", status, warnings=warnings, recs=rec)
 
 
 def validate_sysctl(sysctl: str, actual: str, expected: str) -> bool:


### PR DESCRIPTION
This makes it so kernel arguments that are already set are not reported, making the audit script's output significantly shorter for users who have already run `ujust set-kargs-hardening`. Also adds a recommendation to run `ujust set-kargs-hardening` if any expected kargs are missing. Thanks to @pxlkng for the suggestion.