### PR TITLE
fix(ujust dns-selector): make directories with mode 755

### DIFF
--- a/files/justfiles/dns.just
+++ b/files/justfiles/dns.just
@@ -16,8 +16,8 @@ dns-selector:
     # constants
     readonly resolved_conf="/etc/systemd/resolved.conf.d/10-securedns.conf"
     readonly policy_file="/etc/trivalent/policies/managed/10-securedns-browser.json"
-    mkdir -p /etc/systemd/resolved.conf.d/
-    mkdir -p /etc/trivalent/policies/managed/
+    mkdir -m 755 -p /etc/systemd/resolved.conf.d/
+    mkdir -m 755 -p /etc/trivalent/policies/managed/
     # variables
     valid_input="0"
     resolver_selection=""


### PR DESCRIPTION
This is needed for the systemd-resolved conf file to be user-readable (in particular, readable by the audit script) if the directories don't already exist. PR #1072 fixed the file modes but not the directories.