### PR TITLE
chore(i18n): prepare audit script for localization

### DIFF
--- a/files/po/audit_secureblue.pot
+++ b/files/po/audit_secureblue.pot
@@ -1,0 +1,780 @@
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-07-29 11:19-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: audit_secureblue.py:107
+#, python-brace-format
+msgid "Missing kernel argument: {0}"
+msgstr ""
+
+#: audit_secureblue.py:112
+#, python-brace-format
+msgid "Missing kernel argument: {0} (32-bit support)"
+msgstr ""
+
+#: audit_secureblue.py:117
+#, python-brace-format
+msgid "Missing kernel argument: {0} (force-disable SMT)"
+msgstr ""
+
+#: audit_secureblue.py:129
+#, python-brace-format
+msgid "Missing kernel argument (unstable): {0}"
+msgstr ""
+
+#: audit_secureblue.py:132
+msgid "To set hardened kernel arguments, run:"
+msgstr ""
+
+#: audit_secureblue.py:134
+msgid "Checking for hardened kernel arguments"
+msgstr ""
+
+#: audit_secureblue.py:150 audit_secureblue.py:208 audit_secureblue.py:272
+#: audit_secureblue.py:688 audit_secureblue.py:697
+#, python-brace-format
+msgid "The file {0} has been modified."
+msgstr ""
+
+#: audit_secureblue.py:162
+#, python-brace-format
+msgid "{0} should be {1}, but is actually {2}."
+msgstr ""
+
+#: audit_secureblue.py:165
+msgid "Ensuring no sysctl overrides"
+msgstr ""
+
+#: audit_secureblue.py:179
+#, python-brace-format
+msgid ""
+"The current image is not signed.\n"
+"            To rebase to a signed image, download and run or re-run {0}\n"
+"            from the secureblue GitHub repository."
+msgstr ""
+
+#: audit_secureblue.py:182
+msgid "Ensuring a signed image is in use"
+msgstr ""
+
+#: audit_secureblue.py:212
+#, python-brace-format
+msgid "The module {0} is in {1}, but it is loaded."
+msgstr ""
+
+#: audit_secureblue.py:215
+msgid "Ensuring no modprobe overrides"
+msgstr ""
+
+#: audit_secureblue.py:230
+#, python-brace-format
+msgid "ptrace is allowed and **unrestricted** ({0})!"
+msgstr ""
+
+#: audit_secureblue.py:231 audit_secureblue.py:244
+msgid "For more info on what this means, see:"
+msgstr ""
+
+#: audit_secureblue.py:233 audit_secureblue.py:246
+msgid "To forbid ptrace, run:"
+msgstr ""
+
+#: audit_secureblue.py:235
+msgid "To allow restricted ptrace, run the above command twice."
+msgstr ""
+
+#: audit_secureblue.py:241
+#, python-brace-format
+msgid "ptrace is allowed, but restricted ({0})."
+msgstr ""
+
+#: audit_secureblue.py:251
+msgid "Ensuring ptrace is forbidden"
+msgstr ""
+
+#: audit_secureblue.py:261
+msgid "Ensuring no authselect overrides"
+msgstr ""
+
+#: audit_secureblue.py:276
+#, python-brace-format
+msgid "{0} exists."
+msgstr ""
+
+#: audit_secureblue.py:277
+msgid "Ensuring no container policy overrides"
+msgstr ""
+
+#: audit_secureblue.py:289
+msgid "Unconfined domain user namespace creation is permitted."
+msgstr ""
+
+#: audit_secureblue.py:290 audit_secureblue.py:307
+msgid "To disallow it, run:"
+msgstr ""
+
+#: audit_secureblue.py:294
+msgid "Ensuring unconfined user namespace creation disallowed"
+msgstr ""
+
+#: audit_secureblue.py:306
+msgid "Container domain user namespace creation is permitted."
+msgstr ""
+
+#: audit_secureblue.py:311
+msgid "Ensuring container user namespace creation disallowed"
+msgstr ""
+
+#: audit_secureblue.py:323
+msgid "USBGuard is enabled but has failed to run."
+msgstr ""
+
+#: audit_secureblue.py:326
+msgid "USBGuard is not enabled."
+msgstr ""
+
+#: audit_secureblue.py:329
+msgid "To set up USBGuard, run:"
+msgstr ""
+
+#: audit_secureblue.py:332
+msgid ""
+"Caution: if you have already set up USBGuard, this will overwrite the "
+"existing policy."
+msgstr ""
+
+#: audit_secureblue.py:336
+msgid "Ensuring USBGuard is active"
+msgstr ""
+
+#: audit_secureblue.py:348 audit_secureblue.py:446 audit_secureblue.py:477
+#: audit_secureblue.py:566
+#, python-brace-format
+msgid "{0} is enabled but has failed to run."
+msgstr ""
+
+#: audit_secureblue.py:351 audit_secureblue.py:571
+#, python-brace-format
+msgid "{0} is not enabled."
+msgstr ""
+
+#: audit_secureblue.py:352 audit_secureblue.py:399
+msgid "To start and enable it, run:"
+msgstr ""
+
+#: audit_secureblue.py:354
+msgid "Ensuring chronyd is active"
+msgstr ""
+
+#: audit_secureblue.py:366
+msgid "System DNS resolution is not secure."
+msgstr ""
+
+#: audit_secureblue.py:376 audit_secureblue.py:419
+#, python-brace-format
+msgid "Unable to read file {0}."
+msgstr ""
+
+#: audit_secureblue.py:383
+msgid "System DNS resolution is not secure (opportunistic DNS-over-TLS only)."
+msgstr ""
+
+#: audit_secureblue.py:390
+msgid "To select a secure resolver, run:"
+msgstr ""
+
+#: audit_secureblue.py:392
+msgid "If you are using a VPN, you may want to disregard this recommendation."
+msgstr ""
+
+#: audit_secureblue.py:398
+#, python-brace-format
+msgid "{0} is inactive."
+msgstr ""
+
+#: audit_secureblue.py:403
+msgid "Ensuring system DNS resolution is secure"
+msgstr ""
+
+#: audit_secureblue.py:427
+msgid "MAC randomization is not enabled."
+msgstr ""
+
+#: audit_secureblue.py:428 audit_secureblue.py:454 audit_secureblue.py:483
+#: audit_secureblue.py:514 audit_secureblue.py:549 audit_secureblue.py:574
+msgid "To enable it, run:"
+msgstr ""
+
+#: audit_secureblue.py:434
+msgid "Ensuring MAC randomization is enabled"
+msgstr ""
+
+#: audit_secureblue.py:451 audit_secureblue.py:480
+#, python-brace-format
+msgid "{0} is disabled."
+msgstr ""
+
+#: audit_secureblue.py:459 audit_secureblue.py:488 audit_secureblue.py:579
+#, python-brace-format
+msgid "Ensuring {0} is enabled"
+msgstr ""
+
+#: audit_secureblue.py:506 audit_secureblue.py:541
+#, python-brace-format
+msgid "{0} is enabled globally but has failed to run."
+msgstr ""
+
+#: audit_secureblue.py:511 audit_secureblue.py:546
+#, python-brace-format
+msgid "{0} is not enabled globally."
+msgstr ""
+
+#: audit_secureblue.py:519 audit_secureblue.py:554
+#, python-brace-format
+msgid "Ensuring {0} is enabled globally"
+msgstr ""
+
+#: audit_secureblue.py:591
+msgid "The current user is in the wheel group."
+msgstr ""
+
+#: audit_secureblue.py:592
+msgid "To set up a separate wheel account, follow the instructions here:"
+msgstr ""
+
+#: audit_secureblue.py:600
+msgid "Ensuring user is not a member of the wheel group"
+msgstr ""
+
+#: audit_secureblue.py:609
+msgid "GNOME"
+msgstr ""
+
+#: audit_secureblue.py:612
+msgid "KDE Plasma"
+msgstr ""
+
+#: audit_secureblue.py:615
+msgid "Sway"
+msgstr ""
+
+#: audit_secureblue.py:625
+#, python-brace-format
+msgid "Xwayland is enabled for {0}."
+msgstr ""
+
+#: audit_secureblue.py:626 audit_secureblue.py:725
+msgid "To disable it, run:"
+msgstr ""
+
+#: audit_secureblue.py:630
+#, python-brace-format
+msgid "Ensuring {0} is disabled for {1}"
+msgstr ""
+
+#: audit_secureblue.py:653
+msgid "GNOME user extensions are enabled."
+msgstr ""
+
+#: audit_secureblue.py:654
+msgid "To disable this, run:"
+msgstr ""
+
+#: audit_secureblue.py:658
+msgid "Ensuring GNOME user extensions are disabled"
+msgstr ""
+
+#: audit_secureblue.py:670
+msgid "SELinux is in Permissive mode."
+msgstr ""
+
+#: audit_secureblue.py:671
+msgid "To set it to Enforcing mode, run:"
+msgstr ""
+
+#: audit_secureblue.py:675
+msgid "Ensuring SELinux is in Enforcing mode"
+msgstr ""
+
+#: audit_secureblue.py:691
+#, python-brace-format
+msgid "The file {0} has been deleted."
+msgstr ""
+
+#: audit_secureblue.py:694
+#, python-brace-format
+msgid "The file {0} cannot be read."
+msgstr ""
+
+#: audit_secureblue.py:698
+msgid "To reset it, run:"
+msgstr ""
+
+#: audit_secureblue.py:702
+msgid "Ensuring no environment file overrides"
+msgstr ""
+
+#: audit_secureblue.py:718
+#, python-brace-format
+msgid "The file {0} was not found or inaccessible."
+msgstr ""
+
+#: audit_secureblue.py:724
+msgid "KDE GNHS is enabled."
+msgstr ""
+
+#: audit_secureblue.py:731
+msgid "Ensuring KDE GHNS is disabled"
+msgstr ""
+
+#: audit_secureblue.py:745
+#, python-brace-format
+msgid "The file {0} was not found."
+msgstr ""
+
+#: audit_secureblue.py:752
+#, python-brace-format
+msgid "{0} has mode {1:o} (expected {2:o})"
+msgstr ""
+
+#: audit_secureblue.py:756
+#, python-brace-format
+msgid "{0} is owned by a non-root user!"
+msgstr ""
+
+#: audit_secureblue.py:759
+#, python-brace-format
+msgid "The file {0} has been modified or deleted."
+msgstr ""
+
+#: audit_secureblue.py:760
+msgid "To reset it and enable hardened_malloc for system processes, run:"
+msgstr ""
+
+#: audit_secureblue.py:765
+#, python-brace-format
+msgid "Ensuring {0} has expected permissions"
+msgstr ""
+
+#: audit_secureblue.py:783
+#, python-brace-format
+msgid "{0} is set, but {1} has been modified."
+msgstr ""
+
+#: audit_secureblue.py:788 audit_secureblue.py:791
+#, python-brace-format
+msgid "The '{0}' variant of {1} has been set."
+msgstr ""
+
+#: audit_secureblue.py:794
+#, python-brace-format
+msgid "{0} has not been set."
+msgstr ""
+
+#: audit_secureblue.py:797
+#, python-brace-format
+msgid ""
+"The environment variable {0} has been modified or is unset.\n"
+"                Check that {1} has not been overridden in\n"
+"                {2} or related configuration files."
+msgstr ""
+
+#: audit_secureblue.py:803
+msgid "Ensuring hardened_malloc is set to be preloaded"
+msgstr ""
+
+#: audit_secureblue.py:815
+msgid "Ensuring secure boot is enabled"
+msgstr ""
+
+#: audit_secureblue.py:848
+msgid "Bash environment is not locked down."
+msgstr ""
+
+#: audit_secureblue.py:849
+msgid "The following files do not appear to be immutable or do not exist:"
+msgstr ""
+
+#: audit_secureblue.py:851
+msgid "To fix this, run:"
+msgstr ""
+
+#: audit_secureblue.py:858
+msgid "Ensuring current user's bash environment is locked down"
+msgstr ""
+
+#: audit_secureblue.py:879
+#, python-brace-format
+msgid "{0} is configured with an unknown URL."
+msgstr ""
+
+#: audit_secureblue.py:882
+#, python-brace-format
+msgid "{0} is not a verified flatpak repository."
+msgstr ""
+
+#: audit_secureblue.py:885
+#, python-brace-format
+msgid "Auditing flatpak remote {0}"
+msgstr ""
+
+#: audit_secureblue.py:918
+#, python-brace-format
+msgid "Auditing {0}"
+msgstr ""
+
+#: audit_secureblue.py:934
+msgid "[Audit process interrupted. Exiting.]"
+msgstr ""
+
+#: audit_secureblue.py:947
+msgid "Audit secureblue configuration for security"
+msgstr ""
+
+#: audit_secureblue.py:951
+msgid "skip categories"
+msgstr ""
+
+#: audit_secureblue.py:952
+msgid "display output as JSON"
+msgstr ""
+
+#: audit_secureblue.py:956
+#, python-brace-format
+msgid "Valid arguments to {0} are: {1}"
+msgstr ""
+
+#: audit_secureblue.py:964
+#, python-brace-format
+msgid "*** Error in check '{0}' ***"
+msgstr ""
+
+#: audit_secureblue.py:966
+msgid "*** Continuing... ***"
+msgstr ""
+
+#: audit_secureblue.py:969
+#, python-brace-format
+msgid "Use option '{0}' to skip flatpak recommendations."
+msgstr ""
+
+#: audit_secureblue.py:972
+msgid "*** WARNING: Unexpected error occurred. ***"
+msgstr ""
+
+#: auditor/__init__.py:55
+msgid "PASS"
+msgstr ""
+
+#: auditor/__init__.py:57
+msgid "INFO"
+msgstr ""
+
+#: auditor/__init__.py:59
+msgid "WARN"
+msgstr ""
+
+#: auditor/__init__.py:61
+msgid "FAIL"
+msgstr ""
+
+#: auditor/__init__.py:63
+msgid "UNKNOWN"
+msgstr ""
+
+#: auditor/__init__.py:221
+msgid "Recommendations"
+msgstr ""
+
+#: auditor/__init__.py:262
+msgid "Audit"
+msgstr ""
+
+#: auditor/__init__.py:266
+msgid "Skipping checks in the following category:"
+msgstr ""
+
+#: auditor/__init__.py:268
+msgid "Skipping checks in the following categories:"
+msgstr ""
+
+#: audit_flatpak/__init__.py:145
+msgid "permission"
+msgstr ""
+
+#: audit_flatpak/__init__.py:150
+#, python-brace-format
+msgid "{0} has {1}"
+msgstr ""
+
+#: audit_flatpak/__init__.py:155
+msgid "This may also be used as a sandbox escape vector."
+msgstr ""
+
+#: audit_flatpak/__init__.py:161
+#, python-brace-format
+msgid "The following flatpak app(s) have {0}:"
+msgstr ""
+
+#: audit_flatpak/__init__.py:165 audit_flatpak/__init__.py:313
+#: audit_flatpak/__init__.py:376 audit_flatpak/__init__.py:415
+msgid "To remove this permission from an app, use Flatseal or run:"
+msgstr ""
+
+#: audit_flatpak/__init__.py:167 audit_flatpak/__init__.py:296
+#: audit_flatpak/__init__.py:315 audit_flatpak/__init__.py:378
+#: audit_flatpak/__init__.py:398 audit_flatpak/__init__.py:417
+#, python-brace-format
+msgid "(replacing \"{0}\" with the flatpak app ID)"
+msgstr ""
+
+#: audit_flatpak/__init__.py:184
+msgid "network access"
+msgstr ""
+
+#: audit_flatpak/__init__.py:185
+msgid "inter-process communications access"
+msgstr ""
+
+#: audit_flatpak/__init__.py:186
+msgid "X11 access"
+msgstr ""
+
+#: audit_flatpak/__init__.py:187
+msgid "access to the PulseAudio socket"
+msgstr ""
+
+#: audit_flatpak/__init__.py:192
+msgid "access to the D-Bus session bus"
+msgstr ""
+
+#: audit_flatpak/__init__.py:193
+msgid "This grants access to audio and microphones."
+msgstr ""
+
+#: audit_flatpak/__init__.py:195
+msgid "access to the D-Bus system bus"
+msgstr ""
+
+#: audit_flatpak/__init__.py:196
+msgid "access to the SSH agent"
+msgstr ""
+
+#: audit_flatpak/__init__.py:201
+msgid "This grants access to input devices, GPUs, raw USB, and virtualization."
+msgstr ""
+
+#: audit_flatpak/__init__.py:203
+#, python-brace-format
+msgid "If GPU access is required, allow {0} instead."
+msgstr ""
+
+#: audit_flatpak/__init__.py:205
+msgid "This grants access to input devices."
+msgstr ""
+
+#: audit_flatpak/__init__.py:207
+msgid "This grants access to kernel-based virtualization."
+msgstr ""
+
+#: audit_flatpak/__init__.py:213
+msgid "This grants access to shared memory."
+msgstr ""
+
+#: audit_flatpak/__init__.py:220
+msgid "This grants raw USB device access."
+msgstr ""
+
+#: audit_flatpak/__init__.py:223
+msgid "bluetooth access"
+msgstr ""
+
+#: audit_flatpak/__init__.py:224
+msgid "ptrace access"
+msgstr ""
+
+#: audit_flatpak/__init__.py:263
+#, python-brace-format
+msgid "{0} can acquire arbitrary permissions."
+msgstr ""
+
+#: audit_flatpak/__init__.py:266
+msgid "However, this is required for its functionality."
+msgstr ""
+
+#: audit_flatpak/__init__.py:280
+#, python-brace-format
+msgid "{0} is not requesting {1}"
+msgstr ""
+
+#: audit_flatpak/__init__.py:284 audit_flatpak/__init__.py:288
+#, python-brace-format
+msgid "{0} is requesting {1}"
+msgstr ""
+
+#: audit_flatpak/__init__.py:292
+#, python-brace-format
+msgid "The following flatpak app(s) are not requesting {0}:"
+msgstr ""
+
+#: audit_flatpak/__init__.py:294
+msgid "To enable it for an app, run:"
+msgstr ""
+
+#: audit_flatpak/__init__.py:308
+#, python-brace-format
+msgid "The following flatpak app(s) can talk to {0} on the session bus:"
+msgstr ""
+
+#: audit_flatpak/__init__.py:312 audit_flatpak/__init__.py:414
+msgid "This grants the ability to acquire arbitrary permissions."
+msgstr ""
+
+#: audit_flatpak/__init__.py:353
+msgid "all system files"
+msgstr ""
+
+#: audit_flatpak/__init__.py:354
+msgid "all user files"
+msgstr ""
+
+#: audit_flatpak/__init__.py:355
+msgid "other applications' configuration files"
+msgstr ""
+
+#: audit_flatpak/__init__.py:356
+msgid "other applications' cache files"
+msgstr ""
+
+#: audit_flatpak/__init__.py:357
+msgid "other applications' data files"
+msgstr ""
+
+#: audit_flatpak/__init__.py:368
+#, python-brace-format
+msgid "{0} has {1} permission"
+msgstr ""
+
+#: audit_flatpak/__init__.py:371
+#, python-brace-format
+msgid "The following flatpak app(s) have {0} permission:"
+msgstr ""
+
+#: audit_flatpak/__init__.py:375
+#, python-brace-format
+msgid "This grants access to {0}."
+msgstr ""
+
+#: audit_flatpak/__init__.py:391
+#, python-brace-format
+msgid "{0} is missing {1} permission"
+msgstr ""
+
+#: audit_flatpak/__init__.py:393
+#, python-brace-format
+msgid "The following flatpak app(s) are missing {0} permission:"
+msgstr ""
+
+#: audit_flatpak/__init__.py:395
+msgid "This is required to load hardened_malloc."
+msgstr ""
+
+#: audit_flatpak/__init__.py:396
+msgid "To add this permission to an app, use Flatseal or run:"
+msgstr ""
+
+#: audit_flatpak/__init__.py:412
+msgid "The following flatpak app(s) can modify flatpak overrides:"
+msgstr ""
+
+#: utils/__init__.py:54
+msgid "*** WARNING: Running audit script as root is not recommended. ***"
+msgstr ""
+
+#: utils/__init__.py:55
+msgid "*** Some results may be misleading or incomplete. ***"
+msgstr ""
+
+#: utils/__init__.py:83
+msgid ""
+"The following status indicators accompany checks run by the audit script:"
+msgstr ""
+
+#: utils/__init__.py:86
+msgid "check failed - the configuration may be less secure."
+msgstr ""
+
+#: utils/__init__.py:87
+msgid "partial failure, or less significant issue detected."
+msgstr ""
+
+#: utils/__init__.py:88
+msgid "check passed - no problems detected."
+msgstr ""
+
+#: utils/__init__.py:89
+msgid "unable to perform check (usually due to a file permission issue)."
+msgstr ""
+
+#: utils/__init__.py:94
+msgid "For flatpak checks, the status indicators have more specific meanings:"
+msgstr ""
+
+#: utils/__init__.py:97
+msgid ""
+"app has permissions that can be used as sandbox escapes, allow it to modify\n"
+"            its own permissions, or otherwise grant very broad access to the "
+"system (e.g. access\n"
+"            to certain directories, direct D-Bus access, X11)."
+msgstr ""
+
+#: utils/__init__.py:100
+msgid ""
+"app has permissions that have some sandbox escape potential or otherwise\n"
+"            weaken security (e.g. PulseAudio, Bluetooth, not using "
+"hardened_malloc)."
+msgstr ""
+
+#: utils/__init__.py:102
+msgid ""
+"no potential sandbox escapes detected but some permissions could increase\n"
+"            attack surface or have privacy implications (e.g. network "
+"access)."
+msgstr ""
+
+#: utils/__init__.py:104
+msgid "no app permissions flagged (however, not all permissions are audited)."
+msgstr ""
+
+#: utils/__init__.py:110
+msgid ""
+"            Note that some flatpak apps require broad permissions to "
+"function. Permissions being\n"
+"            flagged by the audit script do not necessarily mean that action "
+"should be taken.\n"
+"            "
+msgstr ""

--- a/files/po/en/audit_secureblue.po
+++ b/files/po/en/audit_secureblue.po
@@ -1,0 +1,805 @@
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-07-29 11:19-0400\n"
+"PO-Revision-Date: 2025-07-29 11:19-0400\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en_US\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: audit_secureblue.py:107
+#, python-brace-format
+msgid "Missing kernel argument: {0}"
+msgstr "Missing kernel argument: {0}"
+
+#: audit_secureblue.py:112
+#, python-brace-format
+msgid "Missing kernel argument: {0} (32-bit support)"
+msgstr "Missing kernel argument: {0} (32-bit support)"
+
+#: audit_secureblue.py:117
+#, python-brace-format
+msgid "Missing kernel argument: {0} (force-disable SMT)"
+msgstr "Missing kernel argument: {0} (force-disable SMT)"
+
+#: audit_secureblue.py:129
+#, python-brace-format
+msgid "Missing kernel argument (unstable): {0}"
+msgstr "Missing kernel argument (unstable): {0}"
+
+#: audit_secureblue.py:132
+msgid "To set hardened kernel arguments, run:"
+msgstr "To set hardened kernel arguments, run:"
+
+#: audit_secureblue.py:134
+msgid "Checking for hardened kernel arguments"
+msgstr "Checking for hardened kernel arguments"
+
+#: audit_secureblue.py:150 audit_secureblue.py:208 audit_secureblue.py:272
+#: audit_secureblue.py:688 audit_secureblue.py:697
+#, python-brace-format
+msgid "The file {0} has been modified."
+msgstr "The file {0} has been modified."
+
+#: audit_secureblue.py:162
+#, python-brace-format
+msgid "{0} should be {1}, but is actually {2}."
+msgstr "{0} should be {1}, but is actually {2}."
+
+#: audit_secureblue.py:165
+msgid "Ensuring no sysctl overrides"
+msgstr "Ensuring no sysctl overrides"
+
+#: audit_secureblue.py:179
+#, python-brace-format
+msgid ""
+"The current image is not signed.\n"
+"            To rebase to a signed image, download and run or re-run {0}\n"
+"            from the secureblue GitHub repository."
+msgstr ""
+"The current image is not signed.\n"
+"            To rebase to a signed image, download and run or re-run {0}\n"
+"            from the secureblue GitHub repository."
+
+#: audit_secureblue.py:182
+msgid "Ensuring a signed image is in use"
+msgstr "Ensuring a signed image is in use"
+
+#: audit_secureblue.py:212
+#, python-brace-format
+msgid "The module {0} is in {1}, but it is loaded."
+msgstr "The module {0} is in {1}, but it is loaded."
+
+#: audit_secureblue.py:215
+msgid "Ensuring no modprobe overrides"
+msgstr "Ensuring no modprobe overrides"
+
+#: audit_secureblue.py:230
+#, python-brace-format
+msgid "ptrace is allowed and **unrestricted** ({0})!"
+msgstr "ptrace is allowed and **unrestricted** ({0})!"
+
+#: audit_secureblue.py:231 audit_secureblue.py:244
+msgid "For more info on what this means, see:"
+msgstr "For more info on what this means, see:"
+
+#: audit_secureblue.py:233 audit_secureblue.py:246
+msgid "To forbid ptrace, run:"
+msgstr "To forbid ptrace, run:"
+
+#: audit_secureblue.py:235
+msgid "To allow restricted ptrace, run the above command twice."
+msgstr "To allow restricted ptrace, run the above command twice."
+
+#: audit_secureblue.py:241
+#, python-brace-format
+msgid "ptrace is allowed, but restricted ({0})."
+msgstr "ptrace is allowed, but restricted ({0})."
+
+#: audit_secureblue.py:251
+msgid "Ensuring ptrace is forbidden"
+msgstr "Ensuring ptrace is forbidden"
+
+#: audit_secureblue.py:261
+msgid "Ensuring no authselect overrides"
+msgstr "Ensuring no authselect overrides"
+
+#: audit_secureblue.py:276
+#, python-brace-format
+msgid "{0} exists."
+msgstr "{0} exists."
+
+#: audit_secureblue.py:277
+msgid "Ensuring no container policy overrides"
+msgstr "Ensuring no container policy overrides"
+
+#: audit_secureblue.py:289
+msgid "Unconfined domain user namespace creation is permitted."
+msgstr "Unconfined domain user namespace creation is permitted."
+
+#: audit_secureblue.py:290 audit_secureblue.py:307
+msgid "To disallow it, run:"
+msgstr "To disallow it, run:"
+
+#: audit_secureblue.py:294
+msgid "Ensuring unconfined user namespace creation disallowed"
+msgstr "Ensuring unconfined user namespace creation disallowed"
+
+#: audit_secureblue.py:306
+msgid "Container domain user namespace creation is permitted."
+msgstr "Container domain user namespace creation is permitted."
+
+#: audit_secureblue.py:311
+msgid "Ensuring container user namespace creation disallowed"
+msgstr "Ensuring container user namespace creation disallowed"
+
+#: audit_secureblue.py:323
+msgid "USBGuard is enabled but has failed to run."
+msgstr "USBGuard is enabled but has failed to run."
+
+#: audit_secureblue.py:326
+msgid "USBGuard is not enabled."
+msgstr "USBGuard is not enabled."
+
+#: audit_secureblue.py:329
+msgid "To set up USBGuard, run:"
+msgstr "To set up USBGuard, run:"
+
+#: audit_secureblue.py:332
+msgid ""
+"Caution: if you have already set up USBGuard, this will overwrite the "
+"existing policy."
+msgstr ""
+"Caution: if you have already set up USBGuard, this will overwrite the "
+"existing policy."
+
+#: audit_secureblue.py:336
+msgid "Ensuring USBGuard is active"
+msgstr "Ensuring USBGuard is active"
+
+#: audit_secureblue.py:348 audit_secureblue.py:446 audit_secureblue.py:477
+#: audit_secureblue.py:566
+#, python-brace-format
+msgid "{0} is enabled but has failed to run."
+msgstr "{0} is enabled but has failed to run."
+
+#: audit_secureblue.py:351 audit_secureblue.py:571
+#, python-brace-format
+msgid "{0} is not enabled."
+msgstr "{0} is not enabled."
+
+#: audit_secureblue.py:352 audit_secureblue.py:399
+msgid "To start and enable it, run:"
+msgstr "To start and enable it, run:"
+
+#: audit_secureblue.py:354
+msgid "Ensuring chronyd is active"
+msgstr "Ensuring chronyd is active"
+
+#: audit_secureblue.py:366
+msgid "System DNS resolution is not secure."
+msgstr "System DNS resolution is not secure."
+
+#: audit_secureblue.py:376 audit_secureblue.py:419
+#, python-brace-format
+msgid "Unable to read file {0}."
+msgstr "Unable to read file {0}."
+
+#: audit_secureblue.py:383
+msgid "System DNS resolution is not secure (opportunistic DNS-over-TLS only)."
+msgstr "System DNS resolution is not secure (opportunistic DNS-over-TLS only)."
+
+#: audit_secureblue.py:390
+msgid "To select a secure resolver, run:"
+msgstr "To select a secure resolver, run:"
+
+#: audit_secureblue.py:392
+msgid "If you are using a VPN, you may want to disregard this recommendation."
+msgstr "If you are using a VPN, you may want to disregard this recommendation."
+
+#: audit_secureblue.py:398
+#, python-brace-format
+msgid "{0} is inactive."
+msgstr "{0} is inactive."
+
+#: audit_secureblue.py:403
+msgid "Ensuring system DNS resolution is secure"
+msgstr "Ensuring system DNS resolution is secure"
+
+#: audit_secureblue.py:427
+msgid "MAC randomization is not enabled."
+msgstr "MAC randomization is not enabled."
+
+#: audit_secureblue.py:428 audit_secureblue.py:454 audit_secureblue.py:483
+#: audit_secureblue.py:514 audit_secureblue.py:549 audit_secureblue.py:574
+msgid "To enable it, run:"
+msgstr "To enable it, run:"
+
+#: audit_secureblue.py:434
+msgid "Ensuring MAC randomization is enabled"
+msgstr "Ensuring MAC randomization is enabled"
+
+#: audit_secureblue.py:451 audit_secureblue.py:480
+#, python-brace-format
+msgid "{0} is disabled."
+msgstr "{0} is disabled."
+
+#: audit_secureblue.py:459 audit_secureblue.py:488 audit_secureblue.py:579
+#, python-brace-format
+msgid "Ensuring {0} is enabled"
+msgstr "Ensuring {0} is enabled"
+
+#: audit_secureblue.py:506 audit_secureblue.py:541
+#, python-brace-format
+msgid "{0} is enabled globally but has failed to run."
+msgstr "{0} is enabled globally but has failed to run."
+
+#: audit_secureblue.py:511 audit_secureblue.py:546
+#, python-brace-format
+msgid "{0} is not enabled globally."
+msgstr "{0} is not enabled globally."
+
+#: audit_secureblue.py:519 audit_secureblue.py:554
+#, python-brace-format
+msgid "Ensuring {0} is enabled globally"
+msgstr "Ensuring {0} is enabled globally"
+
+#: audit_secureblue.py:591
+msgid "The current user is in the wheel group."
+msgstr "The current user is in the wheel group."
+
+#: audit_secureblue.py:592
+msgid "To set up a separate wheel account, follow the instructions here:"
+msgstr "To set up a separate wheel account, follow the instructions here:"
+
+#: audit_secureblue.py:600
+msgid "Ensuring user is not a member of the wheel group"
+msgstr "Ensuring user is not a member of the wheel group"
+
+#: audit_secureblue.py:609
+msgid "GNOME"
+msgstr "GNOME"
+
+#: audit_secureblue.py:612
+msgid "KDE Plasma"
+msgstr "KDE Plasma"
+
+#: audit_secureblue.py:615
+msgid "Sway"
+msgstr "Sway"
+
+#: audit_secureblue.py:625
+#, python-brace-format
+msgid "Xwayland is enabled for {0}."
+msgstr "Xwayland is enabled for {0}."
+
+#: audit_secureblue.py:626 audit_secureblue.py:725
+msgid "To disable it, run:"
+msgstr "To disable it, run:"
+
+#: audit_secureblue.py:630
+#, python-brace-format
+msgid "Ensuring {0} is disabled for {1}"
+msgstr "Ensuring {0} is disabled for {1}"
+
+#: audit_secureblue.py:653
+msgid "GNOME user extensions are enabled."
+msgstr "GNOME user extensions are enabled."
+
+#: audit_secureblue.py:654
+msgid "To disable this, run:"
+msgstr "To disable this, run:"
+
+#: audit_secureblue.py:658
+msgid "Ensuring GNOME user extensions are disabled"
+msgstr "Ensuring GNOME user extensions are disabled"
+
+#: audit_secureblue.py:670
+msgid "SELinux is in Permissive mode."
+msgstr "SELinux is in Permissive mode."
+
+#: audit_secureblue.py:671
+msgid "To set it to Enforcing mode, run:"
+msgstr "To set it to Enforcing mode, run:"
+
+#: audit_secureblue.py:675
+msgid "Ensuring SELinux is in Enforcing mode"
+msgstr "Ensuring SELinux is in Enforcing mode"
+
+#: audit_secureblue.py:691
+#, python-brace-format
+msgid "The file {0} has been deleted."
+msgstr "The file {0} has been deleted."
+
+#: audit_secureblue.py:694
+#, python-brace-format
+msgid "The file {0} cannot be read."
+msgstr "The file {0} cannot be read."
+
+#: audit_secureblue.py:698
+msgid "To reset it, run:"
+msgstr "To reset it, run:"
+
+#: audit_secureblue.py:702
+msgid "Ensuring no environment file overrides"
+msgstr "Ensuring no environment file overrides"
+
+#: audit_secureblue.py:718
+#, python-brace-format
+msgid "The file {0} was not found or inaccessible."
+msgstr "The file {0} was not found or inaccessible."
+
+#: audit_secureblue.py:724
+msgid "KDE GNHS is enabled."
+msgstr "KDE GNHS is enabled."
+
+#: audit_secureblue.py:731
+msgid "Ensuring KDE GHNS is disabled"
+msgstr "Ensuring KDE GHNS is disabled"
+
+#: audit_secureblue.py:745
+#, python-brace-format
+msgid "The file {0} was not found."
+msgstr "The file {0} was not found."
+
+#: audit_secureblue.py:752
+#, python-brace-format
+msgid "{0} has mode {1:o} (expected {2:o})"
+msgstr "{0} has mode {1:o} (expected {2:o})"
+
+#: audit_secureblue.py:756
+#, python-brace-format
+msgid "{0} is owned by a non-root user!"
+msgstr "{0} is owned by a non-root user!"
+
+#: audit_secureblue.py:759
+#, python-brace-format
+msgid "The file {0} has been modified or deleted."
+msgstr "The file {0} has been modified or deleted."
+
+#: audit_secureblue.py:760
+msgid "To reset it and enable hardened_malloc for system processes, run:"
+msgstr "To reset it and enable hardened_malloc for system processes, run:"
+
+#: audit_secureblue.py:765
+#, python-brace-format
+msgid "Ensuring {0} has expected permissions"
+msgstr "Ensuring {0} has expected permissions"
+
+#: audit_secureblue.py:783
+#, python-brace-format
+msgid "{0} is set, but {1} has been modified."
+msgstr "{0} is set, but {1} has been modified."
+
+#: audit_secureblue.py:788 audit_secureblue.py:791
+#, python-brace-format
+msgid "The '{0}' variant of {1} has been set."
+msgstr "The '{0}' variant of {1} has been set."
+
+#: audit_secureblue.py:794
+#, python-brace-format
+msgid "{0} has not been set."
+msgstr "{0} has not been set."
+
+#: audit_secureblue.py:797
+#, python-brace-format
+msgid ""
+"The environment variable {0} has been modified or is unset.\n"
+"                Check that {1} has not been overridden in\n"
+"                {2} or related configuration files."
+msgstr ""
+"The environment variable {0} has been modified or is unset.\n"
+"                Check that {1} has not been overridden in\n"
+"                {2} or related configuration files."
+
+#: audit_secureblue.py:803
+msgid "Ensuring hardened_malloc is set to be preloaded"
+msgstr "Ensuring hardened_malloc is set to be preloaded"
+
+#: audit_secureblue.py:815
+msgid "Ensuring secure boot is enabled"
+msgstr "Ensuring secure boot is enabled"
+
+#: audit_secureblue.py:848
+msgid "Bash environment is not locked down."
+msgstr "Bash environment is not locked down."
+
+#: audit_secureblue.py:849
+msgid "The following files do not appear to be immutable or do not exist:"
+msgstr "The following files do not appear to be immutable or do not exist:"
+
+#: audit_secureblue.py:851
+msgid "To fix this, run:"
+msgstr "To fix this, run:"
+
+#: audit_secureblue.py:858
+msgid "Ensuring current user's bash environment is locked down"
+msgstr "Ensuring current user's bash environment is locked down"
+
+#: audit_secureblue.py:879
+#, python-brace-format
+msgid "{0} is configured with an unknown URL."
+msgstr "{0} is configured with an unknown URL."
+
+#: audit_secureblue.py:882
+#, python-brace-format
+msgid "{0} is not a verified flatpak repository."
+msgstr "{0} is not a verified flatpak repository."
+
+#: audit_secureblue.py:885
+#, python-brace-format
+msgid "Auditing flatpak remote {0}"
+msgstr "Auditing flatpak remote {0}"
+
+#: audit_secureblue.py:918
+#, python-brace-format
+msgid "Auditing {0}"
+msgstr "Auditing {0}"
+
+#: audit_secureblue.py:934
+msgid "[Audit process interrupted. Exiting.]"
+msgstr "[Audit process interrupted. Exiting.]"
+
+#: audit_secureblue.py:947
+msgid "Audit secureblue configuration for security"
+msgstr "Audit secureblue configuration for security"
+
+#: audit_secureblue.py:951
+msgid "skip categories"
+msgstr "skip categories"
+
+#: audit_secureblue.py:952
+msgid "display output as JSON"
+msgstr "display output as JSON"
+
+#: audit_secureblue.py:956
+#, python-brace-format
+msgid "Valid arguments to {0} are: {1}"
+msgstr "Valid arguments to {0} are: {1}"
+
+#: audit_secureblue.py:964
+#, python-brace-format
+msgid "*** Error in check '{0}' ***"
+msgstr "*** Error in check '{0}' ***"
+
+#: audit_secureblue.py:966
+msgid "*** Continuing... ***"
+msgstr "*** Continuing... ***"
+
+#: audit_secureblue.py:969
+#, python-brace-format
+msgid "Use option '{0}' to skip flatpak recommendations."
+msgstr "Use option '{0}' to skip flatpak recommendations."
+
+#: audit_secureblue.py:972
+msgid "*** WARNING: Unexpected error occurred. ***"
+msgstr "*** WARNING: Unexpected error occurred. ***"
+
+#: auditor/__init__.py:55
+msgid "PASS"
+msgstr "PASS"
+
+#: auditor/__init__.py:57
+msgid "INFO"
+msgstr "INFO"
+
+#: auditor/__init__.py:59
+msgid "WARN"
+msgstr "WARN"
+
+#: auditor/__init__.py:61
+msgid "FAIL"
+msgstr "FAIL"
+
+#: auditor/__init__.py:63
+msgid "UNKNOWN"
+msgstr "UNKNOWN"
+
+#: auditor/__init__.py:221
+msgid "Recommendations"
+msgstr "Recommendations"
+
+#: auditor/__init__.py:262
+msgid "Audit"
+msgstr "Audit"
+
+#: auditor/__init__.py:266
+msgid "Skipping checks in the following category:"
+msgstr "Skipping checks in the following category:"
+
+#: auditor/__init__.py:268
+msgid "Skipping checks in the following categories:"
+msgstr "Skipping checks in the following categories:"
+
+#: audit_flatpak/__init__.py:145
+msgid "permission"
+msgstr "permission"
+
+#: audit_flatpak/__init__.py:150
+#, python-brace-format
+msgid "{0} has {1}"
+msgstr "{0} has {1}"
+
+#: audit_flatpak/__init__.py:155
+msgid "This may also be used as a sandbox escape vector."
+msgstr "This may also be used as a sandbox escape vector."
+
+#: audit_flatpak/__init__.py:161
+#, python-brace-format
+msgid "The following flatpak app(s) have {0}:"
+msgstr "The following flatpak app(s) have {0}:"
+
+#: audit_flatpak/__init__.py:165 audit_flatpak/__init__.py:313
+#: audit_flatpak/__init__.py:376 audit_flatpak/__init__.py:415
+msgid "To remove this permission from an app, use Flatseal or run:"
+msgstr "To remove this permission from an app, use Flatseal or run:"
+
+#: audit_flatpak/__init__.py:167 audit_flatpak/__init__.py:296
+#: audit_flatpak/__init__.py:315 audit_flatpak/__init__.py:378
+#: audit_flatpak/__init__.py:398 audit_flatpak/__init__.py:417
+#, python-brace-format
+msgid "(replacing \"{0}\" with the flatpak app ID)"
+msgstr "(replacing \"{0}\" with the flatpak app ID)"
+
+#: audit_flatpak/__init__.py:184
+msgid "network access"
+msgstr "network access"
+
+#: audit_flatpak/__init__.py:185
+msgid "inter-process communications access"
+msgstr "inter-process communications access"
+
+#: audit_flatpak/__init__.py:186
+msgid "X11 access"
+msgstr "X11 access"
+
+#: audit_flatpak/__init__.py:187
+msgid "access to the PulseAudio socket"
+msgstr "access to the PulseAudio socket"
+
+#: audit_flatpak/__init__.py:192
+msgid "access to the D-Bus session bus"
+msgstr "access to the D-Bus session bus"
+
+#: audit_flatpak/__init__.py:193
+msgid "This grants access to audio and microphones."
+msgstr "This grants access to audio and microphones."
+
+#: audit_flatpak/__init__.py:195
+msgid "access to the D-Bus system bus"
+msgstr "access to the D-Bus system bus"
+
+#: audit_flatpak/__init__.py:196
+msgid "access to the SSH agent"
+msgstr "access to the SSH agent"
+
+#: audit_flatpak/__init__.py:201
+msgid "This grants access to input devices, GPUs, raw USB, and virtualization."
+msgstr ""
+"This grants access to input devices, GPUs, raw USB, and virtualization."
+
+#: audit_flatpak/__init__.py:203
+#, python-brace-format
+msgid "If GPU access is required, allow {0} instead."
+msgstr "If GPU access is required, allow {0} instead."
+
+#: audit_flatpak/__init__.py:205
+msgid "This grants access to input devices."
+msgstr "This grants access to input devices."
+
+#: audit_flatpak/__init__.py:207
+msgid "This grants access to kernel-based virtualization."
+msgstr "This grants access to kernel-based virtualization."
+
+#: audit_flatpak/__init__.py:213
+msgid "This grants access to shared memory."
+msgstr "This grants access to shared memory."
+
+#: audit_flatpak/__init__.py:220
+msgid "This grants raw USB device access."
+msgstr "This grants raw USB device access."
+
+#: audit_flatpak/__init__.py:223
+msgid "bluetooth access"
+msgstr "bluetooth access"
+
+#: audit_flatpak/__init__.py:224
+msgid "ptrace access"
+msgstr "ptrace access"
+
+#: audit_flatpak/__init__.py:263
+#, python-brace-format
+msgid "{0} can acquire arbitrary permissions."
+msgstr "{0} can acquire arbitrary permissions."
+
+#: audit_flatpak/__init__.py:266
+msgid "However, this is required for its functionality."
+msgstr "However, this is required for its functionality."
+
+#: audit_flatpak/__init__.py:280
+#, python-brace-format
+msgid "{0} is not requesting {1}"
+msgstr "{0} is not requesting {1}"
+
+#: audit_flatpak/__init__.py:284 audit_flatpak/__init__.py:288
+#, python-brace-format
+msgid "{0} is requesting {1}"
+msgstr "{0} is requesting {1}"
+
+#: audit_flatpak/__init__.py:292
+#, python-brace-format
+msgid "The following flatpak app(s) are not requesting {0}:"
+msgstr "The following flatpak app(s) are not requesting {0}:"
+
+#: audit_flatpak/__init__.py:294
+msgid "To enable it for an app, run:"
+msgstr "To enable it for an app, run:"
+
+#: audit_flatpak/__init__.py:308
+#, python-brace-format
+msgid "The following flatpak app(s) can talk to {0} on the session bus:"
+msgstr "The following flatpak app(s) can talk to {0} on the session bus:"
+
+#: audit_flatpak/__init__.py:312 audit_flatpak/__init__.py:414
+msgid "This grants the ability to acquire arbitrary permissions."
+msgstr "This grants the ability to acquire arbitrary permissions."
+
+#: audit_flatpak/__init__.py:353
+msgid "all system files"
+msgstr "all system files"
+
+#: audit_flatpak/__init__.py:354
+msgid "all user files"
+msgstr "all user files"
+
+#: audit_flatpak/__init__.py:355
+msgid "other applications' configuration files"
+msgstr "other applications' configuration files"
+
+#: audit_flatpak/__init__.py:356
+msgid "other applications' cache files"
+msgstr "other applications' cache files"
+
+#: audit_flatpak/__init__.py:357
+msgid "other applications' data files"
+msgstr "other applications' data files"
+
+#: audit_flatpak/__init__.py:368
+#, python-brace-format
+msgid "{0} has {1} permission"
+msgstr "{0} has {1} permission"
+
+#: audit_flatpak/__init__.py:371
+#, python-brace-format
+msgid "The following flatpak app(s) have {0} permission:"
+msgstr "The following flatpak app(s) have {0} permission:"
+
+#: audit_flatpak/__init__.py:375
+#, python-brace-format
+msgid "This grants access to {0}."
+msgstr "This grants access to {0}."
+
+#: audit_flatpak/__init__.py:391
+#, python-brace-format
+msgid "{0} is missing {1} permission"
+msgstr "{0} is missing {1} permission"
+
+#: audit_flatpak/__init__.py:393
+#, python-brace-format
+msgid "The following flatpak app(s) are missing {0} permission:"
+msgstr "The following flatpak app(s) are missing {0} permission:"
+
+#: audit_flatpak/__init__.py:395
+msgid "This is required to load hardened_malloc."
+msgstr "This is required to load hardened_malloc."
+
+#: audit_flatpak/__init__.py:396
+msgid "To add this permission to an app, use Flatseal or run:"
+msgstr "To add this permission to an app, use Flatseal or run:"
+
+#: audit_flatpak/__init__.py:412
+msgid "The following flatpak app(s) can modify flatpak overrides:"
+msgstr "The following flatpak app(s) can modify flatpak overrides:"
+
+#: utils/__init__.py:54
+msgid "*** WARNING: Running audit script as root is not recommended. ***"
+msgstr "*** WARNING: Running audit script as root is not recommended. ***"
+
+#: utils/__init__.py:55
+msgid "*** Some results may be misleading or incomplete. ***"
+msgstr "*** Some results may be misleading or incomplete. ***"
+
+#: utils/__init__.py:83
+msgid ""
+"The following status indicators accompany checks run by the audit script:"
+msgstr ""
+"The following status indicators accompany checks run by the audit script:"
+
+#: utils/__init__.py:86
+msgid "check failed - the configuration may be less secure."
+msgstr "check failed - the configuration may be less secure."
+
+#: utils/__init__.py:87
+msgid "partial failure, or less significant issue detected."
+msgstr "partial failure, or less significant issue detected."
+
+#: utils/__init__.py:88
+msgid "check passed - no problems detected."
+msgstr "check passed - no problems detected."
+
+#: utils/__init__.py:89
+msgid "unable to perform check (usually due to a file permission issue)."
+msgstr "unable to perform check (usually due to a file permission issue)."
+
+#: utils/__init__.py:94
+msgid "For flatpak checks, the status indicators have more specific meanings:"
+msgstr "For flatpak checks, the status indicators have more specific meanings:"
+
+#: utils/__init__.py:97
+msgid ""
+"app has permissions that can be used as sandbox escapes, allow it to modify\n"
+"            its own permissions, or otherwise grant very broad access to the "
+"system (e.g. access\n"
+"            to certain directories, direct D-Bus access, X11)."
+msgstr ""
+"app has permissions that can be used as sandbox escapes, allow it to modify\n"
+"            its own permissions, or otherwise grant very broad access to the "
+"system (e.g. access\n"
+"            to certain directories, direct D-Bus access, X11)."
+
+#: utils/__init__.py:100
+msgid ""
+"app has permissions that have some sandbox escape potential or otherwise\n"
+"            weaken security (e.g. PulseAudio, Bluetooth, not using "
+"hardened_malloc)."
+msgstr ""
+"app has permissions that have some sandbox escape potential or otherwise\n"
+"            weaken security (e.g. PulseAudio, Bluetooth, not using "
+"hardened_malloc)."
+
+#: utils/__init__.py:102
+msgid ""
+"no potential sandbox escapes detected but some permissions could increase\n"
+"            attack surface or have privacy implications (e.g. network "
+"access)."
+msgstr ""
+"no potential sandbox escapes detected but some permissions could increase\n"
+"            attack surface or have privacy implications (e.g. network "
+"access)."
+
+#: utils/__init__.py:104
+msgid "no app permissions flagged (however, not all permissions are audited)."
+msgstr "no app permissions flagged (however, not all permissions are audited)."
+
+#: utils/__init__.py:110
+msgid ""
+"            Note that some flatpak apps require broad permissions to "
+"function. Permissions being\n"
+"            flagged by the audit script do not necessarily mean that action "
+"should be taken.\n"
+"            "
+msgstr ""
+"            Note that some flatpak apps require broad permissions to "
+"function. Permissions being\n"
+"            flagged by the audit script do not necessarily mean that action "
+"should be taken.\n"
+"            "

--- a/files/scripts/localization.sh
+++ b/files/scripts/localization.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+cd ../po
+for po_file in */*.po; do
+    lang_code=$(dirname -- "$po_file")
+    mo_filename=$(basename -- "$po_file" | sed 's/\.po$/.mo/')
+    msgfmt -o /usr/share/locale/"$lang_code"/LC_MESSAGES/"$mo_filename" -- "$po_file"
+done

--- a/files/system/usr/libexec/secureblue/audit_flatpak/__init__.py
+++ b/files/system/usr/libexec/secureblue/audit_flatpak/__init__.py
@@ -21,7 +21,9 @@ Flatpak permissions checks for secureblue auditing script.
 from dataclasses import dataclass, field
 from typing import Final
 
-from auditor import Recommendation, Status
+from auditor import Recommendation, Status, gettext_marker
+
+_: Final = gettext_marker()
 
 PASS: Final = Status.PASS
 INFO: Final = Status.INFO
@@ -140,30 +142,32 @@ class PermissionCheck:
     def default_description(self) -> str:
         """Default description if other description isn't provided."""
         perm_type = FLATPAK_OVERRIDE_OPTIONS[self.category][0]
-        return f"{perm_type}={self.permission} permission"
+        return f"{perm_type}={self.permission} " + _("permission")
 
     def warning(self, name: str) -> str:
         """Give the warning text for if the check fails."""
         description = self.description or self.default_description()
-        return f"{name} has {description}"
+        return _("{0} has {1}").format(name, description)
 
     def recommendation(self, name: str) -> Recommendation:
         """Give the recommendation for if the check fails."""
         if self.sandbox_escape:
-            sandbox_escape_note = "This may also be used as a sandbox escape vector."
+            sandbox_escape_note = _("This may also be used as a sandbox escape vector.")
         else:
             sandbox_escape_note = ""
         option = FLATPAK_OVERRIDE_OPTIONS[self.category][1]
         description = self.description or self.default_description()
-        rec = f"""The following flatpak app(s) have {description}:
-            {Recommendation.NAMES_PLACEHOLDER}
-            {self.note or ""}
-            {sandbox_escape_note}
-            To remove this permission from an app, use Flatseal or run:
-            $ flatpak override -u --{option}={self.permission} com.example.Example
-            (replacing "com.example.Example" with the flatpak app ID)
-            {self.endnote or ""}"""
-        rec = "\n".join(line.strip() for line in rec.splitlines() if line.strip())
+        rec_lines = (
+            _("The following flatpak app(s) have {0}:").format(description),
+            Recommendation.NAMES_PLACEHOLDER,
+            self.note or "",
+            sandbox_escape_note,
+            _("To remove this permission from an app, use Flatseal or run:"),
+            f"$ flatpak override -u --{option}={self.permission} com.example.Example",
+            _('(replacing "{0}" with the flatpak app ID)').format("com.example.Example"),
+            self.endnote or "",
+        )
+        rec = "\n".join(line.strip() for line in rec_lines if line.strip())
         return Recommendation(rec, mergeable_name=name)
 
 
@@ -177,47 +181,47 @@ class DirectoryInfo:
 
 
 FLATPAK_PERMISSION_CHECKS: list[PermissionCheck] = [
-    PermissionCheck("shared", "network", INFO, "network access"),
-    PermissionCheck("shared", "ipc", INFO, "inter-process communications access"),
-    PermissionCheck("sockets", "x11", FAIL, "X11 access"),
-    PermissionCheck("sockets", "pulseaudio", WARN, "access to the PulseAudio socket"),
+    PermissionCheck("shared", "network", INFO, _("network access")),
+    PermissionCheck("shared", "ipc", INFO, _("inter-process communications access")),
+    PermissionCheck("sockets", "x11", FAIL, _("X11 access")),
+    PermissionCheck("sockets", "pulseaudio", WARN, _("access to the PulseAudio socket")),
     PermissionCheck(
         "sockets",
         "session-bus",
         FAIL,
-        "access to the D-Bus session bus",
-        note="This grants access to audio and microphones.",
+        _("access to the D-Bus session bus"),
+        note=_("This grants access to audio and microphones."),
     ),
-    PermissionCheck("sockets", "system-bus", FAIL, "access to the D-Bus system bus"),
-    PermissionCheck("sockets", "ssh-auth", WARN, "access to the SSH agent"),
+    PermissionCheck("sockets", "system-bus", FAIL, _("access to the D-Bus system bus")),
+    PermissionCheck("sockets", "ssh-auth", WARN, _("access to the SSH agent")),
     PermissionCheck(
         "devices",
         "all",
         FAIL,
-        note="This grants access to input devices, GPUs, raw USB, and virtualization.",
+        note=_("This grants access to input devices, GPUs, raw USB, and virtualization."),
         sandbox_escape=True,
-        endnote="If GPU access is required, allow device=dri instead.",
+        endnote=_("If GPU access is required, allow {0} instead.").format("device=dri"),
     ),
-    PermissionCheck("devices", "input", INFO, note="This grants access to input devices."),
+    PermissionCheck("devices", "input", INFO, note=_("This grants access to input devices.")),
     PermissionCheck(
-        "devices", "kvm", WARN, note="This grants access to kernel-based virtualization."
+        "devices", "kvm", WARN, note=_("This grants access to kernel-based virtualization.")
     ),
     PermissionCheck(
         "devices",
         "shm",
         FAIL,
-        note="This grants access to shared memory.",
+        note=_("This grants access to shared memory."),
         sandbox_escape=True,
     ),
     PermissionCheck(
         "devices",
         "usb",
         WARN,
-        note="This grants raw USB device access.",
+        note=_("This grants raw USB device access."),
         sandbox_escape=True,
     ),
-    PermissionCheck("features", "bluetooth", WARN, "bluetooth access"),
-    PermissionCheck("features", "devel", WARN, "ptrace access"),
+    PermissionCheck("features", "bluetooth", WARN, _("bluetooth access")),
+    PermissionCheck("features", "devel", WARN, _("ptrace access")),
 ]
 
 ARBITRARY_PERMISSIONS_EXPECTED: list[str] = [
@@ -256,15 +260,13 @@ def check_flatpak_permissions(
 
 def _handle_arbitrary_permissions(state: FlatpakPermissionsState):
     if state.arbitrary_permissions:
+        warning = _("{0} can acquire arbitrary permissions.").format(state.name)
         if state.name in ARBITRARY_PERMISSIONS_EXPECTED:
             state.status = state.status.downgrade_to(INFO)
-            state.warnings.append(
-                f"""{state.name} can acquire arbitrary permissions.
-                However, this is required for its functionality."""
-            )
+            warning += "\n" + _("However, this is required for its functionality.")
         else:
             state.status = state.status.downgrade_to(FAIL)
-            state.warnings.append(f"{state.name} can acquire arbitrary permissions")
+        state.warnings.append(warning)
 
 
 def _check_ld_preload(state: FlatpakPermissionsState, perms: Permissions):
@@ -273,46 +275,46 @@ def _check_ld_preload(state: FlatpakPermissionsState, perms: Permissions):
         ld_preload_files = []
     else:
         ld_preload_files = [s.rsplit("/", maxsplit=1)[-1] for s in ld_preload.split()]
-    if "libhardened_malloc.so" not in ld_preload_files:
-        state.warnings.append(f"{state.name} is not requesting hardened_malloc")
-        if "libhardened_malloc-light.so" in ld_preload_files:
-            state.status = state.status.downgrade_to(INFO)
-            state.warnings.append(f"{state.name} is requesting hardened_malloc-light")
-        elif "libhardened_malloc-pkey.so" in ld_preload_files:
-            state.status = state.status.downgrade_to(INFO)
-            state.warnings.append(f"{state.name} is requesting hardened_malloc-pkey")
-        else:
-            state.status = state.status.downgrade_to(WARN)
-        state.recs.append(
-            Recommendation(
-                f"""The following flatpak app(s) are not requesting hardened_malloc:
-                    {Recommendation.NAMES_PLACEHOLDER}
-                    To enable it for an app, run:
-                    $ ujust harden-flatpak com.example.Example
-                    (replacing "com.example.Example" with the flatpak app ID)
-                """,
-                mergeable_name=state.name,
-            )
+    if "libhardened_malloc.so" in ld_preload_files:
+        return
+    state.warnings.append(_("{0} is not requesting {1}").format(state.name, "hardened_malloc"))
+    if "libhardened_malloc-light.so" in ld_preload_files:
+        state.status = state.status.downgrade_to(INFO)
+        state.warnings.append(
+            _("{0} is requesting {1}").format(state.name, "hardened_malloc-light")
         )
+    elif "libhardened_malloc-pkey.so" in ld_preload_files:
+        state.status = state.status.downgrade_to(INFO)
+        state.warnings.append(_("{0} is requesting {1}").format(state.name, "hardened_malloc-pkey"))
+    else:
+        state.status = state.status.downgrade_to(WARN)
+    rec_lines = (
+        _("The following flatpak app(s) are not requesting {0}:").format("hardened_malloc"),
+        Recommendation.NAMES_PLACEHOLDER,
+        _("To enable it for an app, run:"),
+        "$ ujust harden-flatpak com.example.Example",
+        _('(replacing "{0}" with the flatpak app ID)').format("com.example.Example"),
+    )
+    state.recs.append(Recommendation("\n".join(rec_lines), mergeable_name=state.name))
 
 
 def _handle_flatpak_buses(state: FlatpakPermissionsState, perms: Permissions):
-    for bus_name in ("org.freedesktop.Flatpak", "org.freedesktop.impl.portal.PermissionStore"):
-        if bus_name in perms.session_bus_talk:
-            state.arbitrary_permissions = True
-            if state.name not in ARBITRARY_PERMISSIONS_EXPECTED:
-                state.recs.append(
-                    Recommendation(
-                        f"""The following flatpak app(s) can talk to {bus_name} on the session bus:
-                            {Recommendation.NAMES_PLACEHOLDER}
-                            This grants the ability to acquire arbitrary permissions.
-                            To remove this permission from an app, use Flatseal or run:
-                            $ flatpak override -u --no-talk-name={bus_name} com.example.Example
-                            (replacing "com.example.Example" with the flatpak app ID)
-                        """,
-                        mergeable_name=state.name,
-                    )
-                )
+    dangerous_buses = ("org.freedesktop.Flatpak", "org.freedesktop.impl.portal.PermissionStore")
+    present_bus_names = [bus for bus in dangerous_buses if bus in perms.session_bus_talk]
+    for bus_name in present_bus_names:
+        state.arbitrary_permissions = True
+        if state.name not in ARBITRARY_PERMISSIONS_EXPECTED:
+            rec_lines = (
+                _("The following flatpak app(s) can talk to {0} on the session bus:").format(
+                    bus_name
+                ),
+                Recommendation.NAMES_PLACEHOLDER,
+                _("This grants the ability to acquire arbitrary permissions."),
+                _("To remove this permission from an app, use Flatseal or run:"),
+                f"$ flatpak override -u --no-talk-name={bus_name} com.example.Example",
+                _('(replacing "{0}" with the flatpak app ID)').format("com.example.Example"),
+            )
+            state.recs.append(Recommendation("\n".join(rec_lines), mergeable_name=state.name))
 
 
 def _predefined_check_applies(
@@ -348,11 +350,11 @@ def _check_predefined_flatpak_permissions(
 
 def _check_dangerous_dirs(state: FlatpakPermissionsState, filesystems_rw: dict[str, bool]):
     dangerous_dirs: list[DirectoryInfo] = [
-        DirectoryInfo("host", "all system files", FAIL),
-        DirectoryInfo("home", "all user files", FAIL),
-        DirectoryInfo("xdg-config", "other applications' configuration files", FAIL),
-        DirectoryInfo("xdg-cache", "other applications' cache files", FAIL),
-        DirectoryInfo("xdg-data", "other applications' data files", FAIL),
+        DirectoryInfo("host", _("all system files"), FAIL),
+        DirectoryInfo("home", _("all user files"), FAIL),
+        DirectoryInfo("xdg-config", _("other applications' configuration files"), FAIL),
+        DirectoryInfo("xdg-cache", _("other applications' cache files"), FAIL),
+        DirectoryInfo("xdg-data", _("other applications' data files"), FAIL),
     ]
 
     for directory in dangerous_dirs:
@@ -362,19 +364,20 @@ def _check_dangerous_dirs(state: FlatpakPermissionsState, filesystems_rw: dict[s
             is_alias = filesystems_rw[directory.path]
             if is_alias:
                 aliased_path = directory.path.replace(directory.path, ALIASES[directory.path], 1)
-            state.warnings.append(f"{state.name} has filesystem={directory.path} permission")
-            state.recs.append(
-                Recommendation(
-                    f"""The following flatpak app(s) have filesystem={aliased_path} permission:
-                        {Recommendation.NAMES_PLACEHOLDER}
-                        This grants access to {directory.description}.
-                        To remove this permission from an app, use Flatseal or run:
-                        $ flatpak override -u --nofilesystem={aliased_path} com.example.Example
-                        (replacing "com.example.Example" with the flatpak app ID)
-                    """,
-                    mergeable_name=state.name,
-                )
+            state.warnings.append(
+                _("{0} has {1} permission").format(state.name, f"filesystem={directory.path}")
             )
+            rec_lines = (
+                _("The following flatpak app(s) have {0} permission:").format(
+                    f"filesystem={aliased_path}"
+                ),
+                Recommendation.NAMES_PLACEHOLDER,
+                _("This grants access to {0}.").format(directory.description),
+                _("To remove this permission from an app, use Flatseal or run:"),
+                f"$ flatpak override -u --nofilesystem={aliased_path} com.example.Example",
+                _('(replacing "{0}" with the flatpak app ID)').format("com.example.Example"),
+            )
+            state.recs.append(Recommendation("\n".join(rec_lines), mergeable_name=state.name))
 
 
 def _check_hardened_malloc_access(
@@ -385,19 +388,16 @@ def _check_hardened_malloc_access(
 ):
     if filesystems is None or ("host-os" not in filesystems_ro and "host-os" not in filesystems_rw):
         state.status = state.status.downgrade_to(WARN)
-        state.warnings.append(f"{state.name} is missing host-os:ro permission")
-        state.recs.append(
-            Recommendation(
-                f"""The following flatpak app(s) are missing host-os:ro permission:
-                    {Recommendation.NAMES_PLACEHOLDER}
-                    This is required to load hardened_malloc.
-                    To add this permission to an app, use Flatseal or run:
-                    $ flatpak override -u --filesystem=host-os:ro com.example.Example
-                    (replacing "com.example.Example" with the flatpak app ID)
-                """,
-                mergeable_name=state.name,
-            )
+        state.warnings.append(_("{0} is missing {1} permission").format(state.name, "host-os:ro"))
+        rec_lines = (
+            _("The following flatpak app(s) are missing {0} permission:").format("host-os:ro"),
+            Recommendation.NAMES_PLACEHOLDER,
+            _("This is required to load hardened_malloc."),
+            _("To add this permission to an app, use Flatseal or run:"),
+            "$ flatpak override -u --filesystem=host-os:ro com.example.Example",
+            _('(replacing "{0}" with the flatpak app ID)').format("com.example.Example"),
         )
+        state.recs.append(Recommendation("\n".join(rec_lines), mergeable_name=state.name))
 
 
 def _check_overrides_access(state: FlatpakPermissionsState, filesystems_rw: dict[str, bool]):
@@ -408,18 +408,15 @@ def _check_overrides_access(state: FlatpakPermissionsState, filesystems_rw: dict
         if is_alias:
             override_path = override_path.replace("xdg-data", ALIASES["xdg-data"], 1)
         if state.name not in ARBITRARY_PERMISSIONS_EXPECTED:
-            state.recs.append(
-                Recommendation(
-                    f"""The following flatpak app(s) can modify flatpak overrides:
-                        {Recommendation.NAMES_PLACEHOLDER}
-                        This grants the ability to acquire arbitrary permissions.
-                        To remove this permission from an app, use Flatseal or run:
-                        $ flatpak override -u --nofilesystem={override_path} com.example.Example
-                        (replacing "com.example.Example" with the flatpak app ID)
-                    """,
-                    mergeable_name=state.name,
-                )
+            rec_lines = (
+                _("The following flatpak app(s) can modify flatpak overrides:"),
+                Recommendation.NAMES_PLACEHOLDER,
+                _("This grants the ability to acquire arbitrary permissions."),
+                _("To remove this permission from an app, use Flatseal or run:"),
+                "$ flatpak override -u --nofilesystem={override_path} com.example.Example",
+                _('(replacing "{0}" with the flatpak app ID)').format("com.example.Example"),
             )
+            state.recs.append(Recommendation("\n".join(rec_lines), mergeable_name=state.name))
 
 
 def _check_fs_permissions(state: FlatpakPermissionsState, perms: Permissions):

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -35,7 +35,16 @@ import traceback
 from typing import Final
 
 from audit_flatpak import check_flatpak_permissions, parse_flatpak_permissions
-from auditor import Report, Status, audit, bold, categorize, depends_on, global_audit
+from auditor import (
+    Report,
+    Status,
+    audit,
+    bold,
+    categorize,
+    depends_on,
+    gettext_marker,
+    global_audit,
+)
 from utils import (
     Image,
     command_stdout,
@@ -48,6 +57,8 @@ from utils import (
     validate_sysctl,
     warn_if_root,
 )
+
+_: Final = gettext_marker()
 
 PASS: Final = Status.PASS
 INFO: Final = Status.INFO
@@ -93,17 +104,17 @@ def audit_kargs():
     for karg in kargs_expected:
         if karg not in kargs_current:
             status = status.downgrade_to(FAIL)
-            warnings.append(f"Missing kernel argument: {karg}")
+            warnings.append(_("Missing kernel argument: {0}").format(karg))
 
     karg_32bit = "ia32_emulation=0"
     if karg_32bit not in kargs_current:
         status = status.downgrade_to(WARN)
-        warnings.append(f"Missing kernel argument: {karg_32bit} (32-bit support)")
+        warnings.append(_("Missing kernel argument: {0} (32-bit support)").format(karg_32bit))
 
     karg_nosmt = "nosmt=force"
     if karg_nosmt not in kargs_current:
         status = status.downgrade_to(WARN)
-        warnings.append(f"Missing kernel argument: {karg_nosmt} (force-disable SMT)")
+        warnings.append(_("Missing kernel argument: {0} (force-disable SMT)").format(karg_nosmt))
 
     kargs_expected_unstable = (
         "amd_iommu=force_isolation",
@@ -115,13 +126,12 @@ def audit_kargs():
     for karg in kargs_expected_unstable:
         if karg not in kargs_current:
             status = status.downgrade_to(WARN)
-            warnings.append(f"Missing kernel argument (unstable): {karg}")
+            warnings.append(_("Missing kernel argument (unstable): {0}").format(karg))
 
     if status != PASS:
-        rec = """To set hardened kernel arguments, run:
-            $ ujust set-kargs-hardening"""
+        rec = _("To set hardened kernel arguments, run:") + "\n$ ujust set-kargs-hardening"
 
-    yield Report("Checking for hardened kernel arguments", status, warnings=warnings, recs=rec)
+    yield Report(_("Checking for hardened kernel arguments"), status, warnings=warnings, recs=rec)
 
 
 @audit
@@ -137,7 +147,7 @@ def audit_sysctl():
         etc_conf = f.readlines()
     if conf != etc_conf:
         status = WARN
-        sysctl_errors.append(f"{sysctl_file} has been modified")
+        sysctl_errors.append(_("The file {0} has been modified.").format(sysctl_file))
     for sysctl, expected in sysctl_expected.items():
         sysctl_path = f"/proc/sys/{sysctl.replace('.', '/')}"
         for path in glob.iglob(sysctl_path):
@@ -148,9 +158,11 @@ def audit_sysctl():
                 continue
             if not validate_sysctl(sysctl, actual, expected):
                 status = FAIL
-                sysctl_errors.append(f"{sysctl} should be {expected}, found {actual}")
+                sysctl_errors.append(
+                    _("{0} should be {1}, but is actually {2}.").format(sysctl, expected, actual)
+                )
                 break
-    yield Report("Ensuring no sysctl overrides", status, warnings=sysctl_errors)
+    yield Report(_("Ensuring no sysctl overrides"), status, warnings=sysctl_errors)
 
 
 @audit
@@ -164,16 +176,17 @@ def audit_signed_image(state):
         recs = None
     else:
         status = FAIL
-        recs = """The current image is not signed.
-            To rebase to a signed image, download and run or re-run install_secureblue.sh
-            from the secureblue GitHub repository."""
-    yield Report("Ensuring a signed image is in use", status, recs=recs)
+        recs = _("""The current image is not signed.
+            To rebase to a signed image, download and run or re-run {0}
+            from the secureblue GitHub repository.""").format("install_secureblue.sh")
+    yield Report(_("Ensuring a signed image is in use"), status, recs=recs)
 
 
 @audit
 def audit_modprobe(state):
     """Check that the kernel module blacklist has not been overridden."""
-    with open("/usr/etc/modprobe.d/blacklist.conf", encoding="utf-8") as f:
+    blacklist_file = "/etc/modprobe.d/blacklist.conf"
+    with open(f"/usr{blacklist_file}", encoding="utf-8") as f:
         conf = f.readlines()
     blacklisted_modules = []
     for line in conf:
@@ -189,15 +202,17 @@ def audit_modprobe(state):
     unwanted_modules.sort()
     status = PASS
     warnings = []
-    with open("/etc/modprobe.d/blacklist.conf", encoding="utf-8") as f:
+    with open(blacklist_file, encoding="utf-8") as f:
         if f.readlines() != conf:
             status = WARN
-            warnings.append("/etc/modprobe.d/blacklist.conf has been modified")
+            warnings.append(_("The file {0} has been modified.").format(blacklist_file))
     for mod in unwanted_modules:
         status = FAIL
-        warnings.append(f"{mod} is in blacklist.conf but it is loaded")
+        warnings.append(
+            _("The module {0} is in {1}, but it is loaded.").format(mod, blacklist_file)
+        )
     state["bluetooth_loaded"] = "bluetooth" in unwanted_modules
-    yield Report("Ensuring no modprobe overrides", status, warnings=warnings)
+    yield Report(_("Ensuring no modprobe overrides"), status, warnings=warnings)
 
 
 @audit
@@ -211,21 +226,29 @@ def audit_ptrace(state):
             rec = None
         case 0:
             status = FAIL
-            rec = f"""ptrace is allowed and {bold("unrestricted")} (ptrace_scope = 0)!
-                For more info on what this means, see:
-                https://www.kernel.org/doc/html/latest/admin-guide/LSM/Yama.html
-                To forbid ptrace, run:
-                $ ujust toggle-ptrace-scope
-                To allow restricted ptrace, run the above command twice."""
+            rec_lines = (
+                _("ptrace is allowed and **unrestricted** ({0})!").format("ptrace_scope = 0"),
+                _("For more info on what this means, see:"),
+                "https://www.kernel.org/doc/html/latest/admin-guide/LSM/Yama.html",
+                _("To forbid ptrace, run:"),
+                "$ ujust toggle-ptrace-scope",
+                _("To allow restricted ptrace, run the above command twice."),
+            )
+            rec = "\n".join(rec_lines)
         case _:
             status = WARN
-            rec = f"""ptrace is allowed, but restricted (ptrace_scope = {ptrace_scope}).
-                For more info on what this means, see:
-                https://www.kernel.org/doc/html/latest/admin-guide/LSM/Yama.html
-                To forbid ptrace, run:
-                $ ujust toggle-ptrace-scope"""
+            rec_lines = (
+                _("ptrace is allowed, but restricted ({0}).").format(
+                    f"ptrace_scope = {ptrace_scope}"
+                ),
+                _("For more info on what this means, see:"),
+                "https://www.kernel.org/doc/html/latest/admin-guide/LSM/Yama.html",
+                _("To forbid ptrace, run:"),
+                "$ ujust toggle-ptrace-scope",
+            )
+            rec = "\n".join(rec_lines)
     state["ptrace_allowed"] = status != PASS
-    yield Report("Ensuring ptrace is forbidden", status, recs=rec)
+    yield Report(_("Ensuring ptrace is forbidden"), status, recs=rec)
 
 
 @audit
@@ -235,7 +258,7 @@ def audit_authselect():
     cmp = filecmp.dircmp("/usr/etc/authselect", "/etc/authselect", shallow=False, ignore=[])
     if cmp.left_only or cmp.right_only or cmp.diff_files or cmp.funny_files:
         status = FAIL
-    yield Report("Ensuring no authselect overrides", status)
+    yield Report(_("Ensuring no authselect overrides"), status)
 
 
 @audit
@@ -246,12 +269,12 @@ def audit_container_policy():
     policy_file = "/etc/containers/policy.json"
     if not filecmp.cmp(f"/usr{policy_file}", policy_file):
         status = FAIL
-        warnings.append(f"{policy_file} has been modified")
+        warnings.append(_("The file {0} has been modified.").format(policy_file))
     local_override = "~/.config/containers/policy.json"
     if os.path.isfile(os.path.expanduser(local_override)):
         status = FAIL
-        warnings.append(f"{local_override} exists")
-    yield Report("Ensuring no container policy overrides", status, warnings=warnings)
+        warnings.append(_("{0} exists.").format(local_override))
+    yield Report(_("Ensuring no container policy overrides"), status, warnings=warnings)
 
 
 @audit
@@ -262,10 +285,13 @@ def audit_unconfined_userns():
         recs = None
     else:
         status = FAIL
-        recs = """Unconfined domain user namespace creation is permitted.
-                To disallow it, run:
-                $ ujust toggle-unconfined-domain-userns-creation"""
-    yield Report("Ensuring unconfined user namespace creation disallowed", status, recs=recs)
+        rec_lines = (
+            _("Unconfined domain user namespace creation is permitted."),
+            _("To disallow it, run:"),
+            "$ ujust toggle-unconfined-domain-userns-creation",
+        )
+        recs = "\n".join(rec_lines)
+    yield Report(_("Ensuring unconfined user namespace creation disallowed"), status, recs=recs)
 
 
 @audit
@@ -276,10 +302,13 @@ def audit_container_userns():
         recs = None
     else:
         status = WARN
-        recs = """Container domain user namespace creation is permitted.
-                To disallow it, run:
-                $ ujust toggle-container-domain-userns-creation"""
-    yield Report("Ensuring container user namespace creation disallowed", status, recs=recs)
+        rec_lines = (
+            _("Container domain user namespace creation is permitted."),
+            _("To disallow it, run:"),
+            "$ ujust toggle-container-domain-userns-creation",
+        )
+        recs = "\n".join(rec_lines)
+    yield Report(_("Ensuring container user namespace creation disallowed"), status, recs=recs)
 
 
 @audit
@@ -291,15 +320,20 @@ def audit_usbguard():
         rec = None
         if command_succeeds("systemctl", "is-failed", "--quiet", "usbguard"):
             status = status.downgrade_to(WARN)
-            warning = "USBGuard is enabled but has failed to run"
+            warning = _("USBGuard is enabled but has failed to run.")
     else:
         status = FAIL
-        warning = "USBGuard is not enabled"
-        rec = """USBGuard is not enabled. To set up USBGuard, run:
-            $ ujust setup-usbguard
-            Caution: if you have already set up USBGuard, this will overwrite the
-            existing policy."""
-    yield Report("Ensuring usbguard is active", status, warnings=warning, recs=rec)
+        warning = _("USBGuard is not enabled.")
+        rec_lines = (
+            warning,
+            _("To set up USBGuard, run:"),
+            "$ ujust setup-usbguard",
+            _(
+                "Caution: if you have already set up USBGuard, this will overwrite the existing policy."
+            ),
+        )
+        rec = "\n".join(rec_lines)
+    yield Report(_("Ensuring USBGuard is active"), status, warnings=warning, recs=rec)
 
 
 @audit
@@ -311,14 +345,13 @@ def audit_chronyd():
         rec = None
         if command_succeeds("systemctl", "is-failed", "--quiet", "chronyd"):
             status = status.downgrade_to(WARN)
-            warning = "chronyd is enabled but has failed to run"
+            warning = _("{0} is enabled but has failed to run.").format("chronyd")
     else:
         status = FAIL
-        warning = "chronyd is not enabled"
-        rec = """chronyd is not enabled.
-            To start and enable it, run:
-            $ systemctl enable --now chronyd"""
-    yield Report("Ensuring chronyd is active", status, warnings=warning, recs=rec)
+        warning = _("{0} is not enabled.").format("chronyd")
+        rec_lines = (warning, _("To start and enable it, run:"), "$ systemctl enable --now chronyd")
+        rec = "\n".join(rec_lines)
+    yield Report(_("Ensuring chronyd is active"), status, warnings=warning, recs=rec)
 
 
 @audit
@@ -330,6 +363,7 @@ def audit_dns():
         dnssec = None
         dot = None
         conf_path = "/etc/systemd/resolved.conf.d/10-securedns.conf"
+        fail_msg = _("System DNS resolution is not secure.")
         try:
             with open(conf_path, encoding="utf-8") as f:
                 config = parse_config(f)
@@ -339,26 +373,34 @@ def audit_dns():
             status = FAIL
         except PermissionError:
             status = UNKNOWN
-            warning = f"Unable to read file {conf_path}"
+            warning = _("Unable to read file {0}.").format(conf_path)
         else:
             if dnssec == "true" and dot == "true":
                 status = PASS
             elif dot == "opportunistic":
                 status = WARN
+                fail_msg = _(
+                    "System DNS resolution is not secure (opportunistic DNS-over-TLS only)."
+                )
             else:
                 status = FAIL
         if status in (WARN, FAIL):
-            caveat = " (opportunistic DNS-over-TLS only)" if dot == "opportunistic" else ""
-            rec = f"""System DNS resolution is not secure{caveat}.
-                    To select a secure resolver, run:
-                    $ ujust dns-selector
-                    If you are using a VPN, you may want to disregard this recommendation."""
+            rec_lines = (
+                fail_msg,
+                _("To select a secure resolver, run:"),
+                "$ ujust dns-selector",
+                _("If you are using a VPN, you may want to disregard this recommendation."),
+            )
+            rec = "\n".join(rec_lines)
     else:
         status = FAIL
-        rec = """systemd-resolved is inactive.
-                To start and enable it, run:
-                $ systemctl enable --now systemd-resolved"""
-    yield Report("Ensuring system DNS resolution is secure", status, warnings=warning, recs=rec)
+        rec_lines = (
+            _("{0} is inactive.").format("systemd-resolved"),
+            _("To start and enable it, run:"),
+            "$ systemctl enable --now systemd-resolved",
+        )
+        rec = "\n".join(rec_lines)
+    yield Report(_("Ensuring system DNS resolution is secure"), status, warnings=warning, recs=rec)
 
 
 @audit
@@ -374,19 +416,22 @@ def audit_mac_randomization():
         pass
     except PermissionError:
         status = UNKNOWN
-        warning = f"Unable to read file {conf_path}"
+        warning = _("Unable to read file {0}.").format(conf_path)
     else:
         ethernet = config.get("ethernet.cloned-mac-address") in ("random", "stable")
         wifi = config.get("wifi.cloned-mac-address") in ("random", "stable")
         if ethernet and wifi:
             status = PASS
     if status == FAIL:
-        rec = """MAC randomization is not enabled.
-                To enable it, run:
-                $ ujust toggle-mac-randomization"""
+        rec_lines = (
+            _("MAC randomization is not enabled."),
+            _("To enable it, run:"),
+            "$ ujust toggle-mac-randomization",
+        )
+        rec = "\n".join(rec_lines)
     else:
         rec = None
-    yield Report("Ensuring MAC randomization is enabled", status, warnings=warning, recs=rec)
+    yield Report(_("Ensuring MAC randomization is enabled"), status, warnings=warning, recs=rec)
 
 
 @audit
@@ -398,15 +443,20 @@ def audit_rpm_ostree_timer():
         rec = None
         if command_succeeds("systemctl", "is-failed", "--quiet", "rpm-ostreed-automatic.timer"):
             status = status.downgrade_to(WARN)
-            warning = "rpm-ostreed-automatic.timer is enabled but has failed to run"
+            warning = _("{0} is enabled but has failed to run.").format(
+                "rpm-ostreed-automatic.timer"
+            )
     else:
         status = FAIL
-        warning = "rpm-ostreed-automatic.timer is disabled"
-        rec = """rpm-ostreed-automatic.timer is disabled.
-                To enable, run:
-                $ systemctl enable --now rpm-ostreed-automatic.timer"""
+        warning = _("{0} is disabled.").format("rpm-ostreed-automatic.timer")
+        rec_lines = (
+            warning,
+            _("To enable it, run:"),
+            "$ systemctl enable --now rpm-ostreed-automatic.timer",
+        )
+        rec = "\n".join(rec_lines)
     yield Report(
-        "Ensuring rpm-ostreed-automatic.timer is enabled",
+        _("Ensuring {0} is enabled").format("rpm-ostreed-automatic.timer"),
         status,
         warnings=warning,
         recs=rec,
@@ -424,15 +474,18 @@ def audit_podman_auto_update():
             "systemctl", "--user", "is-failed", "--quiet", "podman-auto-update.timer"
         ):
             status = status.downgrade_to(WARN)
-            warning = "podman-auto-update.timer is enabled but has failed to run"
+            warning = _("{0} is enabled but has failed to run.").format("podman-auto-update.timer")
     else:
         status = FAIL
-        warning = "podman-auto-update.timer is disabled"
-        rec = """podman-auto-update.timer is disabled.
-                To enable, run:
-                $ systemctl enable --now podman-auto-update.timer"""
+        warning = _("{0} is disabled.").format("podman-auto-update.timer")
+        rec_lines = (
+            warning,
+            _("To enable it, run:"),
+            "$ systemctl enable --now podman-auto-update.timer",
+        )
+        rec = "\n".join(rec_lines)
     yield Report(
-        "Ensuring podman-auto-update.timer is enabled",
+        _("Ensuring {0} is enabled").format("podman-auto-update.timer"),
         status,
         warnings=warning,
         recs=rec,
@@ -450,15 +503,20 @@ def audit_podman_global_auto_update():
         rec = None
         if command_succeeds("systemctl", "is-failed", "--quiet", "podman-auto-update.timer"):
             status = status.downgrade_to(WARN)
-            warning = "podman-auto-update.timer is enabled globally but has failed to run"
+            warning = _("{0} is enabled globally but has failed to run.").format(
+                "podman-auto-update.timer"
+            )
     else:
         status = FAIL
-        warning = "podman-auto-update.timer is not enabled globally"
-        rec = """podman-auto-update.timer is not enabled globally.
-                To enable, run:
-                $ systemctl enable --global podman-auto-update.timer"""
+        warning = _("{0} is not enabled globally.").format("podman-auto-update.timer")
+        rec_lines = (
+            warning,
+            _("To enable it, run:"),
+            "$ systemctl enable --global podman-auto-update.timer",
+        )
+        rec = "\n".join(rec_lines)
     yield Report(
-        "Ensuring podman-auto-update.timer is enabled globally",
+        _("Ensuring {0} is enabled globally").format("podman-auto-update.timer"),
         status,
         warnings=warning,
         recs=rec,
@@ -480,15 +538,20 @@ def audit_flatpak_auto_update():
             "systemctl", "--user", "is-failed", "--quiet", "flatpak-user-update.timer"
         ):
             status = status.downgrade_to(WARN)
-            warning = "flatpak-user-update.timer is enabled globally but has failed to run."
+            warning = _("{0} is enabled globally but has failed to run.").format(
+                "flatpak-user-update.timer"
+            )
     else:
         status = FAIL
-        warning = "flatpak-user-update.timer is not enabled globally"
-        rec = """flatpak-user-update.timer is not enabled globally.
-                To enable, run:
-                $ systemctl enable --global flatpak-user-update.timer"""
+        warning = _("{0} is not enabled globally.").format("flatpak-user-update.timer")
+        rec_lines = (
+            warning,
+            _("To enable it, run:"),
+            "$ systemctl enable --global flatpak-user-update.timer",
+        )
+        rec = "\n".join(rec_lines)
     yield Report(
-        "Ensuring flatpak-user-update.timer is enabled globally",
+        _("Ensuring {0} is enabled globally").format("flatpak-user-update.timer"),
         status,
         warnings=warning,
         recs=rec,
@@ -500,15 +563,20 @@ def audit_flatpak_auto_update():
         rec = None
         if command_succeeds("systemctl", "is-failed", "--quiet", "flatpak-system-update.timer"):
             status = status.downgrade_to(WARN)
-            warning = "flatpak-system-update.timer is enabled but has failed to run."
+            warning = _("{0} is enabled but has failed to run.").format(
+                "flatpak-system-update.timer"
+            )
     else:
         status = FAIL
-        warning = "flatpak-system-update.timer is not enabled"
-        rec = """flatpak-system-update.timer is not enabled.
-                To enable, run:
-                $ systemctl enable --now flatpak-system-update.timer"""
+        warning = _("{0} is not enabled.").format("flatpak-system-update.timer")
+        rec_lines = (
+            warning,
+            _("To enable it, run:"),
+            "$ systemctl enable --now flatpak-system-update.timer",
+        )
+        rec = "\n".join(rec_lines)
     yield Report(
-        "Ensuring flatpak-system-update.timer is enabled",
+        _("Ensuring {0} is enabled").format("flatpak-system-update.timer"),
         status,
         warnings=warning,
         recs=rec,
@@ -519,14 +587,17 @@ def audit_flatpak_auto_update():
 def audit_wheel():
     """Ensure the current user is not in the wheel group."""
     if "wheel" in command_stdout("groups").split():
-        rec = f"""Current user is in the wheel group.
-            To set up a separate wheel account, follow the instructions here:
-            {bold("https://secureblue.dev/install#wheel")}"""
+        rec_lines = (
+            _("The current user is in the wheel group."),
+            _("To set up a separate wheel account, follow the instructions here:"),
+            bold("https://secureblue.dev/install#wheel"),
+        )
+        rec = "\n".join(rec_lines)
         status = FAIL
     else:
         rec = None
         status = PASS
-    yield Report("Ensuring user is not a member of wheel", status, recs=rec)
+    yield Report(_("Ensuring user is not a member of the wheel group"), status, recs=rec)
 
 
 @audit
@@ -535,13 +606,13 @@ def audit_xwayland(state):
     """Check whether xwayland is disabled."""
     match state["image"]:
         case Image.SILVERBLUE:
-            de = "GNOME"
+            de = _("GNOME")
             path = "/etc/systemd/user/org.gnome.Shell@wayland.service.d/override.conf"
         case Image.KINOITE:
-            de = "KDE Plasma"
+            de = _("KDE Plasma")
             path = "/etc/systemd/user/plasma-kwin_wayland.service.d/override.conf"
         case Image.SERICEA:
-            de = "Sway"
+            de = _("Sway")
             path = "/etc/sway/config.d/99-noxwayland.conf"
         case _:
             return
@@ -550,9 +621,13 @@ def audit_xwayland(state):
         rec = None
     else:
         status = FAIL
-        rec = f"""Xwayland is enabled for {de}. To disable, run:
-            $ ujust toggle-xwayland"""
-    yield Report(f"Ensuring xwayland is disabled for {de}", status, recs=rec)
+        rec_lines = (
+            _("Xwayland is enabled for {0}.").format(de),
+            _("To disable it, run:"),
+            "$ ujust toggle-xwayland",
+        )
+        rec = "\n".join(rec_lines)
+    yield Report(_("Ensuring {0} is disabled for {1}").format("Xwayland", de), status, recs=rec)
 
 
 @audit
@@ -574,9 +649,13 @@ def audit_gnome_extensions(state):
         rec = None
     else:
         status = FAIL
-        rec = """GNOME user extensions are enabled. To disable, run:
-            $ ujust toggle-gnome-extensions"""
-    yield Report("Ensuring GNOME user extensions are disabled", status, recs=rec)
+        rec_lines = (
+            _("GNOME user extensions are enabled."),
+            _("To disable this, run:"),
+            "$ ujust toggle-gnome-extensions",
+        )
+        rec = "\n".join(rec_lines)
+    yield Report(_("Ensuring GNOME user extensions are disabled"), status, recs=rec)
 
 
 @audit
@@ -587,10 +666,13 @@ def audit_selinux():
         rec = None
     else:
         status = FAIL
-        rec = """SELinux is in Permissive mode.
-            To set to Enforcing mode, run:
-            $ run0 setenforce 1"""
-    yield Report("Ensuring SELinux is in Enforcing mode", status, recs=rec)
+        rec_lines = (
+            _("SELinux is in Permissive mode."),
+            _("To set it to Enforcing mode, run:"),
+            "$ run0 setenforce 1",
+        )
+        rec = "\n".join(rec_lines)
+    yield Report(_("Ensuring SELinux is in Enforcing mode"), status, recs=rec)
 
 
 @audit
@@ -603,17 +685,21 @@ def audit_environment_file():
     try:
         if not filecmp.cmp("/usr" + env_file, env_file):
             status = WARN
-            warning = f"{env_file} has been modified"
+            warning = _("The file {0} has been modified.").format(env_file)
     except FileNotFoundError:
         status = WARN
-        warning = f"{env_file} has been deleted"
+        warning = _("The file {0} has been deleted.").format(env_file)
     except PermissionError:
         status = WARN
-        warning = f"{env_file} cannot be read"
+        warning = _("The file {0} cannot be read.").format(env_file)
     if status != PASS:
-        rec = f"""{env_file} has been modified. To reset it, run:
-            $ run0 cp -p /usr{env_file} {env_file}"""
-    yield Report("Ensuring no environment file overrides", status, warnings=warning, recs=rec)
+        rec_lines = (
+            _("The file {0} has been modified."),
+            _("To reset it, run:"),
+            f"$ run0 cp -p /usr{env_file} {env_file}",
+        )
+        rec = "\n".join(rec_lines)
+    yield Report(_("Ensuring no environment file overrides"), status, warnings=warning, recs=rec)
 
 
 @audit
@@ -629,17 +715,20 @@ def audit_kde_ghns(state):
             config = parse_config(f)
     except (FileNotFoundError, PermissionError):
         status = WARN
-        warning = "/etc/xdg/kdeglobals not found or inaccessible"
+        warning = _("The file {0} was not found or inaccessible.").format("/etc/xdg/kdeglobals")
     else:
         if config.get("ghns") == "false":
             status = PASS
     if status == FAIL:
-        rec = """KDE GHNS is enabled.
-            To disable, run:
-            $ ujust toggle-ghns"""
+        rec_lines = (
+            _("KDE GNHS is enabled."),
+            _("To disable it, run:"),
+            "$ ujust toggle-ghns",
+        )
+        rec = "\n".join(rec_lines)
     else:
         rec = None
-    yield Report("Ensuring KDE GHNS is disabled", status, warnings=warning, recs=rec)
+    yield Report(_("Ensuring KDE GHNS is disabled"), status, warnings=warning, recs=rec)
 
 
 @audit
@@ -653,22 +742,27 @@ def audit_ld_preload():
         stat_result = os.stat(ld_so_preload)
     except FileNotFoundError:
         status = FAIL
-        warnings.append(f"{ld_so_preload} not found")
+        warnings.append(_("The file {0} was not found.").format(ld_so_preload))
     else:
         mode = stat.S_IMODE(stat_result.st_mode)
         expected_mode = 0o600
         if mode != expected_mode:
             status = WARN
-            warnings.append(f"{ld_so_preload} has mode {mode:o} (expected {expected_mode:o})")
+            warnings.append(
+                _("{0} has mode {1:o} (expected {2:o})").format(ld_so_preload, mode, expected_mode)
+            )
         if stat_result.st_uid != 0:
             status = FAIL
-            warnings.append(f"{ld_so_preload} is owned by a non-root user!")
+            warnings.append(_("{0} is owned by a non-root user!").format(ld_so_preload))
     if status != PASS:
-        rec = f"""{ld_so_preload} has been modified or deleted.
-            To reset it and enable hardened_malloc for system processes, run:
-            $ run0 cp -p /usr{ld_so_preload} {ld_so_preload}"""
+        rec_lines = (
+            _("The file {0} has been modified or deleted.").format(ld_so_preload),
+            _("To reset it and enable hardened_malloc for system processes, run:"),
+            f"$ run0 cp -p /usr{ld_so_preload} {ld_so_preload}",
+        )
+        rec = "\n".join(rec_lines)
     yield Report(
-        "Ensuring ld.so.preload has expected permissions",
+        _("Ensuring {0} has expected permissions").format("ld.so.preload"),
         status,
         warnings=warnings,
         recs=rec,
@@ -686,23 +780,27 @@ def audit_hardened_malloc():
         warning = None
     elif "libhardened_malloc.so" in preloads:
         status = WARN
-        warning = "hardened_malloc set, but LD_PRELOAD has been modified"
+        warning = _("{0} is set, but {1} has been modified.").format(
+            "hardened_malloc", "LD_PRELOAD"
+        )
     elif "libhardened_malloc-light.so" in preloads:
         status = WARN
-        warning = "'light' variant of hardened_malloc set"
+        warning = _("The '{0}' variant of {1} has been set.").format("light", "hardened_malloc")
     elif "libhardened_malloc-pkey.so" in preloads:
         status = WARN
-        warning = "'pkey' variant of hardened_malloc set"
+        warning = _("The '{0}' variant of {1} has been set.").format("pkey", "hardened_malloc")
     else:
         status = FAIL
-        warning = "libhardened_malloc not set in LD_PRELOAD"
+        warning = _("{0} has not been set.").format("LD_PRELOAD=libhardened_malloc.so")
 
     if status != PASS:
-        rec = """The LD_PRELOAD environment variable has been modified or is unset.
-            Check that LD_PRELOAD=libhardened_malloc.so has not been overridden in
-            /etc/profile.d or related configuration files."""
+        rec = _("""The environment variable {0} has been modified or is unset.
+                Check that {1} has not been overridden in
+                {2} or related configuration files.""").format(
+            "LD_PRELOAD", "LD_PRELOAD=libhardened_malloc.so", "/etc/profile.d"
+        )
     yield Report(
-        "Ensuring hardened_malloc is set to be preloaded",
+        _("Ensuring hardened_malloc is set to be preloaded"),
         status,
         warnings=warning,
         recs=rec,
@@ -712,11 +810,9 @@ def audit_hardened_malloc():
 @audit
 def audit_secureboot():
     """Ensure secureboot is enabled."""
-    if command_stdout("mokutil", "--sb-state", check=False) == "SecureBoot enabled":
-        status = PASS
-    else:
-        status = FAIL
-    yield Report("Ensuring secure boot is enabled", status)
+    sb_enabled = command_stdout("mokutil", "--sb-state", check=False) == "SecureBoot enabled"
+    status = PASS if sb_enabled else FAIL
+    yield Report(_("Ensuring secure boot is enabled"), status)
 
 
 @audit
@@ -748,16 +844,18 @@ def audit_bash_env_lockdown():
                 unlocked_files.append(path)
     if unlocked_files:
         status = FAIL
-        unlocked_files_string = "\n".join(unlocked_files)
-        rec = f"""Bash environment is not locked down.
-                The following files do not appear to be immutable or do not exist:
-                {unlocked_files_string}
-                To fix, run:
-                $ ujust toggle-bash-environment-lockdown"""
+        rec_lines = (
+            _("Bash environment is not locked down."),
+            _("The following files do not appear to be immutable or do not exist:"),
+            *unlocked_files,
+            _("To fix this, run:"),
+            "$ ujust toggle-bash-environment-lockdown",
+        )
+        rec = "\n".join(rec_lines)
     else:
         status = PASS
         rec = None
-    yield Report("Ensuring current user's bash environment is locked down", status, recs=rec)
+    yield Report(_("Ensuring current user's bash environment is locked down"), status, recs=rec)
 
 
 @audit
@@ -778,13 +876,13 @@ def audit_flatpak_remotes():
             "https://dl.flathub.org/beta-repo/",
         ]:
             status = FAIL
-            warnings.append(f"{name} is configured with an unknown url")
+            warnings.append(_("{0} is configured with an unknown URL.").format(name))
         elif subset != "verified":
             status = FAIL
-            warnings.append(f"{name} is not a verified repo")
+            warnings.append(_("{0} is not a verified flatpak repository.").format(name))
         else:
             status = PASS
-        yield Report(f"Auditing flatpak remote {name}", status, warnings=warnings)
+        yield Report(_("Auditing flatpak remote {0}").format(name), status, warnings=warnings)
 
 
 @audit
@@ -816,7 +914,8 @@ async def audit_flatpak_permissions(state):
         flatpak_permissions_state = check_flatpak_permissions(
             name, perms, state["bluetooth_loaded"], state["ptrace_allowed"]
         )
-        report_text = f"Auditing {name}" if version == "stable" else f"Auditing {name} ({version})"
+        display_name = name if version == "stable" else f"{name} ({version})"
+        report_text = _("Auditing {0}").format(display_name)
         yield Report(
             report_text,
             flatpak_permissions_state.status,
@@ -832,7 +931,7 @@ async def audit_flatpak_permissions(state):
 
 def handle_sigint(_sig, _frame):
     """Gracefully handle interrupt signal."""
-    print_err("\n[Audit process interrupted. Exiting.]")
+    print_err("\n" + _("[Audit process interrupted. Exiting.]"))
     # Suppress output from exceptions in unfinished tasks
     sys.stderr = None
     sys.exit(1)
@@ -845,16 +944,16 @@ async def main() -> int:
     parser = argparse.ArgumentParser(
         prog="ujust audit-secureblue",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description="Audit secureblue configuration for security",
+        description=_("Audit secureblue configuration for security"),
         epilog=get_legend(),
     )
     categories = ",".join(sorted(global_audit.categories))
-    parser.add_argument("-s", "--skip", default="", help=f"skip categories ({categories})")
-    parser.add_argument("-j", "--json", action="store_true", help="display output as JSON")
+    parser.add_argument("-s", "--skip", default="", help=_("skip categories") + f" ({categories})")
+    parser.add_argument("-j", "--json", action="store_true", help=_("display output as JSON"))
     args = parser.parse_args()
     skip = args.skip.split(",") if args.skip else []
     if any(cat not in global_audit.categories for cat in skip):
-        print(f"Valid arguments to --skip are: {categories}", file=sys.stderr)
+        print(_("Valid arguments to {0} are: {1}").format("--skip", categories), file=sys.stderr)
         sys.exit(1)
     error_occurred = False
     if args.json:
@@ -862,15 +961,15 @@ async def main() -> int:
             print(report_json)
         return 0
     async for check, err in global_audit.run(exclude=skip, width=get_width()):
-        print_err(f"\n*** Error in check '{check.name}' ***")
+        print_err("\n" + _("*** Error in check '{0}' ***").format(check.name))
         traceback.print_exception(err)
-        print_err("\n*** Continuing... ***")
+        print_err("\n" + _("*** Continuing... ***"))
         error_occurred = True
     if "flatpak" not in skip:
-        print(f"Use option '{bold('--skip flatpak')}' to skip flatpak recommendations.")
+        print(_("Use option '{0}' to skip flatpak recommendations.").format(bold("--skip flatpak")))
     warn_if_root()
     if error_occurred:
-        print_err("\n*** WARNING: Unexpected error occurred. ***")
+        print_err("\n" + _("*** WARNING: Unexpected error occurred. ***"))
         return 1
     return 0
 

--- a/files/system/usr/libexec/secureblue/auditor/__init__.py
+++ b/files/system/usr/libexec/secureblue/auditor/__init__.py
@@ -20,10 +20,19 @@ Framework for system auditing.
 
 import dataclasses
 import enum
+import gettext
 import inspect
 import json
 from collections.abc import AsyncGenerator, Callable, Generator, Sequence
 from typing import Any, ClassVar, Final, Self
+
+
+def gettext_marker() -> Callable[[str], str]:
+    """Get the _ function used by gettext to mark translatable strings."""
+    return gettext.translation("audit_secureblue", "/usr/share/locale", fallback=True).gettext
+
+
+_: Final = gettext_marker()
 
 
 class AuditError(Exception):
@@ -39,6 +48,20 @@ class Status(enum.Enum):
     FAIL = 3
     UNKNOWN = 4
 
+    def local_name(self) -> str:
+        """Get localized name."""
+        match self:
+            case Status.PASS:
+                return _("PASS")
+            case Status.INFO:
+                return _("INFO")
+            case Status.WARN:
+                return _("WARN")
+            case Status.FAIL:
+                return _("FAIL")
+            case Status.UNKNOWN:
+                return _("UNKNOWN")
+
     def to_str_in_color(self) -> str:
         """Colored text representation of the status."""
         match self:
@@ -52,7 +75,11 @@ class Status(enum.Enum):
                 color_code = 31  # red
             case Status.UNKNOWN:
                 color_code = 37  # white
-        return f"\x1b[{color_code}m{self.name}\x1b[39m"
+        return f"\x1b[{color_code}m{self.local_name()}\x1b[39m"
+
+    def width(self) -> int:
+        """Printable width of status."""
+        return len(self.local_name())
 
     def downgrade_to(self, other: Self) -> Self:
         """Returns the more severe of the two statuses."""
@@ -116,7 +143,7 @@ class Report:
         """Represent the report as a string formatted to the given width."""
         status_tag = f" [ {self.status.to_str_in_color()} ]"
         gray_start = "\x1b[38;5;241m"
-        desc_width = width - len(self.status.name) - 5 + len(gray_start)
+        desc_width = width - self.status.width() - 5 + len(gray_start)
         reset_color = "\x1b[39m"
         desc_with_sep = f"{self.description} {gray_start}".ljust(desc_width, "…") + reset_color
         report_str = desc_with_sep + status_tag
@@ -191,7 +218,7 @@ def _format_recommendation_text(rec_text: str, mergeable_names: list[str] | None
 
 
 def _print_recs(recs: list[Recommendation], width: int = 80):
-    print_heading("Recommendations", width=width)
+    print_heading(_("Recommendations"), width=width)
     merged_recs_data: dict[str, list[str]] = {
         rec.text: [] for rec in recs if rec.mergeable_name is not None
     }
@@ -232,15 +259,15 @@ class Audit:
         self, *, exclude: list[str] | None = None, width: int = 80
     ) -> AsyncGenerator[tuple[Check, Exception]]:
         """Runs each stored check, prints their reports, then prints their recommendations."""
+        print_heading(_("Audit"), width=width)
         if exclude is None:
             exclude = []
-        print_heading("Audit", width=width)
-        if exclude:
-            category_word = "category" if len(exclude) == 1 else "categories"
-            print(f"Skipping checks in the following {category_word}: {', '.join(exclude)}")
-        for check in self.checks:
-            if check.category in exclude:
-                continue
+        elif len(exclude) == 1:
+            print(_("Skipping checks in the following category:"), ", ".join(exclude))
+        elif len(exclude) > 1:
+            print(_("Skipping checks in the following categories:"), ", ".join(exclude))
+        checks = [check for check in self.checks if check.category not in exclude]
+        for check in checks:
             try:
                 async for report in check.run(self.state):
                     print(report.to_str(width=width))

--- a/files/system/usr/libexec/secureblue/utils/__init__.py
+++ b/files/system/usr/libexec/secureblue/utils/__init__.py
@@ -31,13 +31,16 @@ from collections.abc import Iterable
 from typing import Final
 
 import rpm
-from auditor import AuditError, Status
+from auditor import AuditError, Status, gettext_marker
 
 PASS: Final = Status.PASS
 INFO: Final = Status.INFO
 WARN: Final = Status.WARN
 FAIL: Final = Status.FAIL
 UNKNOWN: Final = Status.UNKNOWN
+
+
+_: Final = gettext_marker()
 
 
 def print_err(text: str):
@@ -48,8 +51,8 @@ def print_err(text: str):
 def warn_if_root():
     """If run as root, warn that this is not recommended."""
     if not os.getuid():
-        print_err("\n*** WARNING: Running audit script as root is not recommended. ***")
-        print_err("*** Some results may be misleading or incomplete. ***\n")
+        print_err("\n" + _("*** WARNING: Running audit script as root is not recommended. ***"))
+        print_err(_("*** Some results may be misleading or incomplete. ***") + "\n")
 
 
 def get_width() -> int:
@@ -77,34 +80,37 @@ def _format_legend_entry(status: Status, description: str, width: int = 80) -> s
 
 def get_legend(width: int = 80) -> str:
     """Get legend to be printed with --help option."""
-    legend = "The following status indicators accompany checks run by the audit script:\n\n"
+    legend = _("The following status indicators accompany checks run by the audit script:")
+    legend += "\n\n"
     status_descriptions: dict[Status, str] = {
-        FAIL: "check failed - the configuration may be less secure.",
-        WARN: "partial failure, or less significant issue detected.",
-        PASS: "check passed - no problems detected.",
-        UNKNOWN: "unable to perform check (usually due to a file permission issue).",
+        FAIL: _("check failed - the configuration may be less secure."),
+        WARN: _("partial failure, or less significant issue detected."),
+        PASS: _("check passed - no problems detected."),
+        UNKNOWN: _("unable to perform check (usually due to a file permission issue)."),
     }
     for status, desc in status_descriptions.items():
         legend += _format_legend_entry(status, desc, width)
-    legend += "\nFor flatpak checks, the status indicators have more specific meanings:\n\n"
+    legend += "\n"
+    legend += _("For flatpak checks, the status indicators have more specific meanings:")
+    legend += "\n\n"
     flatpak_status_descriptions: dict[Status, str] = {
-        FAIL: """app has permissions that can be used as sandbox escapes, allow it to modify
+        FAIL: _("""app has permissions that can be used as sandbox escapes, allow it to modify
             its own permissions, or otherwise grant very broad access to the system (e.g. access
-            to certain directories, direct D-Bus access, X11).""",
-        WARN: """app has permissions that have some sandbox escape potential or otherwise
-            weaken security (e.g. PulseAudio, Bluetooth, not using hardened_malloc).""",
-        INFO: """no potential sandbox escapes detected but some permissions could increase
-            attack surface or have privacy implications (e.g. network access).""",
-        PASS: "no app permissions flagged (however, not all permissions are audited).",
+            to certain directories, direct D-Bus access, X11)."""),
+        WARN: _("""app has permissions that have some sandbox escape potential or otherwise
+            weaken security (e.g. PulseAudio, Bluetooth, not using hardened_malloc)."""),
+        INFO: _("""no potential sandbox escapes detected but some permissions could increase
+            attack surface or have privacy implications (e.g. network access)."""),
+        PASS: _("no app permissions flagged (however, not all permissions are audited)."),
     }
     for status, desc in flatpak_status_descriptions.items():
         legend += _format_legend_entry(status, desc, width)
     legend += "\n" + textwrap.fill(
         textwrap.dedent(
-            """\
+            _("""\
             Note that some flatpak apps require broad permissions to function. Permissions being
             flagged by the audit script do not necessarily mean that action should be taken.
-            """
+            """)
         ),
         width=width,
     )

--- a/recipes/common/common-packages.yml
+++ b/recipes/common/common-packages.yml
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 type: rpm-ostree
-repos: 
+repos:
   - https://copr.fedorainfracloud.org/coprs/secureblue/hardened_malloc/repo/fedora-%OS_VERSION%/secureblue-hardened_malloc-fedora-%OS_VERSION%.repo
   - https://copr.fedorainfracloud.org/coprs/secureblue/run0edit/repo/fedora-%OS_VERSION%/secureblue-run0edit-fedora-%OS_VERSION%.repo
 install:
@@ -28,6 +28,7 @@ install:
   - nvme-cli
   - hdparm
   - wireguard-tools
-  
-  # signing deps 
+  - gettext
+
+  # signing deps
   - sbsigntools

--- a/recipes/common/common-scripts.yml
+++ b/recipes/common/common-scripts.yml
@@ -22,3 +22,4 @@ scripts:
   - enablekeyverification.sh
   - removefedoraflatpakremoteservice.sh
   - enablecommonautoupdate.sh
+  - localization.sh

--- a/ruff.toml
+++ b/ruff.toml
@@ -33,5 +33,6 @@ ignore = [
 ]
 
 mccabe.max-complexity = 8
+pycodestyle.max-line-length = 110
 pycodestyle.max-doc-length = 100
 pylint.max-statements = 40


### PR DESCRIPTION
* Mark translatable strings in the audit script. Also adjust wording of some messages for clarity and to aid translation,
and relax linter rule so slightly overlong lines aren't flagged.
* Add `files/po` directory and a `localization.sh` script that automatically runs `msgfmt` on .po files in that directory to install compiled .mo files to the appropriate system locale directories. To add translations, .po files can be added to a subdirectory with the appropriate language code.