### PR TITLE
fix: allow initrc_t to relabel to userns-privileged types

### DIFF
--- a/files/scripts/selinux/user_namespace/userns_deny_unconfined_relabels.cil
+++ b/files/scripts/selinux/user_namespace/userns_deny_unconfined_relabels.cil
@@ -16,7 +16,7 @@
 (typeattributeset userns_privileged_file_type (colord_exec_t container_runtime_exec_t devicekit_power_exec_t docker_exec_t flatpak_exec_t kubelet_exec_t nautilus_exec_t systemsettings_exec_t trivalent_exec_t trivalent_script_exec_t))
 
 (typeattribute userns_relabel_allowed)
-(typeattributeset userns_relabel_allowed (init_t install_t kernel_t))
+(typeattributeset userns_relabel_allowed (init_t initrc_t install_t kernel_t))
 
 (typeattribute userns_relabel_restricted)
 (typeattributeset userns_relabel_restricted (and (domain) (not (userns_relabel_allowed))))


### PR DESCRIPTION
This is necessary, for example, to allow system services to take btrfs snapshots of the root filesystem. This shouldn't have security implications as root access is already needed to execute something as initrc_t.