### PR TITLE
fix: check bash session is interactive before modifying prompt

### DIFF
--- a/files/system/etc/profile.d/xx-bash-prompt-command.sh
+++ b/files/system/etc/profile.d/xx-bash-prompt-command.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 # Filename needs to be alphabetically later than vte.sh
-if [ -n "${BASH_VERSION:-}" ]; then
+if [[ $- == *i* && -n "${BASH_VERSION:-}" ]]; then
     # Print nonzero exit codes in bold red text inside square brackets at beginning of prompt
-    export PS1='$(code=${?#0};echo -n "${code:+\[\e[31m\][\[\e[1m\]${code}\[\e[22m\]]\[\e[39m\]}")'"${PS1}"
+    export PS1='$(code=${?#0};echo -n "${code:+\[\e[31m\][\[\e[1m\]${code}\[\e[22m\]]\[\e[39m\]}")'"${PS1:-}"
 fi


### PR DESCRIPTION
Some scripts check whether the prompt variable `PS1` is set to determine whether the shell is interactive. While this is less robust than checking `$-`, it's still a method mentioned in the bash manual, so we should make sure not to break this behavior and only modify `PS1` if the shell is interactive.