### PR TITLE
test: add integration test for audit script results

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -14,8 +14,8 @@ name: integration-tests
 permissions: {}
 on:
   schedule:
-    - cron: "00 7 * * *" # run at 7:00 UTC every day 
-      
+    - cron: "00 7 * * *" # run at 7:00 UTC every day
+
   workflow_dispatch:
 jobs:
   integration-tests:
@@ -27,7 +27,7 @@ jobs:
       packages: write
       id-token: write
     strategy:
-      fail-fast: false 
+      fail-fast: false
 
     steps:
       - name: Checkout repo
@@ -37,10 +37,11 @@ jobs:
 
       - name: Run integration tests
         uses: secureblue/bootc-virtual-machine-action@05aa93d5e9d1e128c8d0772fd534fed5c73f9271 # v0.0.3
-        with:          
+        with:
           registry: ghcr.io/secureblue
           image: silverblue-main-hardened
           token: ${{ secrets.GITHUB_TOKEN }}
           tests: |
+            ./.github/workflows/integration_tests/check_audit_results.sh
             ./.github/workflows/integration_tests/check_cleanup.sh
             ./.github/workflows/integration_tests/check_firstrun.sh

--- a/.github/workflows/integration_tests/check_audit_results.sh
+++ b/.github/workflows/integration_tests/check_audit_results.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+audit_results=$(ujust audit-secureblue --json | jq -c '{name, description, status, warnings}')
+
+if diff expected-audit-silverblue-main-hardened.txt <(echo "$audit_results"); then
+    echo "Audit script output is as expected."
+else
+    echo "Audit script output differs from expected output."
+    exit 1
+fi

--- a/.github/workflows/integration_tests/expected-audit-silverblue-main-hardened.txt
+++ b/.github/workflows/integration_tests/expected-audit-silverblue-main-hardened.txt
@@ -1,0 +1,28 @@
+{"name":"audit_kargs","description":"Checking for hardened kernel arguments","status":"warn","warnings":["Missing kernel argument: ia32_emulation=0 (32-bit support)","Missing kernel argument: nosmt=force (force-disable SMT)","Missing kernel argument (unstable): amd_iommu=force_isolation","Missing kernel argument (unstable): debugfs=off","Missing kernel argument (unstable): efi=disable_early_pci_dma","Missing kernel argument (unstable): gather_data_sampling=force","Missing kernel argument (unstable): oops=panic"]}
+{"name":"audit_sysctl","description":"Ensuring no sysctl overrides","status":"fail","warnings":["kernel.printk should be 3 3 3 3, but is actually 0\t3\t3\t3."]}
+{"name":"audit_signed_image","description":"Ensuring a signed image is in use","status":"fail","warnings":[]}
+{"name":"audit_modprobe","description":"Ensuring no modprobe overrides","status":"pass","warnings":[]}
+{"name":"audit_ptrace","description":"Ensuring ptrace is forbidden","status":"pass","warnings":[]}
+{"name":"audit_authselect","description":"Ensuring no authselect overrides","status":"pass","warnings":[]}
+{"name":"audit_container_policy","description":"Ensuring no container policy overrides","status":"pass","warnings":[]}
+{"name":"audit_unconfined_userns","description":"Ensuring unconfined user namespace creation disallowed","status":"pass","warnings":[]}
+{"name":"audit_container_userns","description":"Ensuring container user namespace creation disallowed","status":"pass","warnings":[]}
+{"name":"audit_usbguard","description":"Ensuring USBGuard is active","status":"fail","warnings":["USBGuard is not enabled."]}
+{"name":"audit_chronyd","description":"Ensuring chronyd is active","status":"pass","warnings":[]}
+{"name":"audit_dns","description":"Ensuring system DNS resolution is secure","status":"fail","warnings":[]}
+{"name":"audit_mac_randomization","description":"Ensuring MAC randomization is enabled","status":"fail","warnings":[]}
+{"name":"audit_rpm_ostree_timer","description":"Ensuring rpm-ostreed-automatic.timer is enabled","status":"pass","warnings":[]}
+{"name":"audit_podman_auto_update","description":"Ensuring podman-auto-update.timer is enabled","status":"pass","warnings":[]}
+{"name":"audit_podman_global_auto_update","description":"Ensuring podman-auto-update.timer is enabled globally","status":"pass","warnings":[]}
+{"name":"audit_flatpak_auto_update","description":"Ensuring flatpak-user-update.timer is enabled globally","status":"pass","warnings":[]}
+{"name":"audit_flatpak_auto_update","description":"Ensuring flatpak-system-update.timer is enabled","status":"pass","warnings":[]}
+{"name":"audit_wheel","description":"Ensuring user is not a member of the wheel group","status":"fail","warnings":[]}
+{"name":"audit_xwayland","description":"Ensuring Xwayland is disabled for GNOME","status":"pass","warnings":[]}
+{"name":"audit_gnome_extensions","description":"Ensuring GNOME user extensions are disabled","status":"pass","warnings":[]}
+{"name":"audit_selinux","description":"Ensuring SELinux is in Enforcing mode","status":"pass","warnings":[]}
+{"name":"audit_environment_file","description":"Ensuring no environment file overrides","status":"pass","warnings":[]}
+{"name":"audit_ld_preload","description":"Ensuring ld.so.preload has expected permissions","status":"pass","warnings":[]}
+{"name":"audit_hardened_malloc","description":"Ensuring hardened_malloc is set to be preloaded","status":"pass","warnings":[]}
+{"name":"audit_secureboot","description":"Ensuring secure boot is enabled","status":"fail","warnings":[]}
+{"name":"audit_bash_env_lockdown","description":"Ensuring current user's bash environment is locked down","status":"fail","warnings":[]}
+{"name":"audit_flatpak_remotes","description":"Auditing flatpak remote flathub-verified","status":"pass","warnings":[]}


### PR DESCRIPTION
This integration test checks that the results of the audit script on first boot are as expected.

(It's unclear why the sysctl `kernel.printk` has the value `0 3 3 3` rather than `3 3 3 3` in the integration test image, but for now we'll just include it in the expected results. This issue is *not* observed on a real installation.)