### PR TITLE
fix: add LD_PRELOAD=libhardened_malloc.so to /etc/profile.d

### DIFF
--- a/files/system/etc/profile.d/hardened_malloc.sh
+++ b/files/system/etc/profile.d/hardened_malloc.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/sh
+export LD_PRELOAD=libhardened_malloc.so


### PR DESCRIPTION
This ensures hardened_malloc is preloaded by user processes started through a TTY rather than via PAM, which includes Sway in its default configuration on the secureblue sericea images.