### PR TITLE
fix: apply hardened_malloc to systemd manager and PAM env

### DIFF
--- a/files/scripts/hardened_malloc-pam.sh
+++ b/files/scripts/hardened_malloc-pam.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+set -euo pipefail
+
+sed -i -e '$a\LD_PRELOAD DEFAULT=libhardened_malloc.so' -e '/^LD_PRELOAD[[:space:]]/d' /etc/security/pam_env.conf

--- a/files/system/usr/lib/systemd/system.conf.d/40-hardened_malloc.conf
+++ b/files/system/usr/lib/systemd/system.conf.d/40-hardened_malloc.conf
@@ -1,0 +1,2 @@
+[Manager]
+DefaultEnvironment=LD_PRELOAD=libhardened_malloc.so

--- a/recipes/common/common-modules.yml
+++ b/recipes/common/common-modules.yml
@@ -23,6 +23,7 @@ modules:
       scripts:
         - manuallyinstalljust.sh
         - hardenlogindefs.sh
+        - hardened_malloc-pam.sh
     - type: files
       files:
         - source: system/usr


### PR DESCRIPTION
This plugs a couple gaps in how hardened_malloc is applied via `LD_PRELOAD`:
1. Set `LD_PRELOAD` as a default environment variable in the systemd system service manager, ensuring systemd user instances preload hardened_malloc.
2. Set `LD_PRELOAD` in `pam_env.conf`, ensuring login shells started via tty also preload hardened_malloc.

See the documentation for `environment.d(5)` for why this is necessary: https://www.man7.org/linux/man-pages/man5/environment.d.5.html
> Note that these files do not affect the environment block of the service manager itself, but exclusively the environment blocks passed to the services it manages. Environment variables set that way thus cannot be used to influence behaviour of the service manager. In order to make changes to the service manager's environment block the environment must be modified before the user's service manager is invoked, **for example from the system service manager or via a PAM module**.