### PR TITLE
fix: specify flathub-verified remote for initial flatpak installs

### DIFF
--- a/files/system/desktop/usr/libexec/secureblue/secureblueflatpaksetup
+++ b/files/system/desktop/usr/libexec/secureblue/secureblueflatpaksetup
@@ -20,10 +20,10 @@ ujust harden-flatpak
 RPM_OSTREE_STATUS=$(rpm-ostree status --json --booted)
 IMAGE_REF_NAME=$(echo "$RPM_OSTREE_STATUS" | jq -r '.deployments[0]."container-image-reference" // empty | split("/")[-1]')
 if [[ "$IMAGE_REF_NAME" != *"kinoite"* ]]; then
-    flatpak install --user -y --noninteractive com.github.tchx84.Flatseal
+    flatpak install --user -y --noninteractive flathub-verified com.github.tchx84.Flatseal
 fi
 
 if [[ "$IMAGE_REF_NAME" == *"silverblue"* ]]; then
-    flatpak install --user -y --noninteractive io.github.flattool.Warehouse
+    flatpak install --user -y --noninteractive flathub-verified io.github.flattool.Warehouse
 fi
 


### PR DESCRIPTION
This prevents an error if the user enables another flatpak remote (such as flathub unfiltered) before the setup script runs. Fixes #1277.