### PR TITLE
chore(securecore): remove coreos oci migration motd

### DIFF
--- a/files/scripts/securecoreremovemigrationmotd.sh
+++ b/files/scripts/securecoreremovemigrationmotd.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+set -oue pipefail
+
+rm /etc/systemd/system/multi-user.target.wants/coreos-oci-migration-motd.service

--- a/recipes/common/server-modules.yml
+++ b/recipes/common/server-modules.yml
@@ -35,3 +35,4 @@ modules:
         - removebrewjust.sh
         - removesuid.sh
         - securecoreremovebrewmotd.sh
+        - securecoreremovemigrationmotd.sh


### PR DESCRIPTION
Upstream is moving to bootc images. We're already using bootc images, so we don't need this migration alert.