### PR TITLE
build: rechunk main images

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -42,6 +42,7 @@ jobs:
     uses: ./.github/workflows/build-one-recipe.yml
     with:
       recipe: general/recipe-silverblue-main.yml
+      rechunk: true
     secrets:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
@@ -57,6 +58,7 @@ jobs:
     uses: ./.github/workflows/build-one-recipe.yml
     with:
       recipe: general/recipe-kinoite-main.yml
+      rechunk: true
     secrets:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
@@ -72,6 +74,7 @@ jobs:
     uses: ./.github/workflows/build-one-recipe.yml
     with:
       recipe: general/recipe-sericea-main.yml
+      rechunk: true
     secrets:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
@@ -87,6 +90,7 @@ jobs:
     uses: ./.github/workflows/build-one-recipe.yml
     with:
       recipe: general/recipe-cosmic-main.yml
+      rechunk: true
     secrets:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
@@ -190,6 +194,7 @@ jobs:
     uses: ./.github/workflows/build-one-recipe.yml
     with:
       recipe: securecore/recipe-securecore-main.yml
+      rechunk: true
     secrets:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
@@ -242,7 +247,7 @@ jobs:
       packages: write # Needed to publish images
       id-token: write # Needed for token generation for signing
     strategy:
-      fail-fast: false 
+      fail-fast: false
       matrix:
         recipe:
           - securecore/recipe-securecore-zfs-nvidia.yml
@@ -265,6 +270,7 @@ jobs:
     uses: ./.github/workflows/build-one-recipe.yml
     with:
       recipe: iot/recipe-iot-main.yml
+      rechunk: true
     secrets:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}

--- a/.github/workflows/build-one-recipe.yml
+++ b/.github/workflows/build-one-recipe.yml
@@ -16,8 +16,12 @@ on:
   workflow_call:
     inputs:
       recipe:
-        required: true
         type: string
+        required: true
+      rechunk:
+        type: boolean
+        required: false
+        default: false
     secrets:
       SIGNING_SECRET:
         required: true
@@ -123,6 +127,8 @@ jobs:
           pr_event_number: ${{ github.event.number }}
           maximize_build_space: true
           squash: true
+          build_chunked_oci: ${{ inputs.rechunk }}
+          max_layers: 128
           skip_checkout: true
           use_cache: false
           retry_push_count: 3


### PR DESCRIPTION
Enable rechunking via BlueBuild's `build-chunked-oci` option for the six "main" images. This moderately decreases image sizes (primarily due to freeing up space from removed packages) and significantly decreases update sizes, at the cost of extra build time.