### PR TITLE
fix: don't install Flatseal on KDE

### DIFF
--- a/files/system/usr/libexec/secureblue/secureblueflatpaksetup
+++ b/files/system/usr/libexec/secureblue/secureblueflatpaksetup
@@ -19,7 +19,9 @@ ujust harden-flatpak
 
 RPM_OSTREE_STATUS=$(rpm-ostree status --json --booted)
 IMAGE_REF_NAME=$(echo "$RPM_OSTREE_STATUS" | jq -r '.deployments[0]."container-image-reference" // empty | split("/")[-1]')
-flatpak install --user com.github.tchx84.Flatseal -y
+if [[ "$IMAGE_REF_NAME" != *"kinoite"* ]]; then
+    flatpak install --user com.github.tchx84.Flatseal -y
+fi
 
 if [[ "$IMAGE_REF_NAME" == *"silverblue"* ]]; then
     flatpak install --user io.github.flattool.Warehouse -y


### PR DESCRIPTION
KDE flatpak settings panel bug [has been fixed](https://invent.kde.org/plasma/flatpak-kcm/-/commit/05ef4c9aa0ad738dfd6865ff1ec4f60b40f83d1f), and the fix is expected to be released with KDE Plasma 6.4.2. This means Flatseal is no longer needed on KDE as the settings panel has the same functionality.

This reverts commit 3d0974fb0633764668fbc36c95e9d27bb62d2239.

(We actually don't need to wait for Plasma 6.4.2—this can be merged after #1151, since that prevents the above bug from crashing system settings.)