### PR TITLE
feat: SELinux policy to prevent moving or deleting .config

### DIFF
--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -291,6 +291,10 @@ toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prom
         exit
     fi
 
+    if [[ "$pending_status" != "locked" ]]; then
+        setsebool -P homedir_lockdown_enabled off
+    fi
+
     for user in "${user_list[@]}"; do
         echo "Applying for user: $user"
         user_home="$(getent passwd "$user" | awk -F':' '{ print $6}')"
@@ -316,6 +320,8 @@ toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prom
         #        add immutability
 
         if [[ "$pending_status" == "locked" ]]; then
+            chcon -t config_locked_home_t "$user_home/.config"
+
             backup_dest="$user_home/bash_env_files/$current_time/"
             mkdir -p "$backup_dest"
 
@@ -350,6 +356,8 @@ toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prom
             chmod -R 700 "$user_home/bash_env_files"
             chown -R "$user:" "$user_home/bash_env_files"
         else
+            restorecon "$user_home/.config"
+
             for file in "${BASH_ENV_FILES[@]}"; do
                 if [ ! -f "$file" ] && [ ! -d "$file" ] && [ -e "$file" ]; then
                     echo "Special file detected on absolute filepath ($file) from BASH_ENV_FILES. It will not be modified."
@@ -361,6 +369,10 @@ toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prom
             done
         fi
     done
+
+    if [[ "$pending_status" == "locked" ]]; then
+        setsebool -P homedir_lockdown_enabled on
+    fi
 
     echo "${user_list[@]}" "$pending_status."
     echo "${bold}NOTE${unbold}: until a reboot, any process with an open file descriptor will continue to have the access they had before this script was run."

--- a/files/scripts/installselinuxpolicies.sh
+++ b/files/scripts/installselinuxpolicies.sh
@@ -32,6 +32,7 @@ cd ./selinux/systemsettings
 bash systemsettings.sh
 cd ../..
 
+semodule -i ./selinux/homedir_lockdown/homedir_lockdown.cil
 semodule -i ./selinux/user_namespace/grant_userns.cil
 semodule -i ./selinux/user_namespace/harden_userns.cil
 semodule -i ./selinux/user_namespace/harden_container_userns.cil

--- a/files/scripts/selinux/homedir_lockdown/homedir_lockdown.cil
+++ b/files/scripts/selinux/homedir_lockdown/homedir_lockdown.cil
@@ -1,0 +1,42 @@
+; Copyright 2025 The Secureblue Authors
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software distributed under the License is
+; distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and limitations under the License.
+
+(type config_locked_home_t)
+
+(allow config_locked_home_t user_home_t (filesystem (associate)))
+(allow config_locked_home_t fs_t (filesystem (associate)))
+
+(macro set_config_locked_perms ((type PROCESS_T))
+    (allow PROCESS_T config_locked_home_t (dir (add_name append execute getattr link map open read remove_name search watch write watch_reads watch_sb watch_with_perm)))
+    (typetransition PROCESS_T config_locked_home_t dir config_home_t)
+    (typetransition PROCESS_T config_locked_home_t file config_home_t)
+    (typetransition PROCESS_T config_locked_home_t lnk_file config_home_t)
+)
+
+(call set_config_locked_perms (container_runtime_t))
+(call set_config_locked_perms (container_t))
+(call set_config_locked_perms (flatpak_t))
+(call set_config_locked_perms (init_t))
+(call set_config_locked_perms (spc_t))
+(call set_config_locked_perms (trivalent_script_t))
+(call set_config_locked_perms (trivalent_t))
+(call set_config_locked_perms (unconfined_dbusd_t))
+(call set_config_locked_perms (unconfined_t))
+
+(allow unconfined_t config_locked_home_t (dir (audit_access execmod ioctl lock quotaon reparent setattr watch_mount)))
+
+(boolean homedir_lockdown_enabled false)
+(booleanif homedir_lockdown_enabled
+    (false
+        (allow unconfined_t config_locked_home_t (dir (create mounton relabelfrom relabelto rename rmdir unlink)))
+    )
+)

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -45,6 +45,7 @@ from utils import (
     get_width,
     parse_config,
     print_err,
+    selinux_context,
     validate_sysctl,
     warn_if_root,
 )
@@ -720,7 +721,7 @@ def audit_secureboot():
 
 
 @audit
-def audit_bash_env_lockdown():
+def audit_bash_env_lockdown(state):
     """Ensure the current user's bash environment is locked down."""
     bash_env_paths = map(
         os.path.expanduser,
@@ -757,7 +758,29 @@ def audit_bash_env_lockdown():
     else:
         status = PASS
         rec = None
+    state["bash_env_lockdown"] = status == PASS
     yield Report("Ensuring current user's bash environment is locked down", status, recs=rec)
+
+
+@audit
+@depends_on("audit_bash_env_lockdown")
+def audit_home_dir_perms(state):
+    """Audit home directory permissions"""
+    if not state.get("bash_env_lockdown"):
+        return
+    status = PASS
+    rec = None
+    config_dir = os.path.expanduser("~/.config")
+    selinux_type = selinux_context(config_dir)[2]
+    if selinux_type != "config_locked_home_t":
+        status = FAIL
+        rec = f"""
+            {config_dir} is not locked down.
+            This is a gap in the bash environment lockdown.
+            To fix, run the following twice (to toggle the lockdown off and on again):
+            $ ujust toggle-bash-environment-lockdown
+        """
+    yield Report("Ensuring config directory is locked down", status, recs=rec)
 
 
 @audit

--- a/files/system/usr/libexec/secureblue/utils/__init__.py
+++ b/files/system/usr/libexec/secureblue/utils/__init__.py
@@ -212,3 +212,9 @@ def validate_sysctl(sysctl: str, actual: str, expected: str) -> bool:
         # https://www.kernel.org/doc/html/latest/admin-guide/sysrq.html
         return actual in (expected, "0", "4")
     return actual == expected
+
+
+def selinux_context(path: str) -> list[str]:
+    """Get SELinux security context of a file."""
+    raw_context = os.getxattr(path, "security.selinux")
+    return raw_context.decode("utf8").rstrip("\x00").split(":")


### PR DESCRIPTION
This enhances the bash environment lockdown with an SELinux policy module that prevents the directory `$HOME/.config` from being moved, deleted, or mounted over.

The restrictions on `.config` are controlled by an SELinux boolean, `homedir_lockdown_enabled`, that defaults to off. When it is on, relabeling to and from `config_locked_home_t` is also disallowed. The bash environment lockdown changes `.config` to have this type and then toggles the boolean on.

Also added a check to the audit script for this enhancement, informing the user if the bash environment lockdown is on but `.config` doesn't have the `config_locked_home_t` type.

Note: This is a rough draft; the basic functionality seems to work on my system, but this is my first time writing an SELinux policy module and I've likely made mistakes or oversights. Review is much appreciated.