### PR TITLE
fix: sandbox sed commands, style/clarity improvements

### DIFF
--- a/docs/example.butane
+++ b/docs/example.butane
@@ -28,7 +28,7 @@ storage:
             if [ $? != 0 ]; then
               echo "Error: Secureblue installer failed."
             else
-              sed -i "/\/opt\/run_install_secureblue.sh/d" /var/home/core/.bash_profile
+              sed -i '/\/opt\/run_install_secureblue.sh/d' /var/home/core/.bash_profile
               sudo rm -f /opt/*install_secureblue.sh
               echo "Automatically rebooting in 5 seconds..."
               sleep 5

--- a/files/justfiles/hardening.just
+++ b/files/justfiles/hardening.just
@@ -201,7 +201,7 @@ setup-usbguard:
         groupadd usbguard
         usermod -aG usbguard "$SUDO_USER"
         usbguard generate-policy > /etc/usbguard/rules.conf
-        sed -i "/IPCAllowedGroups=wheel/s/\$/ usbguard/" /etc/usbguard/usbguard-daemon.conf
+        sed -i "/^IPCAllowedGroups=wheel/s/\$/ usbguard/" /etc/usbguard/usbguard-daemon.conf
         restorecon -vR /var/log/usbguard
         systemctl enable --now usbguard.service
         usbguard add-user "$SUDO_USER"

--- a/files/justfiles/toggles.just
+++ b/files/justfiles/toggles.just
@@ -61,19 +61,19 @@ toggle-bluetooth-modules:
 # Toggle GHNS (KDE Get New Stuff)
 toggle-ghns:
     #! /bin/run0 /bin/bash
-    KDE_GLOBALS_FILE="/etc/xdg/kdeglobals"
-    if test -e $KDE_GLOBALS_FILE; then
-      if grep -q "ghns=false" "$KDE_GLOBALS_FILE"; then
-        sed -i "s/ghns=false/ghns=true/" "$KDE_GLOBALS_FILE"
-        echo "GHNS enabled."
-      elif grep -q "ghns=true" "$KDE_GLOBALS_FILE"; then
-        sed -i "s/ghns=true/ghns=false/" "$KDE_GLOBALS_FILE"
-        echo "GHNS disabled."
+    KDE_GLOBALS_FILE='/etc/xdg/kdeglobals'
+    if test -e "$KDE_GLOBALS_FILE"; then
+      if grep -q '^ghns=false' "$KDE_GLOBALS_FILE"; then
+        sed -i 's/^ghns=false.*/ghns=true/' "$KDE_GLOBALS_FILE"
+        echo 'GHNS enabled.'
+      elif grep -q '^ghns=true' "$KDE_GLOBALS_FILE"; then
+        sed -i 's/^ghns=true.*/ghns=false/' "$KDE_GLOBALS_FILE"
+        echo 'GHNS disabled.'
       else
-        echo "The kdeglobals file is missing the ghns toggle."
+        echo 'The kdeglobals file is missing the ghns toggle.'
       fi
     else
-      echo "No kdeglobals file found. Are you on kinoite?"
+      echo 'No kdeglobals file found. Are you on kinoite?'
     fi
 
 # enable a kernel module that is disabled by modprobe.d (requires restart)
@@ -127,11 +127,11 @@ alias toggle-ptrace-scope := toggle-anticheat-support
 toggle-anticheat-support:
     #! /bin/run0 /bin/bash
     SYSCTL_HARDENING_FILE="/etc/sysctl.d/60-hardening.conf"
-    if grep -q "kernel.yama.ptrace_scope = 3" "$SYSCTL_HARDENING_FILE"; then
-        sed -i "s/kernel.yama.ptrace_scope = 3/kernel.yama.ptrace_scope = 1/" "$SYSCTL_HARDENING_FILE"
+    if grep -q '^kernel.yama.ptrace_scope = 3' "$SYSCTL_HARDENING_FILE"; then
+        sed -i 's/^kernel.yama.ptrace_scope =.*/kernel.yama.ptrace_scope = 1/' "$SYSCTL_HARDENING_FILE"
         echo "Anticheat support enabled. ptrace_scope set to 1."
-    elif grep -q "kernel.yama.ptrace_scope = 1" "$SYSCTL_HARDENING_FILE"; then
-        sed -i "s/kernel.yama.ptrace_scope = 1/kernel.yama.ptrace_scope = 3/" "$SYSCTL_HARDENING_FILE"
+    elif grep -q 'kernel.yama.ptrace_scope = 1' "$SYSCTL_HARDENING_FILE"; then
+        sed -i 's/^kernel.yama.ptrace_scope =.*/kernel.yama.ptrace_scope = 3/' "$SYSCTL_HARDENING_FILE"
         echo "Anticheat support disabled. ptrace_scope set back to 3."
     else
         echo "The sysctl hardening file is missing the ptrace_scope setting."

--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -356,7 +356,6 @@ install-vpn:
     # ref: https://www.ivpn.net/knowledgebase/linux/fedora-silverblue/
     # ref: https://mullvad.net/de/download/vpn/linux
     # ref: https://protonvpn.com/support/en/official-linux-vpn-fedora
-    REPO_REGEX="/^enabled[ =]/ s/0/1/g"
     function install_vpn() {
         local INSTRUCTIONS
         local PACKAGE_NAME
@@ -415,7 +414,7 @@ install-vpn:
                 ;;
         esac
 
-        if ! run0 sh -c "sed -i '$REPO_REGEX' /etc/yum.repos.d/$REPO_NAME.repo && rpm-ostree install --assumeyes $PACKAGE_NAME"; then
+        if ! run0 sh -c 'sed -Ei "s/^enabled ?=.*/enabled=1/" "/etc/yum.repos.d/$1.repo" && rpm-ostree install --assumeyes "$2"' sh "$REPO_NAME" "$PACKAGE_NAME"; then
             echo "Error: The installation didn't complete successfully, aborting..."
             exit 1
         fi

--- a/files/scripts/addchromiumdesktopfile.sh
+++ b/files/scripts/addchromiumdesktopfile.sh
@@ -14,4 +14,4 @@
 
 set -oue pipefail
 
-sed -i 's/org.mozilla.firefox/trivalent/' /usr/share/wayfire/wf-shell.ini 
+sed -i 's/org.mozilla.firefox/trivalent/' /usr/share/wayfire/wf-shell.ini

--- a/files/scripts/addimageinfo.sh
+++ b/files/scripts/addimageinfo.sh
@@ -23,21 +23,21 @@ SUPPORT_URL="https://github.com/secureblue/secureblue/issues"
 BUG_SUPPORT_URL="https://github.com/secureblue/secureblue/issues"
 
 
-sed -i "s|^VARIANT_ID=.*|VARIANT_ID=$IMAGE_NAME|" /usr/lib/os-release
-sed -i "s|^PRETTY_NAME=.*|PRETTY_NAME=\"${IMAGE_PRETTY_NAME} (powered by Fedora Atomic)\"|" /usr/lib/os-release
-sed -i "s|^NAME=.*|NAME=\"$IMAGE_PRETTY_NAME\"|" /usr/lib/os-release
-sed -i "s|^HOME_URL=.*|HOME_URL=\"$HOME_URL\"|" /usr/lib/os-release
-sed -i "s|^DOCUMENTATION_URL=.*|DOCUMENTATION_URL=\"$DOCUMENTATION_URL\"|" /usr/lib/os-release
-sed -i "s|^SUPPORT_URL=.*|SUPPORT_URL=\"$SUPPORT_URL\"|" /usr/lib/os-release
-sed -i "s|^BUG_REPORT_URL=.*|BUG_REPORT_URL=\"$BUG_SUPPORT_URL\"|" /usr/lib/os-release
-sed -i "s|^CPE_NAME=\"cpe:/o:fedoraproject:fedora|CPE_NAME=\"cpe:/o:secureblue:${IMAGE_PRETTY_NAME,}|" /usr/lib/os-release
-sed -i "s|^DEFAULT_HOSTNAME=.*|DEFAULT_HOSTNAME=\"${IMAGE_PRETTY_NAME,}\"|" /usr/lib/os-release
-sed -i "s|^ID=fedora|ID=${IMAGE_PRETTY_NAME,}\nID_LIKE=\"${IMAGE_LIKE}\"|" /usr/lib/os-release
-sed -i "/^REDHAT_BUGZILLA_PRODUCT=/d; /^REDHAT_BUGZILLA_PRODUCT_VERSION=/d; /^REDHAT_SUPPORT_PRODUCT=/d; /^REDHAT_SUPPORT_PRODUCT_VERSION=/d" /usr/lib/os-release
+sed -i --sandbox "s|^VARIANT_ID=.*|VARIANT_ID=$IMAGE_NAME|" /usr/lib/os-release
+sed -i --sandbox "s|^PRETTY_NAME=.*|PRETTY_NAME=\"${IMAGE_PRETTY_NAME} (powered by Fedora Atomic)\"|" /usr/lib/os-release
+sed -i --sandbox "s|^NAME=.*|NAME=\"$IMAGE_PRETTY_NAME\"|" /usr/lib/os-release
+sed -i --sandbox "s|^HOME_URL=.*|HOME_URL=\"$HOME_URL\"|" /usr/lib/os-release
+sed -i --sandbox "s|^DOCUMENTATION_URL=.*|DOCUMENTATION_URL=\"$DOCUMENTATION_URL\"|" /usr/lib/os-release
+sed -i --sandbox "s|^SUPPORT_URL=.*|SUPPORT_URL=\"$SUPPORT_URL\"|" /usr/lib/os-release
+sed -i --sandbox "s|^BUG_REPORT_URL=.*|BUG_REPORT_URL=\"$BUG_SUPPORT_URL\"|" /usr/lib/os-release
+sed -i --sandbox "s|^CPE_NAME=\"cpe:/o:fedoraproject:fedora|CPE_NAME=\"cpe:/o:secureblue:${IMAGE_PRETTY_NAME,}|" /usr/lib/os-release
+sed -i --sandbox "s|^DEFAULT_HOSTNAME=.*|DEFAULT_HOSTNAME=\"${IMAGE_PRETTY_NAME,}\"|" /usr/lib/os-release
+sed -i --sandbox "s|^ID=fedora|ID=${IMAGE_PRETTY_NAME,}\nID_LIKE=\"${IMAGE_LIKE}\"|" /usr/lib/os-release
+sed -Ei '/^REDHAT_(BUGZILLA|SUPPORT)_PRODUCT(_VERSION)?=/d' /usr/lib/os-release
 
 # Added in systemd 249.
 # https://www.freedesktop.org/software/systemd/man/latest/os-release.html#IMAGE_ID=
-sed -i '$a\IMAGE_ID='"\"${IMAGE_NAME}\"" /usr/lib/os-release
+sed -i --sandbox '$a\IMAGE_ID='"\"${IMAGE_NAME}\"" /usr/lib/os-release
 
 # Fix issues caused by ID no longer being fedora
-sed -i "s/^EFIDIR=.*/EFIDIR=\"fedora\"/" /usr/sbin/grub2-switch-to-blscfg
+sed -i 's/^EFIDIR=.*/EFIDIR="fedora"/' /usr/sbin/grub2-switch-to-blscfg

--- a/files/scripts/disablewlrportals.sh
+++ b/files/scripts/disablewlrportals.sh
@@ -4,4 +4,4 @@ set -oue pipefail
 
 PORTALS_CONF="/usr/share/xdg-desktop-portal/sway-portals.conf"
 
-sed -Ei "/^org\.freedesktop\.impl\.portal\.Screen(Cast|shot)=wlr$/s/=wlr/=none/" "$PORTALS_CONF"
+sed -Ei '/^org\.freedesktop\.impl\.portal\.Screen(Cast|shot)=wlr$/s/=wlr/=none/' "$PORTALS_CONF"

--- a/files/scripts/excludepcsc.sh
+++ b/files/scripts/excludepcsc.sh
@@ -14,4 +14,4 @@
 
 set -oue pipefail
 
-sed -i 's/add_dracutmodules+=" fido2 tpm2-tss pkcs11 pcsc "/add_dracutmodules+=" fido2 tpm2-tss pkcs11 "/' /usr/lib/dracut/dracut.conf.d/90-ublue-luks.conf
+sed -i '/^add_dracutmodules+=" .* "/s/ pcsc / /' /usr/lib/dracut/dracut.conf.d/90-ublue-luks.conf

--- a/files/scripts/installnvidiakmod.sh
+++ b/files/scripts/installnvidiakmod.sh
@@ -23,12 +23,12 @@ if [[ "$IMAGE_NAME" == *"open"* ]]; then
 fi
 
 curl -Lo /etc/yum.repos.d/negativo17-fedora-nvidia.repo https://negativo17.org/repos/fedora-nvidia.repo
-sed -i '0,/enabled=1/{s/enabled=1/enabled=1\npriority=90/}' /etc/yum.repos.d/negativo17-fedora-nvidia.repo
+sed -i '/^enabled=1/a\priority=90' /etc/yum.repos.d/negativo17-fedora-nvidia.repo
 
 dnf install -y "kernel-devel-matched-$(rpm -q 'kernel' --queryformat '%{VERSION}')"
 dnf install -y "akmod-nvidia*.fc${RELEASE}"
 
-sed -i "s/^MODULE_VARIANT=.*/MODULE_VARIANT=$KERNEL_MODULE_TYPE/" /etc/nvidia/kernel.conf
+sed -i --sandbox "s/^MODULE_VARIANT=.*/MODULE_VARIANT=$KERNEL_MODULE_TYPE/" /etc/nvidia/kernel.conf
 akmods --force --kernels "${KERNEL_VERSION}" --kmod "nvidia"
 
 # Depends on word splitting

--- a/files/scripts/installnvidiapackages.sh
+++ b/files/scripts/installnvidiapackages.sh
@@ -21,13 +21,13 @@ fi
 
 curl -L https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo \
     -o /etc/yum.repos.d/nvidia-container-toolkit.repo
-sed -i "s@gpgcheck=0@gpgcheck=1@" /etc/yum.repos.d/nvidia-container-toolkit.repo
+sed -i 's/^gpgcheck=0/gpgcheck=1/' /etc/yum.repos.d/nvidia-container-toolkit.repo
 
 curl -L https://negativo17.org/repos/fedora-nvidia.repo -o /etc/yum.repos.d/negativo17-fedora-nvidia.repo
 
 
-sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' /etc/yum.repos.d/nvidia-container-toolkit.repo
-sed -i '0,/enabled=0/{s/enabled=0/enabled=1\npriority=90/}' /etc/yum.repos.d/negativo17-fedora-nvidia.repo
+sed -i 's/^enabled=0.*/enabled=1/' /etc/yum.repos.d/nvidia-container-toolkit.repo
+sed -i 's/^enabled=0.*/enabled=1\npriority=90/' /etc/yum.repos.d/negativo17-fedora-nvidia.repo
 # required for rpm-ostree to function properly
 # shellcheck disable=SC2068
 rpm-ostree install ${nvidia_packages_list[@]}

--- a/files/scripts/installproprietarypackages.sh
+++ b/files/scripts/installproprietarypackages.sh
@@ -18,7 +18,7 @@ set -oue pipefail
 rpm-ostree install libopenjph
 
 curl -Lo /etc/yum.repos.d/negativo17-fedora-multimedia.repo https://negativo17.org/repos/fedora-multimedia.repo
-sed -i '0,/enabled=1/{s/enabled=1/enabled=1\npriority=90/}' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
+sed -i '/^enabled=1/a\priority=90' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
 
 rpm-ostree override replace \
   --experimental \

--- a/files/scripts/regenerateinitramfs.sh
+++ b/files/scripts/regenerateinitramfs.sh
@@ -14,6 +14,6 @@
 
 set -oue pipefail
 
-QUALIFIED_KERNEL="$(rpm -qa | grep -P 'kernel-(\d+\.\d+\.\d+)' | sed -E 's/kernel-//')"
+QUALIFIED_KERNEL="$(rpm -qa | grep -P 'kernel-(\d+\.\d+\.\d+)' | sed 's/kernel-//')"
 /usr/bin/dracut --no-hostonly --kver "$QUALIFIED_KERNEL" --reproducible -v --add ostree -f "/lib/modules/$QUALIFIED_KERNEL/initramfs.img"
 chmod 0600 "/lib/modules/$QUALIFIED_KERNEL/initramfs.img"

--- a/files/scripts/removebrewjust.sh
+++ b/files/scripts/removebrewjust.sh
@@ -15,4 +15,4 @@
 set -oue pipefail
 
 rm -f /usr/share/bluebuild/justfiles/brew.just
-sed -i '/import "\/usr\/share\/bluebuild\/justfiles\/brew.just"/d' /usr/share/ublue-os/just/60-custom.just 
+sed -i '/import "\/usr\/share\/bluebuild\/justfiles\/brew.just"/d' /usr/share/ublue-os/just/60-custom.just

--- a/files/scripts/setearlyloading.sh
+++ b/files/scripts/setearlyloading.sh
@@ -14,5 +14,5 @@
 
 set -oue pipefail
 
-sed -i 's@omit_drivers@force_drivers@g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
-sed -i 's@ nvidia @ i915 amdgpu nvidia @g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
+sed -i 's/omit_drivers/force_drivers/g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
+sed -i 's/ nvidia / i915 amdgpu nvidia /g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf

--- a/files/scripts/setserverdefaultzone.sh
+++ b/files/scripts/setserverdefaultzone.sh
@@ -14,4 +14,4 @@
 
 set -oue pipefail
 
-sed -i 's@DefaultZone=public@DefaultZone=FedoraServer@g' /etc/firewalld/firewalld.conf
+sed -i 's/^DefaultZone=public/DefaultZone=FedoraServer/' /etc/firewalld/firewalld.conf

--- a/files/system/usr/libexec/luks-enable-fido2-unlock.sh
+++ b/files/system/usr/libexec/luks-enable-fido2-unlock.sh
@@ -76,7 +76,7 @@ fi
 
 CRYPT_DISK_INFO=$(cryptsetup luksDump "$CRYPT_DISK")
 # Note: we use { grep "Keyslot" || true; } below to mask the nonzero return code if fido2 has not been setup yet
-before_cryptenroll_keyslot=$(echo "$CRYPT_DISK_INFO" | sed -n '/systemd-fido2$/,/Keyslot:/p' | { grep "Keyslot" || true; } | awk '{print $2}') 
+before_cryptenroll_keyslot=$(echo "$CRYPT_DISK_INFO" | sed -n '/systemd-fido2$/,/Keyslot:/p' | { grep "Keyslot" || true; } | awk '{print $2}')
 
 if echo "$CRYPT_DISK_INFO" | grep systemd-fido2 > /dev/null; then
   echo "FIDO2 already present in LUKS keyslot $before_cryptenroll_keyslot of $CRYPT_DISK."
@@ -96,12 +96,12 @@ fi
 echo "Enrolling FIDO2 unlock requires your existing LUKS unlock password"
 systemd-cryptenroll --fido2-device=auto "$CRYPT_DISK"
 cp /etc/crypttab /etc/crypttab.known-good
-sed -i "s/UUID=$(echo "$RD_LUKS_UUID" | cut -c6-) none discard/UUID=$(echo "$RD_LUKS_UUID" | cut -c6-) none - fido2-device=auto - discard/" /etc/crypttab
+sed -i --sandbox "s/UUID=$(echo "$RD_LUKS_UUID" | cut -c6-) none discard/UUID=$(echo "$RD_LUKS_UUID" | cut -c6-) none - fido2-device=auto - discard/" /etc/crypttab
 
 CRYPT_DISK_INFO=$(cryptsetup luksDump "$CRYPT_DISK")
 # Sets the new fido2 keyslot as preferred if it's the only one currently configured. (Users with more than one configured are presumed advanced and capable of their own priority management.)
 if [ "$(echo "$CRYPT_DISK_INFO" | grep -c "systemd-fido2")" -eq "1" ]; then
-  after_cryptenroll_keyslot=$(echo "$CRYPT_DISK_INFO" | sed -n '/systemd-fido2$/,/Keyslot:/p' | { grep "Keyslot" || true; } | awk '{print $2}') 
+  after_cryptenroll_keyslot=$(echo "$CRYPT_DISK_INFO" | sed -n '/systemd-fido2$/,/Keyslot:/p' | { grep "Keyslot" || true; } | awk '{print $2}')
   cryptsetup config --key-slot "$after_cryptenroll_keyslot" --priority "prefer" "$CRYPT_DISK"
 fi
 

--- a/files/system/usr/libexec/ublue-motd
+++ b/files/system/usr/libexec/ublue-motd
@@ -49,6 +49,6 @@ elif [ "$DIFFERENCE" -ge "$WEEK" ]; then
 else
     TIP='**For secureblue release notifications,** [subscribe:](https://secureblue.dev/faq#releases)'
 fi
-sed -e "s/%IMAGE_REF_NAME%/$IMAGE_REF_NAME/g" -e "s|%TIP%|$TIP|g" /usr/share/ublue-os/motd/secureblue.md | tr '~' '\n' | { command -v glow >/dev/null 2>&1 && glow -s auto -w 78 - || cat; }
+sed --sandbox -e "s/%IMAGE_REF_NAME%/$IMAGE_REF_NAME/g" -e "s|%TIP%|$TIP|g" /usr/share/ublue-os/motd/secureblue.md | tr '~' '\n' | { command -v glow >/dev/null 2>&1 && glow -s auto -w 78 - || cat; }
 
 

--- a/modules/secureblue-signing/secureblue-signing.sh
+++ b/modules/secureblue-signing/secureblue-signing.sh
@@ -75,7 +75,7 @@ cp POLICY.tmp /usr/etc/containers/policy.json
 cp POLICY.tmp /etc/containers/policy.json
 rm POLICY.tmp
 
-sed -i "s ghcr.io/IMAGENAME $IMAGE_REGISTRY g" "$MODULE_DIRECTORY/secureblue-signing/registry-config.yaml"
+sed -i --sandbox "s|ghcr.io/IMAGENAME|$IMAGE_REGISTRY|g" "$MODULE_DIRECTORY/secureblue-signing/registry-config.yaml"
 cp "$MODULE_DIRECTORY/secureblue-signing/registry-config.yaml" "$CONTAINER_DIR/registries.d/$IMAGE_REGISTRY_TITLE.yaml"
 cp "$MODULE_DIRECTORY/secureblue-signing/registry-config.yaml" "$ETC_CONTAINER_DIR/registries.d/$IMAGE_REGISTRY_TITLE.yaml"
 rm "$MODULE_DIRECTORY/secureblue-signing/registry-config.yaml"


### PR DESCRIPTION
The GNU sed program is capable of reading and writing files via the r/w commands and executing external programs via the e command. To eliminate the possibility of command injection, any sed usage where the script to be run has variable substitutions should use the `--sandbox` option to ensure scripts attempting to use the e/w/r commands are rejected.

Also made some conciseness/style/clarity improvements to various sed scripts.