### PR TITLE
feat(audit): merge flatpak recommendations by permission

### DIFF
--- a/files/system/usr/libexec/secureblue/audit_flatpak/__init__.py
+++ b/files/system/usr/libexec/secureblue/audit_flatpak/__init__.py
@@ -8,9 +8,11 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Flatpak permissions checks for secureblue auditing script.
@@ -43,7 +45,7 @@ def parse_flatpak_permissions(perms_text: str) -> Permissions:
     """Get permissions for an installed flatpak."""
     perms = Permissions()
     section = None
-    for line in perms_text.split("\n"):
+    for line in perms_text.splitlines():
         line = line.strip()
         if not line or line.startswith("#"):
             continue
@@ -159,9 +161,8 @@ class PermissionCheck:
             $ flatpak override -u --{option}={self.permission} com.example.Example
             (replacing "com.example.Example" with the flatpak app ID)
             {self.endnote or ""}"""
-        return Recommendation(
-            "\n".join(line.strip() for line in rec.split("\n") if line.strip()), mergeable_name=name
-        )
+        rec = "\n".join(line.strip() for line in rec.splitlines() if line.strip())
+        return Recommendation(rec, mergeable_name=name)
 
 
 @dataclass(frozen=True)

--- a/files/system/usr/libexec/secureblue/audit_flatpak/__init__.py
+++ b/files/system/usr/libexec/secureblue/audit_flatpak/__init__.py
@@ -19,7 +19,7 @@ Flatpak permissions checks for secureblue auditing script.
 from dataclasses import dataclass, field
 from typing import Final
 
-from auditor import Status
+from auditor import Status, Recommendation
 
 PASS: Final = Status.PASS
 INFO: Final = Status.INFO
@@ -134,26 +134,34 @@ class PermissionCheck:
     sandbox_escape: bool = False
     arbitrary_permissions: bool = False
 
+    def default_description(self) -> str:
+        """Default description if other description isn't provided."""
+        perm_type = FLATPAK_OVERRIDE_OPTIONS[self.category][0]
+        return f"have {perm_type}={self.permission} permission"
+
     def warning(self, name: str) -> str:
         """Give the warning text for if the check fails."""
-        perm_type = FLATPAK_OVERRIDE_OPTIONS[self.category][0]
-        description = self.description or f"has {perm_type}={self.permission}"
+        description = self.description or self.default_description()
         return f"{name} {description}"
 
-    def recommendation(self, name: str) -> str:
-        """Give the recommendation text for if the check fails."""
+    def recommendation(self, name: str) -> Recommendation:
+        """Give the recommendation for if the check fails."""
         if self.sandbox_escape:
             sandbox_escape_note = "This may also be used as a sandbox escape vector."
         else:
             sandbox_escape_note = ""
         option = FLATPAK_OVERRIDE_OPTIONS[self.category][1]
-        rec = f"""{self.warning(name)}.
+        rec = f"""The following flatpak app(s) {self.description or self.default_description()}:
+            [[NAMES]]
             {self.note or ""}
             {sandbox_escape_note}
-            To remove this permission, use Flatseal or run:
-            $ flatpak override -u --{option}={self.permission} {name}
+            To remove this permission from an app, use Flatseal or run:
+            $ flatpak override -u --{option}={self.permission} com.example.Example
+            (replacing "com.example.Example" with the flatpak app ID)
             {self.endnote or ""}"""
-        return "\n".join(line.strip() for line in rec.split("\n") if line.strip())
+        return Recommendation(
+            "\n".join(line.strip() for line in rec.split("\n") if line.strip()), mergeable_name=name
+        )
 
 
 @dataclass(frozen=True)
@@ -166,19 +174,19 @@ class DirectoryInfo:
 
 
 FLATPAK_PERMISSION_CHECKS: list[PermissionCheck] = [
-    PermissionCheck("shared", "network", INFO, "has network access"),
-    PermissionCheck("shared", "ipc", INFO, "has inter-process communications access"),
-    PermissionCheck("sockets", "x11", FAIL, "has X11 access"),
-    PermissionCheck("sockets", "pulseaudio", WARN, "has access to the PulseAudio socket"),
+    PermissionCheck("shared", "network", INFO, "have network access"),
+    PermissionCheck("shared", "ipc", INFO, "have inter-process communications access"),
+    PermissionCheck("sockets", "x11", FAIL, "have X11 access"),
+    PermissionCheck("sockets", "pulseaudio", WARN, "have access to the PulseAudio socket"),
     PermissionCheck(
         "sockets",
         "session-bus",
         FAIL,
-        "has access to the D-Bus session bus",
+        "have access to the D-Bus session bus",
         note="This grants access to audio and microphones.",
     ),
-    PermissionCheck("sockets", "system-bus", FAIL, "has access to the D-Bus system bus"),
-    PermissionCheck("sockets", "ssh-auth", WARN, "has access to the SSH agent"),
+    PermissionCheck("sockets", "system-bus", FAIL, "have access to the D-Bus system bus"),
+    PermissionCheck("sockets", "ssh-auth", WARN, "have access to the SSH agent"),
     PermissionCheck(
         "devices",
         "all",
@@ -205,8 +213,8 @@ FLATPAK_PERMISSION_CHECKS: list[PermissionCheck] = [
         note="This grants raw USB device access.",
         sandbox_escape=True,
     ),
-    PermissionCheck("features", "bluetooth", WARN, "has bluetooth access"),
-    PermissionCheck("features", "devel", WARN, "has ptrace access"),
+    PermissionCheck("features", "bluetooth", WARN, "have bluetooth access"),
+    PermissionCheck("features", "devel", WARN, "have ptrace access"),
 ]
 
 ARBITRARY_PERMISSIONS_EXPECTED: list[str] = [
@@ -220,7 +228,7 @@ class FlatpakPermissionsState:
     """The state of a flatpak's permissions."""
 
     warnings: list[str]
-    recs: list[str]
+    recs: list[Recommendation]
     status: Status
     arbitrary_permissions: bool
     name: str
@@ -273,9 +281,15 @@ def _check_ld_preload(state: FlatpakPermissionsState, perms: Permissions):
         else:
             state.status = state.status.downgrade_to(WARN)
         state.recs.append(
-            f"""{state.name} is not requesting hardened_malloc.
-                    To enable it, run:
-                    $ ujust harden-flatpak {state.name}"""
+            Recommendation(
+                """The following flatpak app(s) are not requesting hardened_malloc:
+                [[NAMES]]
+                To enable it for an app, run:
+                $ ujust harden-flatpak com.example.Example
+                (replacing "com.example.Example" with the flatpak app ID)
+            """,
+                mergeable_name=state.name,
+            )
         )
 
 
@@ -285,10 +299,16 @@ def _handle_flatpak_buses(state: FlatpakPermissionsState, perms: Permissions):
             state.arbitrary_permissions = True
             if state.name not in ARBITRARY_PERMISSIONS_EXPECTED:
                 state.recs.append(
-                    f"""{state.name} can talk to {bus_name} on the session bus.
+                    Recommendation(
+                        f"""The following flatpak app(s) can talk to {bus_name} on the session bus:
+                        [[NAMES]]
                         This grants the ability to acquire arbitrary permissions.
-                        To remove this permission, use Flatseal or run:
-                        $ flatpak override -u --no-talk-name={bus_name} {state.name}"""
+                        To remove this permission from an app, use Flatseal or run:
+                        $ flatpak override -u --no-talk-name={bus_name} com.example.Example
+                        (replacing "com.example.Example" with the flatpak app ID)
+                    """,
+                        mergeable_name=state.name,
+                    )
                 )
 
 
@@ -341,10 +361,16 @@ def _check_dangerous_dirs(state: FlatpakPermissionsState, filesystems_rw: dict[s
                 aliased_path = directory.path.replace(directory.path, ALIASES[directory.path], 1)
             state.warnings.append(f"{state.name} has filesystem={directory.path} permission")
             state.recs.append(
-                f"""{state.name} has filesystem={aliased_path} permission.
-                        This grants access to {directory.description}.
-                        To remove this permission, use Flatseal or run:
-                        $ flatpak override -u --nofilesystem={aliased_path} {state.name}"""
+                Recommendation(
+                    f"""The following flatpak app(s) have filesystem={aliased_path} permission:
+                    [[NAMES]]
+                    This grants access to {directory.description}.
+                    To remove this permission from an app, use Flatseal or run:
+                    $ flatpak override -u --nofilesystem={aliased_path} com.example.Example
+                    (replacing "com.example.Example" with the flatpak app ID)
+                """,
+                    mergeable_name=state.name,
+                )
             )
 
 
@@ -358,10 +384,16 @@ def _check_hardened_malloc_access(
         state.status = state.status.downgrade_to(WARN)
         state.warnings.append(f"{state.name} is missing host-os:ro permission")
         state.recs.append(
-            f"""{state.name} is missing host-os:ro permission.
-                    This is required to load hardened_malloc.
-                    To add this permission, use Flatseal or run:
-                    $ flatpak override -u --filesystem=host-os:ro {state.name}"""
+            Recommendation(
+                """The following flatpak app(s) are missing host-os:ro permission:
+                [[NAMES]]
+                This is required to load hardened_malloc.
+                To add this permission to an app, use Flatseal or run:
+                $ flatpak override -u --filesystem=host-os:ro com.example.Example
+                (replacing "com.example.Example" with the flatpak app ID)
+            """,
+                mergeable_name=state.name,
+            )
         )
 
 
@@ -374,10 +406,16 @@ def _check_overrides_access(state: FlatpakPermissionsState, filesystems_rw: dict
             override_path = override_path.replace("xdg-data", ALIASES["xdg-data"], 1)
         if state.name not in ARBITRARY_PERMISSIONS_EXPECTED:
             state.recs.append(
-                f"""{state.name} can modify flatpak overrides.
-                                This grants the ability to acquire arbitrary permissions.
-                                To remove this permission, use Flatseal or run:
-                                $ flatpak override -u --nofilesystem={override_path} {state.name}"""
+                Recommendation(
+                    f"""The following flatpak app(s) can modify flatpak overrides:
+                    [[NAMES]]
+                    This grants the ability to acquire arbitrary permissions.
+                    To remove this permission from an app, use Flatseal or run:
+                    $ flatpak override -u --nofilesystem={override_path} com.example.Example
+                    (replacing "com.example.Example" with the flatpak app ID)
+                """,
+                    mergeable_name=state.name,
+                )
             )
 
 

--- a/files/system/usr/libexec/secureblue/audit_flatpak/__init__.py
+++ b/files/system/usr/libexec/secureblue/audit_flatpak/__init__.py
@@ -154,7 +154,7 @@ class PermissionCheck:
             sandbox_escape_note = ""
         option = FLATPAK_OVERRIDE_OPTIONS[self.category][1]
         rec = f"""The following flatpak app(s) {self.description or self.default_description()}:
-            [[NAMES]]
+            {Recommendation.NAMES_PLACEHOLDER}
             {self.note or ""}
             {sandbox_escape_note}
             To remove this permission from an app, use Flatseal or run:
@@ -283,12 +283,12 @@ def _check_ld_preload(state: FlatpakPermissionsState, perms: Permissions):
             state.status = state.status.downgrade_to(WARN)
         state.recs.append(
             Recommendation(
-                """The following flatpak app(s) are not requesting hardened_malloc:
-                [[NAMES]]
-                To enable it for an app, run:
-                $ ujust harden-flatpak com.example.Example
-                (replacing "com.example.Example" with the flatpak app ID)
-            """,
+                f"""The following flatpak app(s) are not requesting hardened_malloc:
+                    {Recommendation.NAMES_PLACEHOLDER}
+                    To enable it for an app, run:
+                    $ ujust harden-flatpak com.example.Example
+                    (replacing "com.example.Example" with the flatpak app ID)
+                """,
                 mergeable_name=state.name,
             )
         )
@@ -302,12 +302,12 @@ def _handle_flatpak_buses(state: FlatpakPermissionsState, perms: Permissions):
                 state.recs.append(
                     Recommendation(
                         f"""The following flatpak app(s) can talk to {bus_name} on the session bus:
-                        [[NAMES]]
-                        This grants the ability to acquire arbitrary permissions.
-                        To remove this permission from an app, use Flatseal or run:
-                        $ flatpak override -u --no-talk-name={bus_name} com.example.Example
-                        (replacing "com.example.Example" with the flatpak app ID)
-                    """,
+                            {Recommendation.NAMES_PLACEHOLDER}
+                            This grants the ability to acquire arbitrary permissions.
+                            To remove this permission from an app, use Flatseal or run:
+                            $ flatpak override -u --no-talk-name={bus_name} com.example.Example
+                            (replacing "com.example.Example" with the flatpak app ID)
+                        """,
                         mergeable_name=state.name,
                     )
                 )
@@ -364,12 +364,12 @@ def _check_dangerous_dirs(state: FlatpakPermissionsState, filesystems_rw: dict[s
             state.recs.append(
                 Recommendation(
                     f"""The following flatpak app(s) have filesystem={aliased_path} permission:
-                    [[NAMES]]
-                    This grants access to {directory.description}.
-                    To remove this permission from an app, use Flatseal or run:
-                    $ flatpak override -u --nofilesystem={aliased_path} com.example.Example
-                    (replacing "com.example.Example" with the flatpak app ID)
-                """,
+                        {Recommendation.NAMES_PLACEHOLDER}
+                        This grants access to {directory.description}.
+                        To remove this permission from an app, use Flatseal or run:
+                        $ flatpak override -u --nofilesystem={aliased_path} com.example.Example
+                        (replacing "com.example.Example" with the flatpak app ID)
+                    """,
                     mergeable_name=state.name,
                 )
             )
@@ -386,13 +386,13 @@ def _check_hardened_malloc_access(
         state.warnings.append(f"{state.name} is missing host-os:ro permission")
         state.recs.append(
             Recommendation(
-                """The following flatpak app(s) are missing host-os:ro permission:
-                [[NAMES]]
-                This is required to load hardened_malloc.
-                To add this permission to an app, use Flatseal or run:
-                $ flatpak override -u --filesystem=host-os:ro com.example.Example
-                (replacing "com.example.Example" with the flatpak app ID)
-            """,
+                f"""The following flatpak app(s) are missing host-os:ro permission:
+                    {Recommendation.NAMES_PLACEHOLDER}
+                    This is required to load hardened_malloc.
+                    To add this permission to an app, use Flatseal or run:
+                    $ flatpak override -u --filesystem=host-os:ro com.example.Example
+                    (replacing "com.example.Example" with the flatpak app ID)
+                """,
                 mergeable_name=state.name,
             )
         )
@@ -409,12 +409,12 @@ def _check_overrides_access(state: FlatpakPermissionsState, filesystems_rw: dict
             state.recs.append(
                 Recommendation(
                     f"""The following flatpak app(s) can modify flatpak overrides:
-                    [[NAMES]]
-                    This grants the ability to acquire arbitrary permissions.
-                    To remove this permission from an app, use Flatseal or run:
-                    $ flatpak override -u --nofilesystem={override_path} com.example.Example
-                    (replacing "com.example.Example" with the flatpak app ID)
-                """,
+                        {Recommendation.NAMES_PLACEHOLDER}
+                        This grants the ability to acquire arbitrary permissions.
+                        To remove this permission from an app, use Flatseal or run:
+                        $ flatpak override -u --nofilesystem={override_path} com.example.Example
+                        (replacing "com.example.Example" with the flatpak app ID)
+                    """,
                     mergeable_name=state.name,
                 )
             )

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -8,9 +8,11 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Auditing script for secureblue. See https://secureblue.dev/ for more info.
@@ -667,7 +669,7 @@ def audit_flatpak_remotes():
     if not command_succeeds(*"command -v flatpak".split()):
         return
 
-    remotes = command_stdout(*"flatpak remotes --columns=name,url,subset".split()).split("\n")
+    remotes = command_stdout(*"flatpak remotes --columns=name,url,subset".split()).splitlines()
     for remote in remotes:
         if not remote:
             continue

--- a/files/system/usr/libexec/secureblue/auditor/__init__.py
+++ b/files/system/usr/libexec/secureblue/auditor/__init__.py
@@ -192,14 +192,13 @@ def _format_recommendation_text(rec_text: str, mergeable_names: list[str] | None
 
 def _print_recs(recs: list[Recommendation], width: int = 80):
     print_heading("Recommendations", width=width)
-    ordinary_recs = [rec for rec in recs if rec.mergeable_name is None]
-    mergeable_recs = [rec for rec in recs if rec.mergeable_name is not None]
-    # Print non-mergeable recommendations first
-    for rec in ordinary_recs:
-        print(_format_recommendation_text(rec.text))
-    merged_recs_data = {rec.text: [] for rec in mergeable_recs}
-    for rec in mergeable_recs:
-        merged_recs_data[rec.text].append(rec.mergeable_name)
+    merged_recs_data = {rec.text: [] for rec in recs if rec.mergeable_name is not None}
+    for rec in recs:
+        if rec.mergeable_name is None:
+            # Print non-mergeable recommendations first
+            print(_format_recommendation_text(rec.text))
+        else:
+            merged_recs_data[rec.text].append(rec.mergeable_name)
     for rec_template, names in merged_recs_data.items():
         print(_format_recommendation_text(rec_template, mergeable_names=names))
 

--- a/files/system/usr/libexec/secureblue/auditor/__init__.py
+++ b/files/system/usr/libexec/secureblue/auditor/__init__.py
@@ -8,9 +8,11 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Framework for system auditing.
@@ -119,7 +121,7 @@ class Report:
         desc_with_sep = f"{self.description} {gray_start}".ljust(desc_width, "…") + reset_color
         report_str = desc_with_sep + status_tag
         for warning in self.warnings:
-            warning_lines = [line.strip() for line in warning.split("\n") if line]
+            warning_lines = [line.strip() for line in warning.splitlines() if line.strip()]
             if warning_lines:
                 report_str += "\n> " + warning_lines[0]
             for line in warning_lines[1:]:
@@ -175,19 +177,17 @@ class DependencyError(AuditError):
 
 
 def _format_recommendation_text(rec_text: str, mergeable_names: list[str] | None = None) -> str:
-    rec_lines = []
-    for line in rec_text.split("\n"):
-        line = line.strip()
-        if not line:
-            continue
+    rec_lines_raw = [line.strip() for line in rec_text.splitlines() if line.strip()]
+    rec_lines_formatted = []
+    for line in rec_lines_raw:
         if mergeable_names is not None and line == "[[NAMES]]":
             for name in mergeable_names:
-                rec_lines.append("  " + name)
+                rec_lines_formatted.append("  " + name)
         elif line[0] in ("$", "#"):
-            rec_lines.append(bold(line))
+            rec_lines_formatted.append(bold(line))
         else:
-            rec_lines.append(line)
-    return "\n  ".join(rec_lines) + "\n"
+            rec_lines_formatted.append(line)
+    return "\n  ".join(rec_lines_formatted) + "\n"
 
 
 def _print_recs(recs: list[Recommendation], width: int = 80):

--- a/files/system/usr/libexec/secureblue/auditor/__init__.py
+++ b/files/system/usr/libexec/secureblue/auditor/__init__.py
@@ -24,7 +24,7 @@ import inspect
 import json
 
 from collections.abc import Callable, Sequence
-from typing import Any, AsyncGenerator, Generator, Self
+from typing import Any, AsyncGenerator, ClassVar, Final, Generator, Self
 
 
 class AuditError(Exception):
@@ -66,6 +66,7 @@ class Recommendation:
 
     text: str
     mergeable_name: str | None = None
+    NAMES_PLACEHOLDER: ClassVar[Final[str]] = "[[NAMES_PLACEHOLDER]]"
 
     def __init__(self, rec: str | Self, mergeable_name: str | None = None):
         self.text = rec.text if isinstance(rec, Recommendation) else str(rec)
@@ -179,10 +180,10 @@ class DependencyError(AuditError):
 def _format_recommendation_text(rec_text: str, mergeable_names: list[str] | None = None) -> str:
     rec_lines_raw = [line.strip() for line in rec_text.splitlines() if line.strip()]
     rec_lines_formatted = []
+    name_text_lines = [] if mergeable_names is None else ["  " + name for name in mergeable_names]
     for line in rec_lines_raw:
-        if mergeable_names is not None and line == "[[NAMES]]":
-            for name in mergeable_names:
-                rec_lines_formatted.append("  " + name)
+        if line == Recommendation.NAMES_PLACEHOLDER:
+            rec_lines_formatted += name_text_lines
         elif line[0] in ("$", "#"):
             rec_lines_formatted.append(bold(line))
         else:

--- a/files/system/usr/libexec/secureblue/auditor/__init__.py
+++ b/files/system/usr/libexec/secureblue/auditor/__init__.py
@@ -16,6 +16,7 @@
 Framework for system auditing.
 """
 
+import dataclasses
 import enum
 import inspect
 import json
@@ -57,16 +58,42 @@ class Status(enum.Enum):
         return max(self, other, key=lambda status: status.value)
 
 
+@dataclasses.dataclass
+class Recommendation:
+    """A recommendation for user action to be taken."""
+
+    text: str
+    mergeable_name: str | None = None
+
+    def __init__(self, rec: str | Self, mergeable_name: str | None = None):
+        self.text = rec.text if isinstance(rec, Recommendation) else str(rec)
+        if isinstance(rec, Recommendation):
+            self.text = rec.text
+        else:
+            self.text = str(rec)
+        if mergeable_name is not None:
+            self.mergeable_name = mergeable_name
+        elif isinstance(rec, Recommendation):
+            self.mergeable_name = rec.mergeable_name
+        else:
+            self.mergeable_name = None
+
+
 class Report:
     """A result of a check to be reported."""
+
+    description: str
+    status: Status
+    warnings: list[str]
+    recs: list[Recommendation]
 
     def __init__(
         self,
         desc: str,
         status: Status,
         *,
-        warnings: str | list[str] | None = None,
-        recs: str | list[str] | None = None,
+        warnings: str | Sequence[str] | None = None,
+        recs: str | Recommendation | Sequence[str | Recommendation] | None = None,
     ):
         self.description = desc
         self.status = status
@@ -75,13 +102,13 @@ class Report:
         elif isinstance(warnings, str):
             self.warnings = [warnings]
         else:
-            self.warnings = warnings
+            self.warnings = list(warnings)
         if recs is None:
             self.recs = []
-        elif isinstance(recs, str):
-            self.recs = [recs]
+        elif isinstance(recs, (str, Recommendation)):
+            self.recs = [Recommendation(recs)]
         else:
-            self.recs = recs
+            self.recs = [Recommendation(rec) for rec in recs]
 
     def to_str(self, width: int = 80) -> str:
         """Represent the report as a string formatted to the given width."""
@@ -100,29 +127,18 @@ class Report:
         return report_str
 
 
+@dataclasses.dataclass
 class Check:
     """A single check done as part of an audit."""
 
-    def __init__(
-        self,
-        name: str,
-        callback: Callable[..., AsyncGenerator[Report]],
-        *,
-        stateful: bool = False,
-        category: str | None = None,
-        dependencies: Sequence[str] | None = None,
-    ):
-        self.name = name
-        self.callback = callback
-        self.category = category
-        self.stateful = stateful
-        if dependencies is None:
-            self.dependencies = []
-        else:
-            self.dependencies = dependencies
-        self.done = False
-        self.reports: list[Report] = []
-        self.recs: list[str] = []
+    name: str
+    callback: Callable[..., AsyncGenerator[Report]]
+    category: str | None = None
+    stateful: bool = False
+    dependencies: list[str] = dataclasses.field(default_factory=list)
+    done: bool = False
+    reports: list[Report] = dataclasses.field(default_factory=list)
+    recs: list[Recommendation] = dataclasses.field(default_factory=list)
 
     async def run(
         self, state: dict[str, Any] | None = None, rerun: bool = False
@@ -158,16 +174,34 @@ class DependencyError(AuditError):
     """A check's dependency requirements were not satisfied."""
 
 
-def _print_recs(recs: list[str], width: int = 80):
+def _format_recommendation_text(rec_text: str, mergeable_names: list[str] | None = None) -> str:
+    rec_lines = []
+    for line in rec_text.split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        if mergeable_names is not None and line == "[[NAMES]]":
+            for name in mergeable_names:
+                rec_lines.append("  " + name)
+        elif line[0] in ("$", "#"):
+            rec_lines.append(bold(line))
+        else:
+            rec_lines.append(line)
+    return "\n  ".join(rec_lines) + "\n"
+
+
+def _print_recs(recs: list[Recommendation], width: int = 80):
     print_heading("Recommendations", width=width)
-    for rec in recs:
-        rec_lines = [line.strip() for line in rec.split("\n")]
-        for i, line in enumerate(rec_lines):
-            if not line:
-                continue
-            if line[0] in ["$", "#"]:
-                rec_lines[i] = bold(line)
-        print("\n  ".join(rec_lines) + "\n")
+    ordinary_recs = [rec for rec in recs if rec.mergeable_name is None]
+    mergeable_recs = [rec for rec in recs if rec.mergeable_name is not None]
+    # Print non-mergeable recommendations first
+    for rec in ordinary_recs:
+        print(_format_recommendation_text(rec.text))
+    merged_recs_data = {rec.text: [] for rec in mergeable_recs}
+    for rec in mergeable_recs:
+        merged_recs_data[rec.text].append(rec.mergeable_name)
+    for rec_template, names in merged_recs_data.items():
+        print(_format_recommendation_text(rec_template, mergeable_names=names))
 
 
 class Audit:
@@ -176,7 +210,7 @@ class Audit:
     def __init__(self):
         self.checks: list[Check] = []
         self.state: dict[str, Any] = {}
-        self.recs: list[str] = []
+        self.recs: list[Recommendation] = []
         self.categories: set[str] = set()
 
     def names(self) -> list[str]:
@@ -224,6 +258,9 @@ class Audit:
             if check.category in exclude:
                 continue
             async for report in check.run(self.state):
+                recs = [
+                    {"text": rec.text, "mergeable_name": rec.mergeable_name} for rec in report.recs
+                ]
                 yield json.dumps(
                     {
                         "name": check.name,
@@ -231,7 +268,7 @@ class Audit:
                         "description": report.description,
                         "status": report.status.name.lower(),
                         "warnings": report.warnings,
-                        "recommendations": report.recs,
+                        "recommendations": recs,
                     }
                 )
 
@@ -274,7 +311,7 @@ def depends_on(*dependencies: str) -> Callable[..., Check]:
 
     def add_dependencies(f) -> Check:
         check = make_check(f)
-        check.dependencies = dependencies
+        check.dependencies += list(dependencies)
         return check
 
     return add_dependencies

--- a/files/system/usr/libexec/secureblue/utils/__init__.py
+++ b/files/system/usr/libexec/secureblue/utils/__init__.py
@@ -8,9 +8,11 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Utils for system auditing.
@@ -25,10 +27,13 @@ import re
 import subprocess  # nosec
 import sys
 import textwrap
+
 from collections.abc import Iterable
 from typing import Generator, Final
-from auditor import Status, AuditError
+
 import rpm
+
+from auditor import Status, AuditError
 
 
 PASS: Final = Status.PASS


### PR DESCRIPTION
This makes the recommendations associated to flatpak permissions group the recommendations by permission, giving a list of flatpaks that have each flagged permission. This significantly shortens the recommendation list in many cases, resulting in the recommendations being more usable as users can see at a glance which flatpaks have a given permission.

To give an example of what this looks like in practice, rather than giving a separate recommendation for each flatpak app that has network permissions, these would be merged into a single recommendation with the following text:
```
The following flatpak app(s) have network access:
    app.organicmaps.desktop
    com.calibre_ebook.calibre
    com.valvesoftware.Steam
    [...]
  To remove this permission from an app, use Flatseal or run:
  $ flatpak override -u --unshare=network com.example.Example
  (replacing "com.example.Example" with the flatpak app ID)
```
(where the list of app IDs would of course be replaced with whichever flatpak apps the user has installed with network access, and likewise for each other flatpak app permission the audit script checks for)