### PR TITLE
docs: have icon image in readme link to website instead of this repo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://github.com/secureblue/secureblue">
+  <a href="https://secureblue.dev">
     <img src="https://github.com/secureblue/secureblue/blob/live/docs/secureblue.png" href="https://github.com/secureblue/secureblue" alt="secureblue logo" width=180 />
   </a>
 </p>


### PR DESCRIPTION
Linking this repo in the readme seems pointless. I think we should have the icon image link the website, or just remove the link.