### PR TITLE
chore: ensure all images have rsync

### DIFF
--- a/recipes/common/common-packages.yml
+++ b/recipes/common/common-packages.yml
@@ -29,6 +29,7 @@ install:
   - hdparm
   - wireguard-tools
   - gettext
+  - rsync
 
   # signing deps
   - sbsigntools


### PR DESCRIPTION
Our bash env ujust requires it, but IOT images don't have it upstream.