### PR TITLE
chore(audit): add Bazaar to "expected arbitrary permissions" list

### DIFF
--- a/files/system/usr/libexec/secureblue/audit_flatpak/__init__.py
+++ b/files/system/usr/libexec/secureblue/audit_flatpak/__init__.py
@@ -227,6 +227,7 @@ FLATPAK_PERMISSION_CHECKS: list[PermissionCheck] = [
 ARBITRARY_PERMISSIONS_EXPECTED: list[str] = [
     "com.github.tchx84.Flatseal",
     "io.github.flattool.Warehouse",
+    "io.github.kolunmi.Bazaar",
 ]
 
 


### PR DESCRIPTION
Bazaar is designed to manage installed flatpaks and therefore requires access to the flatpak session bus.