### PR TITLE
fix: use standard malloc for KDE system settings

### DIFF
--- a/files/scripts/systemsettings-standard-malloc.sh
+++ b/files/scripts/systemsettings-standard-malloc.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+set -euo pipefail
+
+# Unset LD_PRELOAD in all invocations of systemsettings in .desktop files
+sed -Ei 's/^Exec=systemsettings( .*)?$/Exec=env LD_PRELOAD= systemsettings\1/' /usr/share/applications/*.desktop

--- a/recipes/common/kinoite-modules.yml
+++ b/recipes/common/kinoite-modules.yml
@@ -30,10 +30,11 @@ modules:
       # depends on fedora-flathub-remote
       - plasma-welcome-fedora
   - type: files
-    files:  
+    files:
       - source: system/kinoite
         destination: /
   - type: script
     scripts:
       - enabledisablekdesplash.sh
       - setdefaultkdewallpapers.sh
+      - systemsettings-standard-malloc.sh


### PR DESCRIPTION
This erases `LD_PRELOAD` for all invocations of `systemsettings` in .desktop files on KDE, meaning the system settings app will be launched without hardened_malloc preloaded. This is necessary because some settings panels invoke Qt WebEngine, which uses Chromium, which is incompatible with hardened_malloc.

(Fixes #1149. This depends on #1150 and won't work properly until that's merged.)