### PR TITLE
feat: enhance bash env lockdown by preventing moving .config

### DIFF
--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -220,6 +220,8 @@ toggle-xwayland ACTION="prompt":
       fi
     fi
 
+alias toggle-home-dir-lockdown := toggle-bash-environment-lockdown
+
 # Toggle bash environment lockdown (mitigates LD_PRELOAD attacks). Use skip_approval to bypass initial prompt, and apply_for_all_users to bypass secondary prompt.
 toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prompt":
     #!/bin/run0 /bin/bash
@@ -296,6 +298,13 @@ toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prom
         user_home="$(getent passwd "$user" | awk -F':' '{ print $6}')"
         [ -d "$user_home" ] || { echo "Variable \$user_home for $user is somehow empty (check your getent passwd entries)"; echo "safely exiting."; exit 1; }
 
+        STICKY_DIRS=(
+            "$user_home"
+            "$user_home/.cache"
+            "$user_home/.config"
+            "$user_home/.local"
+        )
+
         BASH_ENV_FILES=(
             "$user_home/.bashrc"
             "$user_home/.bash_profile"
@@ -316,6 +325,22 @@ toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prom
         #        add immutability
 
         if [[ "$pending_status" == "locked" ]]; then
+            # Make home directory and certain subdirectories owned by root but with the user
+            # granted read-write-execute permissions. Set the sticky bit to prevent the user
+            # from moving or deleting files or subdirectories they don't own.
+            for directory in "${STICKY_DIRS[@]}"; do
+                mkdir -p "$directory"
+                # Ensure group is set before giving group write permissions.
+                chgrp "$user" "$directory"
+                chmod 01770 "$directory"
+                # If directory has an ACL (which could override default group permissions),
+                # set ACL granting user rwx access.
+                if [ -n "$(getfacl --skip-base "$directory")" ]; then
+                    setfacl -m "user:${user}:rwx" "$directory"
+                fi
+                chown "root:${user}" "$directory"
+            done
+
             backup_dest="$user_home/bash_env_files/$current_time/"
             mkdir -p "$backup_dest"
 
@@ -350,6 +375,13 @@ toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prom
             chmod -R 700 "$user_home/bash_env_files"
             chown -R "$user:" "$user_home/bash_env_files"
         else
+            for directory in "${LOCKDOWN_DIRS[@]}"; do
+                if [ -e "$directory" ]; then
+                    chown "${user}:${user}" "$directory"
+                    chmod 00700 "$directory"
+                fi
+            done
+
             for file in "${BASH_ENV_FILES[@]}"; do
                 if [ ! -f "$file" ] && [ ! -d "$file" ] && [ -e "$file" ]; then
                     echo "Special file detected on absolute filepath ($file) from BASH_ENV_FILES. It will not be modified."

--- a/files/system/etc/profile.d/xdg-base-dirs.sh
+++ b/files/system/etc/profile.d/xdg-base-dirs.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/sh
+# For reference, see: https://specifications.freedesktop.org/basedir-spec/latest/
+export XDG_DATA_HOME="${HOME}/.local/share"
+export XDG_CONFIG_HOME="${HOME}/.config"
+export XDG_STATE_HOME="${HOME}/.local/state"
+export XDG_CACHE_HOME="${HOME}/.cache"

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -24,7 +24,6 @@ import filecmp
 import glob
 import json
 import os
-import os.path
 import signal
 import stat
 
@@ -32,6 +31,7 @@ import stat
 import subprocess  # nosec
 import sys
 import traceback
+from pathlib import Path
 from typing import Final
 
 from audit_flatpak import check_flatpak_permissions, parse_flatpak_permissions
@@ -248,7 +248,7 @@ def audit_container_policy():
         status = FAIL
         warnings.append(f"{policy_file} has been modified")
     local_override = "~/.config/containers/policy.json"
-    if os.path.isfile(os.path.expanduser(local_override)):
+    if Path(local_override).expanduser().is_file():
         status = FAIL
         warnings.append(f"{local_override} exists")
     yield Report("Ensuring no container policy overrides", status, warnings=warnings)
@@ -481,7 +481,7 @@ def audit_xwayland(state):
             path = "/etc/sway/config.d/99-noxwayland.conf"
         case _:
             return
-    if os.path.isfile(path):
+    if Path(path).is_file():
         status = PASS
         rec = None
     else:
@@ -645,44 +645,74 @@ def audit_secureboot():
 
 
 @audit
-def audit_bash_env_lockdown():
+def audit_bash_env_lockdown(state):
     """Ensure the current user's bash environment is locked down."""
-    bash_env_paths = map(
-        os.path.expanduser,
-        [
-            "~/.bashrc",
-            "~/.bash_profile",
-            "~/.config/bash_completion",
-            "~/.profile",
-            "~/.bash_logout",
-            "~/.bash_login",
-            "~/.bashrc.d/",
-            "~/.config/environment.d/",
-        ],
-    )
+    status = PASS
+    rec = None
+    home = Path.home()
+    bash_env_paths = [
+        home / ".bashrc",
+        home / ".bash_profile",
+        home / ".config/bash_completion",
+        home / ".profile",
+        home / ".bash_logout",
+        home / ".bash_login",
+        home / ".bashrc.d/",
+        home / ".config/environment.d/",
+    ]
     unlocked_files = []
     for path in bash_env_paths:
-        if not os.path.exists(path) or (not os.path.isfile(path) and not os.path.isdir(path)):
+        if not path.exists() or (not path.is_file() and not path.is_dir()):
             unlocked_files.append(path)
         else:
             try:
-                immutable = "i" in command_stdout("lsattr", "-d", path).split()[0]
+                immutable = "i" in command_stdout("lsattr", "-d", str(path)).split()[0]
             except subprocess.CalledProcessError:
                 immutable = False
             if not immutable:
                 unlocked_files.append(path)
     if unlocked_files:
         status = FAIL
-        unlocked_files_string = "\n".join(unlocked_files)
+        unlocked_files_string = "\n".join(str(path) for path in unlocked_files)
         rec = f"""Bash environment is not locked down.
                 The following files do not appear to be immutable or do not exist:
                 {unlocked_files_string}
                 To fix, run:
                 $ ujust toggle-bash-environment-lockdown"""
-    else:
-        status = PASS
-        rec = None
+    state["bash_env_lockdown"] = status == PASS
     yield Report("Ensuring current user's bash environment is locked down", status, recs=rec)
+
+
+@audit
+@depends_on("audit_bash_env_lockdown")
+def audit_home_dir_perms(state):
+    """Audit home directory permissions"""
+    if not state["bash_env_lockdown"]:
+        return
+    status = PASS
+    rec = None
+    home = Path.home()
+    uid = os.getuid()
+
+    def perms_correct(directory: Path, uid: int) -> bool:
+        dir_stat = directory.stat()
+        root_owned = dir_stat.st_uid == 0
+        user_group = dir_stat.st_gid == uid
+        mode_1770 = stat.filemode(dir_stat.st_mode) == "drwxrwx--T"
+        return root_owned and user_group and mode_1770
+
+    home_perms_correct = perms_correct(home, uid)
+    config_perms_correct = perms_correct(home / ".config", uid)
+    if not home_perms_correct or not config_perms_correct:
+        status = FAIL
+        rec = f"""
+            Certain permissions must be set to avoid a gap in the bash environment lockdown.
+            {"" if home_perms_correct else "Home directory permissions are not set properly."}
+            {"" if config_perms_correct else "~/.config permissions are not set properly."}
+            To fix, run the following twice (to toggle the lockdown off and on again):
+            $ ujust toggle-bash-environment-lockdown
+        """
+    yield Report("Checking home directory permissions", status, recs=rec)
 
 
 @audit


### PR DESCRIPTION
This enhances the bash environment lockdown by changing certain directory permissions to prevent unprivileged users from moving or deleting the subdirectories `.config`, `.cache`, and `.local` of their home directory, while still allowing users full read-write access to those directories.

This is accomplished as follows:
1. Change the modes of the user's home directory and the above subdirectories to 1770. The sticky bit prevents the user from moving or deleting contained files or directories they do not own.
2. Use `setfacl` to grant the user `rwx` access to any of the directories that already have an ACL (which could override the default group permissions).
3. Change the directories' ownership to `root:user`. Because of the first two steps, the user still has full access to the directories' contents.

This is admittedly somewhat of a hack, but it works and shouldn't restrict user access to their files in any unintended ways.

Also added a check to the audit script for these permission settings.

Also set `XDG_CONFIG_HOME` explicitly (in `/etc/profile.d`) to its default value, which normally wouldn't change anything; however, if `XDG_CONFIG_HOME` is not set, [podman checks](https://github.com/containers/storage/blob/f555b9f2ddaeafe1a516117a9be585405cd7fbde/pkg/homedir/homedir_unix.go#L107) that `~/.config` is owned by the current user and errors out if it's not. Unclear whether podman will change this behavior to also apply to `XDG_CONFIG_HOME` but for now it works.