### PR TITLE
fix(nvidia): switch back to ngl renderer

### DIFF
--- a/files/scripts/setgtknvidiaenvironment.sh
+++ b/files/scripts/setgtknvidiaenvironment.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright 2025 The Secureblue Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -10,24 +12,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-modules:
-  - type: script
-    scripts:
-      - installnvidiakmod.sh
-    secrets:
-      - type: env
-        name: KERNEL_PRIVKEY
-        mount:
-          type: file
-          destination: /tmp/certs/private_key.priv
-  - type: script
-    scripts:
-      - installnvidiapackages.sh
-      - removeunusedrepos.sh
-      - setearlyloading.sh
-      - setdrmvariables.sh
-      - setgtknvidiaenvironment.sh
-  - type: files
-    files:
-      - source: system/nvidia
-        destination: /
+set -oue pipefail
+
+echo 'GSK_RENDERER=ngl' > /usr/lib/environment.d/30-nvidia-gtk-renderer.conf


### PR DESCRIPTION
adds a /usr/lib/environment.d drop-in for nvidia images to set the gtk renderer to `ngl`, rather than the default `vulkan`

- bazzite have patched but don't seem to be tracking it: https://github.com/ublue-os/bazzite/commit/bb0e8f0d9cfe26efa56eed0fa75b7d1e8c110c46
- haven't found an upstream issue yet 🫤 
  - nvidia claim to have fixed a similar issue in [580.65.06](https://www.nvidia.com/en-us/drivers/details/251355/), but apparently still a problem on secureblue 580.76.05
- builds and behaves as expected, has fixed issue for two users

---

This was the previous default, so it should be safe. This should be reverted when the upstream issue is resolved.

secureblue issue: <https://github.com/secureblue/secureblue/issues/1293>