### PR TITLE
feat: make default bash prompt display nonzero exit codes

### DIFF
--- a/files/system/etc/profile.d/xx-bash-prompt-command.sh
+++ b/files/system/etc/profile.d/xx-bash-prompt-command.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+# Filename needs to be alphabetically later than vte.sh
+if [ -n "${BASH_VERSION:-}" ]; then
+    export PROMPT_COMMAND='__bash_prompt_command 2>/dev/null'
+
+    __bash_prompt_command() {
+        local prev_status="$?"
+        if [ "$prev_status" != 0 ]; then
+            # Print nonzero exit code in bold red text inside square brackets
+            printf '\033[31m[\033[1m%s\033[22m]\033[39m' "$prev_status"
+        fi
+        # Default prompt taken from /etc/bashrc
+        printf '\033]0;%s@%s:%s\007' "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"
+    }
+fi


### PR DESCRIPTION
If the previous command's exit code was nonzero, the exit code is displayed inside square brackets in bold and red at the beginning of the bash command prompt. This gives a visual indicator of when a process has silently failed, which is particularly useful for run0 given that it currently will silently fail with exit code 203 for commands where it runs into problems with SELinux.