### PR TITLE
style: enable lots more Ruff lints, apply lint suggestions

### DIFF
--- a/files/system/usr/libexec/secureblue/audit_flatpak/__init__.py
+++ b/files/system/usr/libexec/secureblue/audit_flatpak/__init__.py
@@ -21,7 +21,7 @@ Flatpak permissions checks for secureblue auditing script.
 from dataclasses import dataclass, field
 from typing import Final
 
-from auditor import Status, Recommendation
+from auditor import Recommendation, Status
 
 PASS: Final = Status.PASS
 INFO: Final = Status.INFO
@@ -41,39 +41,40 @@ class Permissions:
     system_bus_own: list[str] = field(default_factory=list)
 
 
+def _parse_config_sections(conf_text: str) -> dict[str | None, dict[str, str]]:
+    """Parse config file into sections containing key-value mappings"""
+    sections = {}
+    current_section = None
+    for raw_line in conf_text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            current_section = line[1:-1]
+            sections[current_section] = {}
+            continue
+        key, value = line.split("=", maxsplit=1)
+        sections[current_section][key] = value
+    return sections
+
+
 def parse_flatpak_permissions(perms_text: str) -> Permissions:
     """Get permissions for an installed flatpak."""
     perms = Permissions()
-    section = None
-    for line in perms_text.splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("["):
-            section = line.strip("[]")
-            continue
-        key, value = line.split("=", maxsplit=1)
+    sections = _parse_config_sections(perms_text)
+    for section, lines in sections.items():
         match section:
             case "Session Bus Policy":
-                match value:
-                    case "talk":
-                        perms.session_bus_talk.append(key)
-                    case "own":
-                        perms.session_bus_own.append(key)
-                    case _:
-                        raise ValueError(f"Unknown session bus permission '{value}'")
+                perms.session_bus_talk = [key for key, value in lines.items() if value == "talk"]
+                perms.session_bus_own = [key for key, value in lines.items() if value == "own"]
             case "System Bus Policy":
-                match value:
-                    case "talk":
-                        perms.system_bus_talk.append(key)
-                    case "own":
-                        perms.system_bus_own.append(key)
-                    case _:
-                        raise ValueError(f"Unknown system bus permission '{value}'")
+                perms.system_bus_talk = [key for key, value in lines.items() if value == "talk"]
+                perms.system_bus_own = [key for key, value in lines.items() if value == "own"]
             case "Environment":
-                perms.environment[key] = value
+                perms.environment = lines
             case _:
-                perms.permissions[key] = [val for val in value.split(";") if val]
+                for key, value in lines.items():
+                    perms.permissions[key] = [val for val in value.split(";") if val]
     return perms
 
 

--- a/files/system/usr/libexec/secureblue/audit_flatpak/__init__.py
+++ b/files/system/usr/libexec/secureblue/audit_flatpak/__init__.py
@@ -140,12 +140,12 @@ class PermissionCheck:
     def default_description(self) -> str:
         """Default description if other description isn't provided."""
         perm_type = FLATPAK_OVERRIDE_OPTIONS[self.category][0]
-        return f"have {perm_type}={self.permission} permission"
+        return f"{perm_type}={self.permission} permission"
 
     def warning(self, name: str) -> str:
         """Give the warning text for if the check fails."""
         description = self.description or self.default_description()
-        return f"{name} {description}"
+        return f"{name} has {description}"
 
     def recommendation(self, name: str) -> Recommendation:
         """Give the recommendation for if the check fails."""
@@ -154,7 +154,8 @@ class PermissionCheck:
         else:
             sandbox_escape_note = ""
         option = FLATPAK_OVERRIDE_OPTIONS[self.category][1]
-        rec = f"""The following flatpak app(s) {self.description or self.default_description()}:
+        description = self.description or self.default_description()
+        rec = f"""The following flatpak app(s) have {description}:
             {Recommendation.NAMES_PLACEHOLDER}
             {self.note or ""}
             {sandbox_escape_note}
@@ -176,19 +177,19 @@ class DirectoryInfo:
 
 
 FLATPAK_PERMISSION_CHECKS: list[PermissionCheck] = [
-    PermissionCheck("shared", "network", INFO, "have network access"),
-    PermissionCheck("shared", "ipc", INFO, "have inter-process communications access"),
-    PermissionCheck("sockets", "x11", FAIL, "have X11 access"),
-    PermissionCheck("sockets", "pulseaudio", WARN, "have access to the PulseAudio socket"),
+    PermissionCheck("shared", "network", INFO, "network access"),
+    PermissionCheck("shared", "ipc", INFO, "inter-process communications access"),
+    PermissionCheck("sockets", "x11", FAIL, "X11 access"),
+    PermissionCheck("sockets", "pulseaudio", WARN, "access to the PulseAudio socket"),
     PermissionCheck(
         "sockets",
         "session-bus",
         FAIL,
-        "have access to the D-Bus session bus",
+        "access to the D-Bus session bus",
         note="This grants access to audio and microphones.",
     ),
-    PermissionCheck("sockets", "system-bus", FAIL, "have access to the D-Bus system bus"),
-    PermissionCheck("sockets", "ssh-auth", WARN, "have access to the SSH agent"),
+    PermissionCheck("sockets", "system-bus", FAIL, "access to the D-Bus system bus"),
+    PermissionCheck("sockets", "ssh-auth", WARN, "access to the SSH agent"),
     PermissionCheck(
         "devices",
         "all",
@@ -215,8 +216,8 @@ FLATPAK_PERMISSION_CHECKS: list[PermissionCheck] = [
         note="This grants raw USB device access.",
         sandbox_escape=True,
     ),
-    PermissionCheck("features", "bluetooth", WARN, "have bluetooth access"),
-    PermissionCheck("features", "devel", WARN, "have ptrace access"),
+    PermissionCheck("features", "bluetooth", WARN, "bluetooth access"),
+    PermissionCheck("features", "devel", WARN, "ptrace access"),
 ]
 
 ARBITRARY_PERMISSIONS_EXPECTED: list[str] = [

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -127,11 +127,7 @@ def audit_sysctl():
     sysctl_file = "/etc/sysctl.d/60-hardening.conf"
     with open(f"/usr{sysctl_file}", encoding="utf-8") as f:
         conf = f.readlines()
-    sysctl_expected: dict[str, str] = {}
-    for key, value in parse_config(conf):
-        if value is None:
-            raise ValueError(f"failed to parse /usr{sysctl_file}")
-        sysctl_expected[key] = value
+    sysctl_expected = parse_config(conf)
     status = PASS
     sysctl_errors = []
     with open(sysctl_file, encoding="utf-8") as f:
@@ -323,11 +319,9 @@ def audit_dns():
         conf_path = "/etc/systemd/resolved.conf.d/10-securedns.conf"
         try:
             with open(conf_path, encoding="utf-8") as f:
-                for key, value in parse_config(f):
-                    if key == "DNSSEC":
-                        dnssec = value
-                    elif key == "DNSOverTLS":
-                        dot = value
+                config = parse_config(f)
+                dnssec = config.get("DNSSEC")
+                dot = config.get("DNSOverTLS")
         except FileNotFoundError:
             status = FAIL
         except PermissionError:
@@ -362,21 +356,17 @@ def audit_mac_randomization():
     conf_path = "/etc/NetworkManager/conf.d/rand_mac.conf"
     try:
         with open(conf_path, encoding="utf-8") as f:
-            ethernet = False
-            wifi = False
-            for key, value in parse_config(f):
-                if key == "ethernet.cloned-mac-address" and value in ["random", "stable"]:
-                    ethernet = True
-                if key == "wifi.cloned-mac-address" and value in ["random", "stable"]:
-                    wifi = True
-                if ethernet and wifi:
-                    status = PASS
-                    break
+            config = parse_config(f)
     except FileNotFoundError:
         pass
     except PermissionError:
         status = UNKNOWN
         warning = f"Unable to read file {conf_path}"
+    else:
+        ethernet = config.get("ethernet.cloned-mac-address") in ("random", "stable")
+        wifi = config.get("wifi.cloned-mac-address") in ("random", "stable")
+        if ethernet and wifi:
+            status = PASS
     if status == FAIL:
         rec = """MAC randomization is not enabled.
                 To enable it, run:
@@ -560,13 +550,13 @@ def audit_kde_ghns(state):
     warning = None
     try:
         with open("/etc/xdg/kdeglobals", encoding="utf-8") as f:
-            for key, value in parse_config(f):
-                if key == "ghns" and value == "false":
-                    status = PASS
-                    break
+            config = parse_config(f)
     except (FileNotFoundError, PermissionError):
         status = WARN
         warning = "/etc/xdg/kdeglobals not found or inaccessible"
+    else:
+        if config.get("ghns") == "false":
+            status = PASS
     if status == FAIL:
         rec = """KDE GHNS is enabled.
             To disable, run:

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -26,26 +26,26 @@ import json
 import os
 import os.path
 import signal
-import sys
-import traceback
 
 # All subprocess calls we make have trusted inputs and do not use shell=True.
 import subprocess  # nosec
+import sys
+import traceback
 from typing import Final
 
-from auditor import Report, Status, audit, bold, categorize, depends_on, global_audit
 from audit_flatpak import check_flatpak_permissions, parse_flatpak_permissions
+from auditor import Report, Status, audit, bold, categorize, depends_on, global_audit
 from utils import (
-    print_err,
-    warn_if_root,
-    get_width,
-    get_legend,
-    parse_config,
-    command_stdout,
     Image,
+    command_stdout,
     command_succeeds,
-    validate_sysctl,
     get_flatpak_permissions,
+    get_legend,
+    get_width,
+    parse_config,
+    print_err,
+    validate_sysctl,
+    warn_if_root,
 )
 
 PASS: Final = Status.PASS
@@ -124,23 +124,26 @@ def audit_kargs():
 @audit
 def audit_sysctl():
     """Check for sysctl overrides."""
-    with open("/usr/etc/sysctl.d/60-hardening.conf", "r", encoding="utf-8") as f:
+    sysctl_file = "/etc/sysctl.d/60-hardening.conf"
+    with open(f"/usr{sysctl_file}", encoding="utf-8") as f:
         conf = f.readlines()
-    sysctl_expected = {}
+    sysctl_expected: dict[str, str] = {}
     for key, value in parse_config(conf):
+        if value is None:
+            raise ValueError(f"failed to parse /usr{sysctl_file}")
         sysctl_expected[key] = value
     status = PASS
     sysctl_errors = []
-    with open("/etc/sysctl.d/60-hardening.conf", "r", encoding="utf-8") as f:
+    with open(sysctl_file, encoding="utf-8") as f:
         etc_conf = f.readlines()
     if conf != etc_conf:
         status = WARN
-        sysctl_errors.append("/etc/sysctl.d/60-hardening.conf has been modified")
+        sysctl_errors.append(f"{sysctl_file} has been modified")
     for sysctl, expected in sysctl_expected.items():
         sysctl_path = f"/proc/sys/{sysctl.replace('.', '/')}"
         for path in glob.iglob(sysctl_path):
             try:
-                with open(path, "r", encoding="utf-8") as f:
+                with open(path, encoding="utf-8") as f:
                     actual = f.read().strip()
             except PermissionError:
                 continue
@@ -171,7 +174,7 @@ def audit_signed_image(state):
 @audit
 def audit_modprobe(state):
     """Check that the kernel module blacklist has not been overridden."""
-    with open("/usr/etc/modprobe.d/blacklist.conf", "r", encoding="utf-8") as f:
+    with open("/usr/etc/modprobe.d/blacklist.conf", encoding="utf-8") as f:
         conf = f.readlines()
     blacklisted_modules = []
     for line in conf:
@@ -179,7 +182,7 @@ def audit_modprobe(state):
         if words and words[0] in ["blacklist", "install"]:
             blacklisted_modules.append(words[1])
     unwanted_modules = []
-    with open("/proc/modules", "r", encoding="utf-8") as f:
+    with open("/proc/modules", encoding="utf-8") as f:
         for line in f:
             mod = line.split()[0]
             if mod in blacklisted_modules:
@@ -187,7 +190,7 @@ def audit_modprobe(state):
     unwanted_modules.sort()
     status = PASS
     warnings = []
-    with open("/etc/modprobe.d/blacklist.conf", "r", encoding="utf-8") as f:
+    with open("/etc/modprobe.d/blacklist.conf", encoding="utf-8") as f:
         if f.readlines() != conf:
             status = WARN
             warnings.append("/etc/modprobe.d/blacklist.conf has been modified")
@@ -201,9 +204,8 @@ def audit_modprobe(state):
 @audit
 def audit_ptrace(state):
     """Ensure the ptrace syscall is forbidden."""
-    with open("/proc/sys/kernel/yama/ptrace_scope", "r", encoding="utf-8") as f:
+    with open("/proc/sys/kernel/yama/ptrace_scope", encoding="utf-8") as f:
         ptrace_scope = int(f.read())
-    state["ptrace_allowed"] = ptrace_scope < 3
     match ptrace_scope:
         case 3:
             status = PASS
@@ -223,17 +225,17 @@ def audit_ptrace(state):
                 https://www.kernel.org/doc/html/latest/admin-guide/LSM/Yama.html
                 To forbid ptrace, run:
                 $ ujust toggle-ptrace-scope"""
+    state["ptrace_allowed"] = status != PASS
     yield Report("Ensuring ptrace is forbidden", status, recs=rec)
 
 
 @audit
 def audit_authselect():
     """Ensure no authselect overrides have been made."""
+    status = PASS
     cmp = filecmp.dircmp("/usr/etc/authselect", "/etc/authselect", shallow=False, ignore=[])
     if cmp.left_only or cmp.right_only or cmp.diff_files or cmp.funny_files:
         status = FAIL
-    else:
-        status = PASS
     yield Report("Ensuring no authselect overrides", status)
 
 
@@ -272,7 +274,7 @@ def audit_container_userns():
     """Ensure container-domain processes cannot create user namespaces."""
     if command_stdout("ujust", "check-container-userns-state") == "disabled":
         status = PASS
-        recs = []
+        recs = None
     else:
         status = WARN
         recs = """Container domain user namespace creation is permitted.
@@ -284,7 +286,7 @@ def audit_container_userns():
 @audit
 def audit_usbguard():
     """Ensure usbguard is active."""
-    if command_succeeds(*"systemctl is-active --quiet usbguard".split()):
+    if command_succeeds("systemctl", "is-active", "--quiet", "usbguard"):
         status = PASS
         rec = None
     else:
@@ -299,7 +301,7 @@ def audit_usbguard():
 @audit
 def audit_chronyd():
     """Ensure chronyd is active."""
-    if command_succeeds(*"systemctl is-active --quiet chronyd".split()):
+    if command_succeeds("systemctl", "is-active", "--quiet", "chronyd"):
         status = PASS
         rec = None
     else:
@@ -315,12 +317,12 @@ def audit_dns():
     """Ensure system DNS resolution is active and secure."""
     rec = None
     warning = None
-    if command_succeeds(*"systemctl is-active --quiet systemd-resolved".split()):
+    if command_succeeds("systemctl", "is-active", "--quiet", "systemd-resolved"):
         dnssec = None
         dot = None
         conf_path = "/etc/systemd/resolved.conf.d/10-securedns.conf"
         try:
-            with open(conf_path, "r", encoding="utf-8") as f:
+            with open(conf_path, encoding="utf-8") as f:
                 for key, value in parse_config(f):
                     if key == "DNSSEC":
                         dnssec = value
@@ -359,7 +361,7 @@ def audit_mac_randomization():
     warning = None
     conf_path = "/etc/NetworkManager/conf.d/rand_mac.conf"
     try:
-        with open(conf_path, "r", encoding="utf-8") as f:
+        with open(conf_path, encoding="utf-8") as f:
             ethernet = False
             wifi = False
             for key, value in parse_config(f):
@@ -387,7 +389,7 @@ def audit_mac_randomization():
 @audit
 def audit_rpm_ostree_timer():
     """Ensure rpm-ostree automatic updates are enabled."""
-    if command_succeeds(*"systemctl is-enabled --quiet rpm-ostreed-automatic.timer".split()):
+    if command_succeeds("systemctl", "is-enabled", "--quiet", "rpm-ostreed-automatic.timer"):
         status = PASS
         rec = None
     else:
@@ -401,7 +403,7 @@ def audit_rpm_ostree_timer():
 @audit
 def audit_podman_auto_update():
     """Ensure podman automatic updates are enabled."""
-    if command_succeeds(*"systemctl is-enabled --quiet podman-auto-update.timer".split()):
+    if command_succeeds("systemctl", "is-enabled", "--quiet", "podman-auto-update.timer"):
         status = PASS
         rec = None
     else:
@@ -415,7 +417,9 @@ def audit_podman_auto_update():
 @audit
 def audit_podman_global_auto_update():
     """Ensure podman automatic updates are enabled globally."""
-    if command_succeeds(*"systemctl --global is-enabled --quiet podman-auto-update.timer".split()):
+    if command_succeeds(
+        "systemctl", "--global", "is-enabled", "--quiet", "podman-auto-update.timer"
+    ):
         status = PASS
         rec = None
     else:
@@ -429,9 +433,11 @@ def audit_podman_global_auto_update():
 @audit
 def audit_flatpak_auto_update():
     """Ensure flatpak automatic updates are enabled."""
-    if not command_succeeds(*"command -v flatpak".split()):
+    if not command_succeeds("command", "-v", "flatpak"):
         return
-    if command_succeeds(*"systemctl --global is-enabled --quiet flatpak-user-update.timer".split()):
+    if command_succeeds(
+        "systemctl", "--global", "is-enabled", "--quiet", "flatpak-user-update.timer"
+    ):
         status = PASS
         rec = None
     else:
@@ -441,7 +447,7 @@ def audit_flatpak_auto_update():
                 $ systemctl enable --global flatpak-user-update.timer"""
     yield Report("Ensuring flatpak-user-update.timer is enabled globally", status, recs=rec)
 
-    if command_succeeds(*"systemctl is-enabled --quiet flatpak-system-update.timer".split()):
+    if command_succeeds("systemctl", "is-enabled", "--quiet", "flatpak-system-update.timer"):
         status = PASS
         rec = None
     else:
@@ -499,7 +505,7 @@ def audit_gnome_extensions(state):
     if state["image"] != Image.SILVERBLUE:
         return
     allowed = command_stdout(
-        *"command -p gsettings get org.gnome.shell allow-extension-installation".split()
+        "command", "-p", "gsettings", "get", "org.gnome.shell", "allow-extension-installation"
     )
     if allowed == "false":
         status = PASS
@@ -553,7 +559,7 @@ def audit_kde_ghns(state):
     status = FAIL
     warning = None
     try:
-        with open("/etc/xdg/kdeglobals", "r", encoding="utf-8") as f:
+        with open("/etc/xdg/kdeglobals", encoding="utf-8") as f:
             for key, value in parse_config(f):
                 if key == "ghns" and value == "false":
                     status = PASS
@@ -573,9 +579,10 @@ def audit_kde_ghns(state):
 @audit
 def audit_hardened_malloc():
     """Ensure hardened_malloc is set to be preloaded in place of the default system malloc."""
+    rec = None
     warnings = []
     try:
-        with open("/etc/ld.so.preload", "r", encoding="utf-8") as f:
+        with open("/etc/ld.so.preload", encoding="utf-8") as f:
             preloaded = f.read().split()
     except FileNotFoundError:
         status = FAIL
@@ -598,9 +605,7 @@ def audit_hardened_malloc():
         else:
             status = FAIL
             warnings.append("hardened_malloc not set")
-    if status == PASS:
-        rec = None
-    else:
+    if status != PASS:
         rec = """/etc/ld.so.preload has been modified.
             To reset it and enable hardened_malloc system-wide, run:
             $ run0 cp /usr/etc/ld.so.preload /etc/ld.so.preload"""
@@ -637,9 +642,7 @@ def audit_bash_env_lockdown():
     )
     unlocked_files = []
     for path in bash_env_paths:
-        if not os.path.exists(path):
-            unlocked_files.append(path)
-        elif not os.path.isfile(path) and not os.path.isdir(path):
+        if not os.path.exists(path) or (not os.path.isfile(path) and not os.path.isdir(path)):
             unlocked_files.append(path)
         else:
             try:
@@ -666,10 +669,10 @@ def audit_bash_env_lockdown():
 @categorize("flatpak")
 def audit_flatpak_remotes():
     """Audit flatpak remotes."""
-    if not command_succeeds(*"command -v flatpak".split()):
+    if not command_succeeds("command", "-v", "flatpak"):
         return
 
-    remotes = command_stdout(*"flatpak remotes --columns=name,url,subset".split()).splitlines()
+    remotes = command_stdout("flatpak", "remotes", "--columns=name,url,subset").splitlines()
     for remote in remotes:
         if not remote:
             continue
@@ -694,13 +697,13 @@ def audit_flatpak_remotes():
 @depends_on("audit_modprobe", "audit_ptrace")
 async def audit_flatpak_permissions(state):
     """Audit flatpak permissions."""
-    if not command_succeeds(*"command -v flatpak".split()):
+    if not command_succeeds("command", "-v", "flatpak"):
         return
 
     flatpaks = []
-    for line in command_stdout(*"flatpak list --app --columns=application,branch".split()).split(
-        "\n"
-    ):
+    for line in command_stdout(
+        "flatpak", "list", "--app", "--columns=application,branch"
+    ).splitlines():
         if not line:
             continue
         name, version = line.split("\t")
@@ -718,10 +721,7 @@ async def audit_flatpak_permissions(state):
         flatpak_permissions_state = check_flatpak_permissions(
             name, perms, state["bluetooth_loaded"], state["ptrace_allowed"]
         )
-        if version == "stable":
-            report_text = f"Auditing {name}"
-        else:
-            report_text = f"Auditing {name} ({version})"
+        report_text = f"Auditing {name}" if version == "stable" else f"Auditing {name} ({version})"
         yield Report(
             report_text,
             flatpak_permissions_state.status,

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -574,12 +574,9 @@ def audit_hardened_malloc():
     try:
         with open("/etc/ld.so.preload", encoding="utf-8") as f:
             preloaded = f.read().split()
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError):
         status = FAIL
-        warnings.append("ld.so.preload not found")
-    except PermissionError:
-        status = FAIL
-        warnings.append("Permission denied to read ld.so.preload")
+        warnings.append("ld.so.preload not found or unreadable")
     else:
         if preloaded == ["libhardened_malloc.so"]:
             status = PASS

--- a/files/system/usr/libexec/secureblue/auditor/__init__.py
+++ b/files/system/usr/libexec/secureblue/auditor/__init__.py
@@ -22,9 +22,8 @@ import dataclasses
 import enum
 import inspect
 import json
-
-from collections.abc import Callable, Sequence
-from typing import Any, AsyncGenerator, ClassVar, Final, Generator, Self
+from collections.abc import AsyncGenerator, Callable, Generator, Sequence
+from typing import Any, ClassVar, Final, Self
 
 
 class AuditError(Exception):
@@ -193,7 +192,9 @@ def _format_recommendation_text(rec_text: str, mergeable_names: list[str] | None
 
 def _print_recs(recs: list[Recommendation], width: int = 80):
     print_heading("Recommendations", width=width)
-    merged_recs_data = {rec.text: [] for rec in recs if rec.mergeable_name is not None}
+    merged_recs_data: dict[str, list[str]] = {
+        rec.text: [] for rec in recs if rec.mergeable_name is not None
+    }
     for rec in recs:
         if rec.mergeable_name is None:
             # Print non-mergeable recommendations first

--- a/files/system/usr/libexec/secureblue/utils/__init__.py
+++ b/files/system/usr/libexec/secureblue/utils/__init__.py
@@ -27,7 +27,7 @@ import re
 import subprocess  # nosec
 import sys
 import textwrap
-from collections.abc import Generator, Iterable
+from collections.abc import Iterable
 from typing import Final
 
 import rpm
@@ -148,20 +148,20 @@ def command_succeeds(*args: str) -> bool:
 
 
 def parse_config(
-    stream: Iterable[str], *, sep: str = "=", comment: str = "#"
-) -> Generator[tuple[str, str | None]]:
+    stream: Iterable[str], *, sep: str = "=", comment: str = "#", section_start: str = "["
+) -> dict[str, str]:
     """
-    Parse a text stream as a simple configuration file, yielding a sequence of keys and values
-    separated by the given separator ("=" by default).
+    Parse a text stream as a simple configuration file with keys and values separated
+    by the given separator ("=" by default).
     """
+    config = {}
     for raw_line in stream:
         line = raw_line.strip()
-        if not line or line.startswith(comment):
+        if sep not in line or line.startswith((comment, section_start)):
             continue
-        split = line.split(sep, maxsplit=1)
-        key = split[0].strip()
-        value = split[1].strip() if len(split) > 1 else None
-        yield key, value
+        key, value = line.split(sep, maxsplit=1)
+        config[key.strip()] = value.strip()
+    return config
 
 
 def is_rpm_package_installed(name: str) -> bool:

--- a/files/system/usr/libexec/secureblue/utils/__init__.py
+++ b/files/system/usr/libexec/secureblue/utils/__init__.py
@@ -27,14 +27,11 @@ import re
 import subprocess  # nosec
 import sys
 import textwrap
-
-from collections.abc import Iterable
-from typing import Generator, Final
+from collections.abc import Generator, Iterable
+from typing import Final
 
 import rpm
-
-from auditor import Status, AuditError
-
+from auditor import AuditError, Status
 
 PASS: Final = Status.PASS
 INFO: Final = Status.INFO
@@ -157,16 +154,13 @@ def parse_config(
     Parse a text stream as a simple configuration file, yielding a sequence of keys and values
     separated by the given separator ("=" by default).
     """
-    for line in stream:
-        line = line.strip()
+    for raw_line in stream:
+        line = raw_line.strip()
         if not line or line.startswith(comment):
             continue
         split = line.split(sep, maxsplit=1)
         key = split[0].strip()
-        if len(split) == 2:
-            value = split[1].strip()
-        else:
-            value = None
+        value = split[1].strip() if len(split) > 1 else None
         yield key, value
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -17,6 +17,7 @@ select = [
     "TC", # flake8-type-checking
     "ARG", # flake8-unused-arguments
     "I", # isort
+    "C90", # mccabe
     "N", # pep8-naming
     "E", # pycodestyle error
     "W", # pycodestyle warning

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,1 +1,36 @@
 line-length = 100
+
+[lint]
+select = [
+    "S", # flake8-bandit
+    "B", # flake8-bugbear
+    "A", # flake8-builtins
+    "C4", # flake8-comprehensions
+    "FIX", # flake8-fixme
+    "ICN", # flake8-import-conventions
+    "PIE", # flake8-pie
+    "Q", # flake8-quotes
+    "RSE", # flake8-raise
+    "RET", # flake8-return
+    "SLF", # flake8-self
+    "SIM", # flake8-simplify
+    "TC", # flake8-type-checking
+    "ARG", # flake8-unused-arguments
+    "I", # isort
+    "N", # pep8-naming
+    "E", # pycodestyle error
+    "W", # pycodestyle warning
+    "F", # pyflakes
+    "PL", # pylint
+    "UP", # pyupgrade
+    "FURB", # refurb
+    "RUF", # Ruff-specific rules
+]
+
+ignore = [
+    "S603", # subprocess-without-shell-equals-true
+]
+
+mccabe.max-complexity = 8
+pycodestyle.max-doc-length = 100
+pylint.max-statements = 40


### PR DESCRIPTION
The enabled lints include many of the lints from Flake8, Pylint, Bandit, Pyupgrade, and mccabe (a cyclomatic complexity checker). Also simplified `parse_config` and factored out part of the parsing logic of the function `parse_flatpak_permissions` to reduce cyclomatic complexity of several functions, and fixed a small grammar issue with `PermissionCheck`.