### PR TITLE
chore: ensure wireguard-tools is present on all images

### DIFF
--- a/recipes/common/common-packages.yml
+++ b/recipes/common/common-packages.yml
@@ -25,6 +25,7 @@ install:
   - podman
   - nvme-cli
   - hdparm
+  - wireguard-tools
   
   # signing deps 
   - sbsigntools


### PR DESCRIPTION
This is a tiny (~100KB) package that should be present on all images since the brew package has reported issues