### PR TITLE
fix: only inform about `--skip flatpak` option if flatpak installed

### DIFF
--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -965,7 +965,7 @@ async def main() -> int:
         traceback.print_exception(err)
         print_err("\n" + _("*** Continuing... ***"))
         error_occurred = True
-    if "flatpak" not in skip:
+    if "flatpak" not in skip and command_succeeds("command", "-v", "flatpak"):
         print(_("Use option '{0}' to skip flatpak recommendations.").format(bold("--skip flatpak")))
     warn_if_root()
     if error_occurred:


### PR DESCRIPTION
If flatpak is not installed (e.g. on the server images), then the flatpak checks are already skipped so there's no need to inform the user of the `--skip flatpak` option. Fixes #1248.