### PR TITLE
feat(resolved): disable LLMNR resolution by default

### DIFF
--- a/files/system/etc/systemd/resolved.conf.d/10-disable-llmnr.conf
+++ b/files/system/etc/systemd/resolved.conf.d/10-disable-llmnr.conf
@@ -1,0 +1,2 @@
+[Resolve]
+LLMNR=false


### PR DESCRIPTION
Link-local multicast name resolution (LLMNR) is a deprecated mDNS-like Microsoft protocol used in Windows that is [being phased out](https://techcommunity.microsoft.com/blog/networkingblog/aligning-on-mdns-ramping-down-netbios-name-resolution-and-llmnr/3290816). systemd-resolved resolves LLMNR names by default, but the service [allows spoofed responses and is trivial to poison.](https://attack.mitre.org/techniques/T1557/001/)

There's an [upstream PR](https://github.com/systemd/systemd/pull/28263) to disable it by default that hasn't seen much action, so it might make sense to do it here. It probably isn't worth a `ujust` toggle given how rarely it's used.

Old behaviour:
```
$ resolvectl status
[...] Link 2 (enp1s0)
    Current Scopes: DNS LLMNR/IPv4 LLMNR/IPv6
         Protocols: +DefaultRoute LLMNR=resolve -mDNS +DNSOverTLS DNSSEC=yes/supported
```

New behaviour:
```
$ resolvectl status
[...] Link 2 (enp1s0)
    Current Scopes: DNS
         Protocols: +DefaultRoute -LLMNR -mDNS +DNSOverTLS DNSSEC=yes/supported
```