### PR TITLE
chore(kinoite): remove trivalent qt ui

### DIFF
--- a/recipes/common/kinoite-modules.yml
+++ b/recipes/common/kinoite-modules.yml
@@ -14,8 +14,6 @@ modules:
   - type: rpm-ostree
     repos:
       - https://repo.secureblue.dev/secureblue.repo
-    install:
-      - trivalent-qt6-ui
     remove:
       - kde-connect
       - kde-connect-libs


### PR DESCRIPTION
The qt ui for chromium-based browsers is unstable and crashes frequently. Removing this from our images until this is resolved upstream. 

In the meantime, users can layer this back if they want, but it's not usable in its current state.