### PR TITLE
fix: mask akmods-keygen on zfs images

### DIFF
--- a/files/scripts/installzfskmod.sh
+++ b/files/scripts/installzfskmod.sh
@@ -88,5 +88,6 @@ rm -f /etc/dnf/protected.d/sudo.conf
 dnf remove -y sudo autoconf automake mock 
 
 systemctl disable akmods-keygen@akmods-keygen.service
+systemctl mask akmods-keygen@akmods-keygen.service
 systemctl disable akmods-keygen.target
-
+systemctl mask akmods-keygen.target


### PR DESCRIPTION
We don't need keygen because we handle signing at build time