### PR TITLE
chore: drop cap for no longer present executable

### DIFF
--- a/files/scripts/removesuid.sh
+++ b/files/scripts/removesuid.sh
@@ -86,6 +86,5 @@ set_caps_if_present() {
 }
 
 set_caps_if_present "cap_dac_read_search,cap_audit_write=ep" "/usr/bin/chage"
-set_caps_if_present "cap_dac_read_search=ep" "/usr/libexec/openssh/ssh-keysign"
 set_caps_if_present "cap_sys_admin=ep" "/usr/bin/fusermount3"
 set_caps_if_present "cap_dac_read_search,cap_audit_write=ep" "/usr/sbin/unix_chkpwd"


### PR DESCRIPTION
ssh-keysign is no longer being shipped in our base images by default