### PR TITLE
fix: add retry logic for secureblue-flatpak-setup.service

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -45,5 +45,6 @@ jobs:
             ./.github/workflows/integration_tests/check_audit_results.sh
             ./.github/workflows/integration_tests/check_cleanup.sh
             ./.github/workflows/integration_tests/check_firstrun.sh
+            ./.github/workflows/integration_tests/check_flatpak_setup.sh
           data-files: |
             ./.github/workflows/integration_tests/expected-audit-silverblue-main-hardened.txt

--- a/.github/workflows/integration_tests/check_audit_results.sh
+++ b/.github/workflows/integration_tests/check_audit_results.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-audit_results=$(ujust audit-secureblue --json | jq -c '{name, description, status, warnings}')
+audit_results=$(ujust audit-secureblue --json --skip flatpak | jq -c '{name, description, status, warnings}')
 
 if diff 'expected-audit-silverblue-main-hardened.txt' <(echo "${audit_results}"); then
     echo 'Audit script output is as expected.'

--- a/.github/workflows/integration_tests/check_flatpak_setup.sh
+++ b/.github/workflows/integration_tests/check_flatpak_setup.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+service_name="secureblue-flatpak-setup.service"
+timer_name="secureblue-flatpak-setup.timer"
+
+test-fail() {
+    echo "Test failed: $1"
+    echo "Service status:"
+    systemctl --user status --full "${service_name}" || true
+    exit 1
+}
+
+if ! systemctl --user is-enabled --quiet "${timer_name}"; then
+    test-fail "${timer_name} is not enabled."
+fi
+
+check-flatpak-remotes() {
+    if [ "$(flatpak remotes --columns=name)" != 'flathub-verified' ]; then
+        test-fail "flathub-verified flatpak remote not present or not the only remote."
+    fi
+}
+
+check-installed-flatpaks() {
+    if [ "$(flatpak list --app --columns=application)" = 'com.github.tchx84.Flatseal' ]; then
+        echo "Flatseal is installed."
+    else
+        test-fail "installed flatpaks were not as expected (Flatseal only)."
+    fi
+}
+
+state=$(systemctl --user show "${service_name}" --property=ActiveState | sed 's/^ActiveState=//')
+
+if [ -e "$HOME/.config/secureblue/secureblue-flatpak-setup.stamp" ]; then
+    echo "${service_name} has successfully completed."
+    check-flatpak-remotes
+    check-installed-flatpaks
+elif [ "${state}" = 'activating' ] || [ "${state}" = 'active' ]; then
+    echo "${service_name} is currently running."
+    # flathub-verified should be added right at the start of the service, so we test for it.
+    check-flatpak-remotes
+elif [ "${state}" = 'failed' ]; then
+    test-fail "${service_name} is in a failed state."
+else
+    test-fail "${service_name} is enabled, but has not started for some reason."
+fi

--- a/.github/workflows/integration_tests/expected-audit-silverblue-main-hardened.txt
+++ b/.github/workflows/integration_tests/expected-audit-silverblue-main-hardened.txt
@@ -25,4 +25,3 @@
 {"name":"audit_hardened_malloc","description":"Ensuring hardened_malloc is set to be preloaded","status":"pass","warnings":[]}
 {"name":"audit_secureboot","description":"Ensuring secure boot is enabled","status":"fail","warnings":[]}
 {"name":"audit_bash_env_lockdown","description":"Ensuring current user's bash environment is locked down","status":"fail","warnings":[]}
-{"name":"audit_flatpak_remotes","description":"Auditing flatpak remote flathub-verified","status":"pass","warnings":[]}

--- a/files/system/usr/lib/systemd/user/secureblue-flatpak-setup.service
+++ b/files/system/usr/lib/systemd/user/secureblue-flatpak-setup.service
@@ -8,3 +8,7 @@ ConditionPathExists=!%h/.config/secureblue/secureblue-flatpak-setup.stamp
 Type=oneshot
 ExecStart=/usr/libexec/secureblue/secureblueflatpaksetup
 ExecStartPost=/bin/bash -c 'mkdir -p "$HOME/.config/secureblue" && touch "$HOME/.config/secureblue/secureblue-flatpak-setup.stamp"'
+Restart=on-failure
+RestartSec=30s
+RestartMaxDelaySec=1800s
+RestartSteps=10


### PR DESCRIPTION
The retry logic is copied from securebluefirstrun.service and restarts the service on failure, with exponential backoff in the event of repeated failures.