### PR TITLE
fix(tests): update integration test workflow, add data file

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: Run integration tests
-        uses: secureblue/bootc-virtual-machine-action@05aa93d5e9d1e128c8d0772fd534fed5c73f9271 # v0.0.3
+        uses: secureblue/bootc-integration-test-action@11988e1d2eab00767a2e099a0b087816f5e508c9 # v0.0.4
         with:
           registry: ghcr.io/secureblue
           image: silverblue-main-hardened
@@ -45,3 +45,5 @@ jobs:
             ./.github/workflows/integration_tests/check_audit_results.sh
             ./.github/workflows/integration_tests/check_cleanup.sh
             ./.github/workflows/integration_tests/check_firstrun.sh
+          data-files: |
+            ./.github/workflows/integration_tests/expected-audit-silverblue-main-hardened.txt

--- a/.github/workflows/integration_tests/check_audit_results.sh
+++ b/.github/workflows/integration_tests/check_audit_results.sh
@@ -16,12 +16,11 @@
 
 set -euo pipefail
 
-test_dir='./.github/workflows/integration_tests'
 audit_results=$(ujust audit-secureblue --json | jq -c '{name, description, status, warnings}')
 
-if diff "${test_dir}/expected-audit-silverblue-main-hardened.txt" <(echo "${audit_results}"); then
-    echo "Audit script output is as expected."
+if diff 'expected-audit-silverblue-main-hardened.txt' <(echo "${audit_results}"); then
+    echo 'Audit script output is as expected.'
 else
-    echo "Audit script output differs from expected output."
+    echo 'Audit script output differs from expected output.'
     exit 1
 fi


### PR DESCRIPTION
The new version of `bootc-integration-test-action` allows for data files to be included that are copied to the VM, allowing them to be referenced in tests.