### PR TITLE
fix: flatpak-permission-lockdown grants Warehouse needed bus

### DIFF
--- a/files/justfiles/hardening.just
+++ b/files/justfiles/hardening.just
@@ -95,10 +95,11 @@ flatpak-permissions-lockdown:
     kKnownSessionBusNames=("org.xfce.ScreenSaver" "org.mate.ScreenSaver" "org.cinnamon.ScreenSaver" "org.gnome.ScreenSaver" "org.kde.kwalletd6" "org.gnome.Mutter.IdleMonitor.*" "org.gnome.ControlCenter" "org.gnome.Settings" "org.gnome.SettingsDaemon.MediaKeys" "org.gnome.SessionManager" "org.gnome.Shell.Screenshot" "org.kde.kiod5" "org.kde.kwin.Screenshot" "org.kde.JobViewServer" "org.gtk.vfs.*" "org.freedesktop.secrets" "org.kde.kconfig.notify" "org.kde.kpasswdserver" "org.kde.*" "org.kde.StatusNotifierWatcher" "org.kde.kded6" "org.kde.kpasswdserver6" "org.kde.kiod6" "com.canonical.Unity" "org.freedesktop.Notifications" "org.freedesktop.FileManager1" "org.freedesktop.impl.portal.PermissionStore" "org.freedesktop.Flatpak" "com.canonical.AppMenu.Registrar" "org.kde.KGlobalSettings" "org.kde.kded5" "com.canonical.Unity.LauncherEntry" "org.kde.kwalletd5" "org.gnome.SettingsDaemon" "org.a11y.Bus" "com.canonical.indicator.application" "org.freedesktop.ScreenSaver" "ca.desrt.dconf" "org.freedesktop.PowerManagement" "org.gnome.Software" "org.freedesktop.Tracker3.Writeback" "io.missioncenter.MissionCenter.Gatherer")
     kKnownSystemBusNames=("org.bluez" "org.freedesktop.home1" "org.freedesktop.hostname1" "org.freedesktop.import1" "org.freedesktop.locale1" "org.freedesktop.LogControl1" "org.freedesktop.machine1" "org.freedesktop.network1" "org.freedesktop.oom1" "org.freedesktop.portable1" "org.freedesktop.resolve1" "org.freedesktop.sysupdate1" "org.freedesktop.timesync1" "org.freedesktop.timedate1" "org.freedesktop.systemd1" "org.freedesktop.Avahi" "org.freedesktop.Avahi.*" "org.freedesktop.login1" "org.freedesktop.NetworkManager" "org.freedesktop.UPower" "org.freedesktop.UDisks2" "org.freedesktop.fwupd")
     kFlatsealNameAccess=("org.gnome.Software" "org.freedesktop.impl.portal.PermissionStore")
+    kWarehouseNameAccess=("org.freedesktop.Flatpak")
     confirmation=""
 
     echo "This will configure flatpak to automatically reject most permissions (with the exception of the Wayland socket and the Dri device, since these are commonly used and ensure at the very least most apps will work without crashing)."
-    echo "This will also grant Flatseal access to certain permissions to allow it to operate and make reconfiguring much easier."
+    echo "This will also grant Flatseal and Warehouse access to certain permissions to allow it to operate and make reconfiguring much easier."
     echo "NOTE: This will break just about all Flatpaks by default, it is ON YOU to configure them to work with this configuration."
     echo "NOTE 2: This DOES NOT enable hardened_malloc, use the harden-flatpak ujust command."
     echo ""
@@ -171,7 +172,12 @@ flatpak-permissions-lockdown:
             $kCommand --talk-name="$i" com.github.tchx84.Flatseal
         done
         echo ""
-        echo "Done"
+        echo "-- Granting Warehouse Access to Bus Names --"
+        for i in "${kWarehouseNameAccess[@]}"; do
+            echo "	Granting $i..."
+            $kCommand --talk-name="$i" io.github.flattool.Warehouse
+        done
+        echo ""        echo "Done"
     fi
 
 # Resets Flatpak's global overrides

--- a/files/justfiles/hardening.just
+++ b/files/justfiles/hardening.just
@@ -177,7 +177,8 @@ flatpak-permissions-lockdown:
             echo "	Granting $i..."
             $kCommand --talk-name="$i" io.github.flattool.Warehouse
         done
-        echo ""        echo "Done"
+        echo ""
+        echo "Done"
     fi
 
 # Resets Flatpak's global overrides

--- a/files/justfiles/hardening.just
+++ b/files/justfiles/hardening.just
@@ -99,7 +99,7 @@ flatpak-permissions-lockdown:
     confirmation=""
 
     echo "This will configure flatpak to automatically reject most permissions (with the exception of the Wayland socket and the Dri device, since these are commonly used and ensure at the very least most apps will work without crashing)."
-    echo "This will also grant Flatseal and Warehouse access to certain permissions to allow it to operate and make reconfiguring much easier."
+    echo "This will also grant Flatseal and Warehouse access to certain permissions to allow them to operate and make reconfiguring much easier."
     echo "NOTE: This will break just about all Flatpaks by default, it is ON YOU to configure them to work with this configuration."
     echo "NOTE 2: This DOES NOT enable hardened_malloc, use the harden-flatpak ujust command."
     echo ""


### PR DESCRIPTION
This PR edits the `flatpak-permission-lockdown` ujust command to add the `org.freedesktop.Flatpak`  talk permission to Warehouse, which it needs in order to manage and install flatpaks.