### PR TITLE
fix: enable timers, not services, for timer-triggered units

### DIFF
--- a/files/system/usr/lib/systemd/system-preset/10-flatpak-system-update.preset
+++ b/files/system/usr/lib/systemd/system-preset/10-flatpak-system-update.preset
@@ -1,1 +1,1 @@
-enable flatpak-system-update.service
+enable flatpak-system-update.timer

--- a/files/system/usr/lib/systemd/user-preset/10-flatpak-user-update.preset
+++ b/files/system/usr/lib/systemd/user-preset/10-flatpak-user-update.preset
@@ -1,1 +1,1 @@
-enable flatpak-user-update.service
+enable flatpak-user-update.timer

--- a/files/system/usr/lib/systemd/user-preset/11-secureblue-key-enrollment-verification.preset
+++ b/files/system/usr/lib/systemd/user-preset/11-secureblue-key-enrollment-verification.preset
@@ -1,2 +1,1 @@
-enable secureblue-key-enrollment-verification.service
 enable secureblue-key-enrollment-verification.timer

--- a/files/system/usr/lib/systemd/user-preset/12-secureblue-flatpak-setup.preset
+++ b/files/system/usr/lib/systemd/user-preset/12-secureblue-flatpak-setup.preset
@@ -1,2 +1,1 @@
-enable secureblue-flatpak-setup.service
 enable secureblue-flatpak-setup.timer

--- a/files/system/usr/lib/systemd/user-preset/13-secureblue-update-verification.preset
+++ b/files/system/usr/lib/systemd/user-preset/13-secureblue-update-verification.preset
@@ -1,2 +1,1 @@
-enable secureblue-update-verification.service
 enable secureblue-update-verification.timer


### PR DESCRIPTION
Fixes #1170. These systemd service units are triggered by timers and have no [Install] section, so enabling the service directly does nothing; only the corresponding timer should be enabled.