### PR TITLE
ci: split up PR build workflow using reusable workflow

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -11,49 +11,38 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 name: build-pullrequest
+
 permissions: {}
+
 on:
-  pull_request:
-    branches:
-      - live
-      - staging
-    paths-ignore:
-      - "**.md"
+  workflow_call:
+    inputs:
+      recipe:
+        required: true
+        type: string
+
 jobs:
   bluebuild:
     name: PR build
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    strategy:
-      fail-fast: false 
-      matrix:
-        recipe:
-          - general/recipe-cosmic-main.yml
-          - general/recipe-sericea-main.yml
-          - general/recipe-kinoite-main.yml
-          - general/recipe-silverblue-main.yml
-          - general/recipe-silverblue-nvidia.yml
-          - general/recipe-silverblue-nvidia-open.yml
-          - securecore/recipe-securecore-zfs-main.yml
-          - securecore/recipe-securecore-zfs-nvidia.yml
-          - securecore/recipe-securecore-zfs-nvidia-open.yml
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
       - name: Gather image data from recipe
         shell: bash
         env:
-          RECIPE: ${{ matrix.recipe }}
+          RECIPE: ${{ inputs.recipe }}
         run: |
-          echo "IMAGE_NAME=$(grep '^name:' ./recipes/${RECIPE} | sed 's/^name: //')" >> $GITHUB_ENV
-          echo "IMAGE_MAJOR_VERSION=$(grep '^image-version:' ./recipes/${RECIPE} | sed 's/^image-version: //')" >> $GITHUB_ENV
-          BASE_IMAGE=$(grep '^base-image:' ./recipes/${RECIPE} | sed 's/^base-image: //')
-          echo "BASE_IMAGE_NAME=$(echo $BASE_IMAGE | sed 's/.*\/.*\///')" >> $GITHUB_ENV
+          echo "IMAGE_NAME=$(grep '^name:' "./recipes/${RECIPE}" | sed 's/^name: //')" >> "$GITHUB_ENV"
+          echo "IMAGE_MAJOR_VERSION=$(grep '^image-version:' "./recipes/${RECIPE}" | sed 's/^image-version: //')" >> "$GITHUB_ENV"
+          BASE_IMAGE=$(grep '^base-image:' "./recipes/${RECIPE}" | sed 's/^base-image: //')
+          echo "BASE_IMAGE_NAME=$(echo "$BASE_IMAGE" | sed 's/.*\/.*\///')" >> "$GITHUB_ENV"
 
       - name: Maximize build space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
@@ -62,7 +51,7 @@ jobs:
         id: build_vars
         shell: bash
         env:
-          RECIPE: ${{ matrix.recipe }}
+          RECIPE: ${{ inputs.recipe }}
         run: |
           RECIPE_PATH=""
           if [ -f "./config/${RECIPE}" ]; then
@@ -70,7 +59,7 @@ jobs:
           else
             RECIPE_PATH="./recipes/${RECIPE}"
           fi
-          echo "recipe_path=${RECIPE_PATH}" >> ${GITHUB_OUTPUT}
+          echo "recipe_path=${RECIPE_PATH}" >> "${GITHUB_OUTPUT}"
 
       - name: Install BlueBuild
         shell: bash
@@ -84,7 +73,6 @@ jobs:
 
       - name: Build Image
         shell: bash
-        working-directory: ${{ inputs.working_directory }}
         env:
           RECIPE_PATH: ${{ steps.build_vars.outputs.recipe_path }}
           RUST_LOG_STYLE: always
@@ -96,5 +84,4 @@ jobs:
           export KERNEL_PRIVKEY
 
           BUILD_OPTS="--build-driver podman --squash"
-          bluebuild build -v ${BUILD_OPTS} ${RECIPE_PATH}
-          
+          bluebuild build -v ${BUILD_OPTS} "${RECIPE_PATH}"

--- a/.github/workflows/pr_build_all_main.yml
+++ b/.github/workflows/pr_build_all_main.yml
@@ -1,0 +1,50 @@
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+name: pr-build-main
+
+permissions: {}
+
+on:
+  pull_request:
+    branches:
+      - live
+      - staging
+    paths:
+      - 'cosign.pub'
+      - 'files/scripts/**'
+      - 'files/system/kinoite/**'
+      - 'files/system/sericea/**'
+      - 'files/system/server/**'
+      - 'modules/**'
+      - 'recipes/**'
+      - '!**nvidia**'
+      - '!**zfs**'
+      - '!**.md'
+
+jobs:
+  bluebuild:
+    name: PR build
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        recipe:
+          - general/recipe-cosmic-main.yml
+          - general/recipe-kinoite-main.yml
+          - general/recipe-sericea-main.yml
+          # general/recipe-silverblue-main already covered by pr_build_minimal.yml
+          - securecore/recipe-securecore-main.yml
+    uses: ./.github/workflows/pr_build.yml
+    with:
+      recipe: ${{ matrix.recipe }}

--- a/.github/workflows/pr_build_minimal.yml
+++ b/.github/workflows/pr_build_minimal.yml
@@ -1,0 +1,32 @@
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+name: pr-build-minimal
+
+permissions: {}
+
+on:
+  pull_request:
+    branches:
+      - live
+      - staging
+    paths-ignore:
+      - "**.md"
+
+jobs:
+  bluebuild:
+    name: PR build (general/recipe-silverblue-main.yml)
+    permissions:
+      contents: read
+    uses: ./.github/workflows/pr_build.yml
+    with:
+      recipe: general/recipe-silverblue-main.yml

--- a/.github/workflows/pr_build_nvidia.yml
+++ b/.github/workflows/pr_build_nvidia.yml
@@ -1,0 +1,40 @@
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+name: pr-build-nvidia
+
+permissions: {}
+
+on:
+  pull_request:
+    branches:
+      - live
+      - staging
+    paths:
+      - '**nvidia**'
+      - '!**.md'
+      - '!.github/**'
+
+jobs:
+  bluebuild:
+    name: PR build
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        recipe:
+          - general/recipe-silverblue-nvidia-open.yml
+          - general/recipe-silverblue-nvidia.yml
+    uses: ./.github/workflows/pr_build.yml
+    with:
+      recipe: ${{ matrix.recipe }}

--- a/.github/workflows/pr_build_zfs.yml
+++ b/.github/workflows/pr_build_zfs.yml
@@ -1,0 +1,41 @@
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+name: pr-build-zfs
+
+permissions: {}
+
+on:
+  pull_request:
+    branches:
+      - live
+      - staging
+    paths:
+      - '**zfs**'
+      - '!**.md'
+      - '!.github/**'
+
+jobs:
+  bluebuild:
+    name: PR build
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        recipe:
+          - securecore/recipe-securecore-zfs-main.yml
+          - securecore/recipe-securecore-zfs-nvidia-open.yml
+          - securecore/recipe-securecore-zfs-nvidia.yml
+    uses: ./.github/workflows/pr_build.yml
+    with:
+      recipe: ${{ matrix.recipe }}


### PR DESCRIPTION
This makes a reusable workflow out of the PR build workflow, and uses it in four workflows with different triggers:

* `pr_build_minimal.yml` builds only the `silverblue-main-hardened` image if any non-markdown file is modified by the PR.
* `pr_build_all_main.yml` builds the other four "main" (non-Nvidia, non-ZFS) images if files either specific to one of the non-Silverblue images or with more potential to affect the build process are modified.
* `pr_build_nvidia.yml` builds one `nvidia` and one `nvidia-open` image if a file with "nvidia" in the filename is modified.
* `pr_build_zfs.yml` builds the three ZFS images if a file with "zfs" in the filename is modified.

This should significantly reduce compute time spent unnecessarily building images for PRs that are highly unlikely to cause build failures in those images (or if they did, would cause build failures in *all* images, which will still be caught by `pr_build_minimal.yml`).