### PR TITLE
fix: ujust libvirt documentation

### DIFF
--- a/files/justfiles/utilities.just
+++ b/files/justfiles/utilities.just
@@ -338,7 +338,7 @@ install-libvirt-packages:
     set -euo pipefail
     rpm-ostree install -y libvirt libvirt-nss qemu qemu-char-spice qemu-device-display-virtio-gpu qemu-device-display-virtio-vga qemu-device-usb-redirect qemu-img qemu-system-x86-core qemu-user-binfmt qemu-user-static virt-install virt-manager virt-v2v virt-viewer
     echo "Check out the Red Hat documentation to see which services to enable for your usecase:"
-    echo "https://docs.redhat.com/fr/documentation/red_hat_enterprise_linux/9/html/monitoring_and_managing_system_status_and_performance/assembly_optimizing-libvirt-daemons_optimizing-virtual-machine-performance-in-rhel#proc_enabling-modular-libvirt-daemons_assembly_optimizing-libvirt-daemons"
+    echo "https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/configuring_and_managing_virtualization/optimizing-virtual-machine-performance-in-rhel_configuring-and-managing-virtualization#proc_enabling-modular-libvirt-daemons_assembly_optimizing-libvirt-daemons"
 
 # Convenience utility for layering VPN provider packages
 install-vpn:


### PR DESCRIPTION
Change old link from French localized version to far more expansive English version and specifically link the REHL recommended modular libvirt services. 