### PR TITLE
chore: relicense selinux policy to dual Apache2/MIT

### DIFF
--- a/files/scripts/selinux/flatpakfull/flatpakfull.fc
+++ b/files/scripts/selinux/flatpakfull/flatpakfull.fc
@@ -1,14 +1,6 @@
-# Copyright 2025 The Secureblue Authors
+# SPDX-FileCopyrightText 2025 The Secureblue Authors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 /usr/bin/flatpak	--	gen_context(system_u:object_r:flatpak_exec_t,s0)
 /usr/bin/flatpak-bisect	--	gen_context(system_u:object_r:flatpak_exec_t,s0)

--- a/files/scripts/selinux/flatpakfull/flatpakfull.if
+++ b/files/scripts/selinux/flatpakfull/flatpakfull.if
@@ -1,16 +1,8 @@
 ## <summary>flatpak packaging system</summary>
 
-# Copyright 2025 The Secureblue Authors
+# SPDX-FileCopyrightText 2025 The Secureblue Authors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 ########################################
 ## <summary>

--- a/files/scripts/selinux/flatpakfull/flatpakfull.sh
+++ b/files/scripts/selinux/flatpakfull/flatpakfull.sh
@@ -1,16 +1,8 @@
 #!/usr/bin/env bash
 
-# Copyright 2025 The Secureblue Authors
+# SPDX-FileCopyrightText 2025 The Secureblue Authors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 echo "Building and Loading Policy"
 

--- a/files/scripts/selinux/flatpakfull/flatpakfull.te
+++ b/files/scripts/selinux/flatpakfull/flatpakfull.te
@@ -1,16 +1,8 @@
 policy_module(flatpakfull, 1.0.0)
 
-# Copyright 2025 The Secureblue Authors
+# SPDX-FileCopyrightText 2025 The Secureblue Authors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 ########################################
 #

--- a/files/scripts/selinux/flatpakfull/grant_systemd_flatpak_exec.cil
+++ b/files/scripts/selinux/flatpakfull/grant_systemd_flatpak_exec.cil
@@ -1,13 +1,5 @@
-;; Copyright 2025 The Secureblue Authors
+;; SPDX-FileCopyrightText 2025 The Secureblue Authors
 ;;
-;; Licensed under the Apache License, Version 2.0 (the "License");
-;; you may not use this file except in compliance with the License.
-;; You may obtain a copy of the License at
-;;
-;;     http://www.apache.org/licenses/LICENSE-2.0
-;;
-;; Unless required by applicable law or agreed to in writing, software distributed under the License is
-;; distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-;; See the License for the specific language governing permissions and limitations under the License.
+;; SPDX-License-Identifier: Apache-2.0 OR MIT
 
 (allow init_t flatpak_exec_t (file (execute execute_no_trans open read map)))

--- a/files/scripts/selinux/nautilus/nautilus.fc
+++ b/files/scripts/selinux/nautilus/nautilus.fc
@@ -1,13 +1,5 @@
-# Copyright 2025 The Secureblue Authors
+# SPDX-FileCopyrightText 2025 The Secureblue Authors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 /usr/bin/nautilus	--	gen_context(system_u:object_r:nautilus_exec_t,s0)

--- a/files/scripts/selinux/nautilus/nautilus.if
+++ b/files/scripts/selinux/nautilus/nautilus.if
@@ -1,16 +1,9 @@
 ## <summary>nautilus file manager</summary>
 
-# Copyright 2025 The Secureblue Authors
+# SPDX-FileCopyrightText 2025 The Secureblue Authors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
 
 ########################################
 ## <summary>

--- a/files/scripts/selinux/nautilus/nautilus.sh
+++ b/files/scripts/selinux/nautilus/nautilus.sh
@@ -1,16 +1,8 @@
 #!/usr/bin/env bash
 
-# Copyright 2025 The Secureblue Authors
+# SPDX-FileCopyrightText 2025 The Secureblue Authors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 echo "Building and Loading Policy"
 

--- a/files/scripts/selinux/nautilus/nautilus.te
+++ b/files/scripts/selinux/nautilus/nautilus.te
@@ -1,16 +1,8 @@
 policy_module(nautilus, 1.0.0)
 
-# Copyright 2025 The Secureblue Authors
+# SPDX-FileCopyrightText 2025 The Secureblue Authors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 ########################################
 #

--- a/files/scripts/selinux/systemsettings/systemsettings.fc
+++ b/files/scripts/selinux/systemsettings/systemsettings.fc
@@ -1,13 +1,5 @@
-# Copyright 2025 The Secureblue Authors
+# SPDX-FileCopyrightText 2025 The Secureblue Authors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 /usr/bin/systemsettings	--	gen_context(system_u:object_r:systemsettings_exec_t,s0)

--- a/files/scripts/selinux/systemsettings/systemsettings.if
+++ b/files/scripts/selinux/systemsettings/systemsettings.if
@@ -1,16 +1,8 @@
 ## <summary>systemsettings policy</summary>
 
-# Copyright 2025 The Secureblue Authors
+# SPDX-FileCopyrightText 2025 The Secureblue Authors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 ########################################
 ## <summary>

--- a/files/scripts/selinux/systemsettings/systemsettings.sh
+++ b/files/scripts/selinux/systemsettings/systemsettings.sh
@@ -1,16 +1,8 @@
 #!/usr/bin/env bash
 
-# Copyright 2025 The Secureblue Authors
+# SPDX-FileCopyrightText 2025 The Secureblue Authors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 echo "Building and Loading Policy"
 

--- a/files/scripts/selinux/systemsettings/systemsettings.te
+++ b/files/scripts/selinux/systemsettings/systemsettings.te
@@ -1,16 +1,8 @@
 policy_module(systemsettings, 1.0.0)
 
-# Copyright 2025 The Secureblue Authors
+# SPDX-FileCopyrightText 2025 The Secureblue Authors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 ########################################
 #

--- a/files/scripts/selinux/trivalent/trivalent.fc
+++ b/files/scripts/selinux/trivalent/trivalent.fc
@@ -1,14 +1,6 @@
-# Copyright 2025 The Secureblue Authors
+# SPDX-FileCopyrightText 2025 The Secureblue Authors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 /usr/lib/trivalent/trivalent				--	gen_context(system_u:object_r:trivalent_exec_t,s0)
 

--- a/files/scripts/selinux/trivalent/trivalent.if
+++ b/files/scripts/selinux/trivalent/trivalent.if
@@ -1,16 +1,8 @@
 ## <summary>trivalent browser</summary>
 
-# Copyright 2025 The Secureblue Authors
+# SPDX-FileCopyrightText 2025 The Secureblue Authors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 ########################################
 ## <summary>

--- a/files/scripts/selinux/trivalent/trivalent.sh
+++ b/files/scripts/selinux/trivalent/trivalent.sh
@@ -1,16 +1,8 @@
 #!/usr/bin/env bash
 
-# Copyright 2025 The Secureblue Authors
+# SPDX-FileCopyrightText 2025 The Secureblue Authors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 echo "Building and Loading Policy"
 

--- a/files/scripts/selinux/trivalent/trivalent.te
+++ b/files/scripts/selinux/trivalent/trivalent.te
@@ -1,16 +1,8 @@
 policy_module(trivalent, 1.0.0)
 
-# Copyright 2025 The Secureblue Authors
+# SPDX-FileCopyrightText 2025 The Secureblue Authors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 ########################################
 #

--- a/files/scripts/selinux/user_namespace/grant_userns.cil
+++ b/files/scripts/selinux/user_namespace/grant_userns.cil
@@ -1,14 +1,6 @@
-;; Copyright 2025 The Secureblue Authors
+;; SPDX-FileCopyrightText 2025 The Secureblue Authors
 ;;
-;; Licensed under the Apache License, Version 2.0 (the "License");
-;; you may not use this file except in compliance with the License.
-;; You may obtain a copy of the License at
-;;
-;;     http://www.apache.org/licenses/LICENSE-2.0
-;;
-;; Unless required by applicable law or agreed to in writing, software distributed under the License is
-;; distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-;; See the License for the specific language governing permissions and limitations under the License.
+;; SPDX-License-Identifier: Apache-2.0 OR MIT
 
 (allow colord_t self (user_namespace (create)))
 (allow devicekit_power_t self (user_namespace (create)))

--- a/files/scripts/selinux/user_namespace/harden_container_userns.cil
+++ b/files/scripts/selinux/user_namespace/harden_container_userns.cil
@@ -1,14 +1,6 @@
-;; Copyright 2025 The Secureblue Authors
+;; SPDX-FileCopyrightText 2025 The Secureblue Authors
 ;;
-;; Licensed under the Apache License, Version 2.0 (the "License");
-;; you may not use this file except in compliance with the License.
-;; You may obtain a copy of the License at
-;;
-;;     http://www.apache.org/licenses/LICENSE-2.0
-;;
-;; Unless required by applicable law or agreed to in writing, software distributed under the License is
-;; distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-;; See the License for the specific language governing permissions and limitations under the License.
+;; SPDX-License-Identifier: Apache-2.0 OR MIT
 
 (deny container_domain self (user_namespace (create)))
 (deny container_runtime_domain self (user_namespace (create)))

--- a/files/scripts/selinux/user_namespace/harden_userns.cil
+++ b/files/scripts/selinux/user_namespace/harden_userns.cil
@@ -1,14 +1,6 @@
-;; Copyright 2025 The Secureblue Authors
+;; SPDX-FileCopyrightText 2025 The Secureblue Authors
 ;;
-;; Licensed under the Apache License, Version 2.0 (the "License");
-;; you may not use this file except in compliance with the License.
-;; You may obtain a copy of the License at
-;;
-;;     http://www.apache.org/licenses/LICENSE-2.0
-;;
-;; Unless required by applicable law or agreed to in writing, software distributed under the License is
-;; distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-;; See the License for the specific language governing permissions and limitations under the License.
+;; SPDX-License-Identifier: Apache-2.0 OR MIT
 
 (deny userdomain self (user_namespace (create)))
 (deny unconfined_service_t self (user_namespace (create)))

--- a/files/scripts/selinux/user_namespace/userns_deny_unconfined_relabels.cil
+++ b/files/scripts/selinux/user_namespace/userns_deny_unconfined_relabels.cil
@@ -1,16 +1,6 @@
-; Copyright 2025 The Secureblue Authors
-;
-; Licensed under the Apache License, Version 2.0 (the "License");
-; you may not use this file except in compliance with the License.
-; You may obtain a copy of the License at
-;
-;     http://www.apache.org/licenses/LICENSE-2.0
-;
-; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS,
-; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; See the License for the specific language governing permissions and
-; limitations under the License.
+;; SPDX-FileCopyrightText 2025 The Secureblue Authors
+;;
+;; SPDX-License-Identifier: Apache-2.0 OR MIT
 
 (typeattribute userns_privileged_file_type)
 (typeattributeset userns_privileged_file_type (colord_exec_t container_runtime_exec_t devicekit_power_exec_t docker_exec_t flatpak_exec_t kubelet_exec_t nautilus_exec_t systemsettings_exec_t trivalent_exec_t trivalent_script_exec_t))

--- a/files/system/etc/chrony.conf
+++ b/files/system/etc/chrony.conf
@@ -1,4 +1,4 @@
-# Copyright © 2014-2024 GrapheneOS
+# Copyright © 2014-2025 GrapheneOS
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -17,8 +17,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-
-# https://github.com/GrapheneOS/infrastructure/blob/main/chrony.conf
 
 server time.cloudflare.com iburst nts
 server ntppool1.time.nl iburst nts

--- a/files/system/etc/sysctl.d/60-hardening.conf
+++ b/files/system/etc/sysctl.d/60-hardening.conf
@@ -1,3 +1,15 @@
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
 # https://docs.kernel.org/networking/ip-sysctl.html
 net.ipv4.tcp_syncookies=1
 


### PR DESCRIPTION
Upstream selinux packages use GPLv2 or LGPLv2, which are not compatible with Apache 2.0. This allows us to upstream changes from these files freely.