### PR TITLE
fix(test): add 5 second sleep to integration test

### DIFF
--- a/.github/workflows/integration_tests/check_flatpak_setup.sh
+++ b/.github/workflows/integration_tests/check_flatpak_setup.sh
@@ -26,10 +26,6 @@ test-fail() {
     exit 1
 }
 
-if ! systemctl --user is-enabled --quiet "${timer_name}"; then
-    test-fail "${timer_name} is not enabled."
-fi
-
 check-flatpak-remotes() {
     if [ "$(flatpak remotes --columns=name)" != 'flathub-verified' ]; then
         test-fail "flathub-verified flatpak remote not present or not the only remote."
@@ -43,6 +39,13 @@ check-installed-flatpaks() {
         test-fail "installed flatpaks were not as expected (Flatseal only)."
     fi
 }
+
+# Wait a few seconds to give the service time to start
+sleep 5
+
+if ! systemctl --user is-enabled --quiet "${timer_name}"; then
+    test-fail "${timer_name} is not enabled."
+fi
 
 state=$(systemctl --user show "${service_name}" --property=ActiveState | sed 's/^ActiveState=//')
 


### PR DESCRIPTION
The flatpak setup service is a user service, so it can't start until the user logs in, which in the integration testing VM only happens when the test user logs in via ssh to run the tests. This leaves only a very brief time window for the service to start, so to give it more time, we sleep for a few seconds at the start of the test.