### PR TITLE
fix(test): adjust flatpak setup test to fix failures

### DIFF
--- a/.github/workflows/integration_tests/check_flatpak_setup.sh
+++ b/.github/workflows/integration_tests/check_flatpak_setup.sh
@@ -40,12 +40,12 @@ check-installed-flatpaks() {
     fi
 }
 
-# Wait a few seconds to give the service time to start
-sleep 5
-
 if ! systemctl --user is-enabled --quiet "${timer_name}"; then
     test-fail "${timer_name} is not enabled."
 fi
+
+# Wait a few seconds to give the service time to start
+sleep 5
 
 state=$(systemctl --user show "${service_name}" --property=ActiveState | sed 's/^ActiveState=//')
 
@@ -55,7 +55,8 @@ if [ -e "$HOME/.config/secureblue/secureblue-flatpak-setup.stamp" ]; then
     check-installed-flatpaks
 elif [ "${state}" = 'activating' ] || [ "${state}" = 'active' ]; then
     echo "${service_name} is currently running."
-    # flathub-verified should be added right at the start of the service, so we test for it.
+    # flathub-verified remote should be added first, so wait a few more seconds then test for it.
+    sleep 5
     check-flatpak-remotes
 elif [ "${state}" = 'failed' ]; then
     test-fail "${service_name} is in a failed state."


### PR DESCRIPTION
If the service is running, sleep a few more seconds after checking service status to give it time to set up the flathub-verified remote.