### PR TITLE
fix: mark non-printable characters in bash prompt

### DIFF
--- a/files/system/etc/profile.d/xx-bash-prompt-command.sh
+++ b/files/system/etc/profile.d/xx-bash-prompt-command.sh
@@ -1,15 +1,6 @@
 #!/usr/bin/bash
 # Filename needs to be alphabetically later than vte.sh
 if [ -n "${BASH_VERSION:-}" ]; then
-    export PROMPT_COMMAND='__bash_prompt_command 2>/dev/null'
-
-    __bash_prompt_command() {
-        local prev_status="$?"
-        if [ "$prev_status" != 0 ]; then
-            # Print nonzero exit code in bold red text inside square brackets
-            printf '\033[31m[\033[1m%s\033[22m]\033[39m' "$prev_status"
-        fi
-        # Default prompt taken from /etc/bashrc
-        printf '\033]0;%s@%s:%s\007' "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"
-    }
+    # Print nonzero exit codes in bold red text inside square brackets at beginning of prompt
+    export PS1='$(code=${?#0};echo -n "${code:+\[\e[31m\][\[\e[1m\]${code}\[\e[22m\]]\[\e[39m\]}")'"${PS1}"
 fi


### PR DESCRIPTION
This ensures bash correctly calculates prompt width, fixing a bug where parts of the prompt could be overwritten when navigating command history. Also switch to a simpler method of modifying the prompt that only uses `PS1` instead of `PROMPT_COMMAND`. The non-printable characters are marked by enclosing them in `\[\]`, as documented [here](https://www.gnu.org/software/bash/manual/bash.html#Controlling-the-Prompt-1).