### PR TITLE
fix: run user services only for non-system users

### DIFF
--- a/files/system/desktop/usr/lib/systemd/user/flatpak-user-update.service
+++ b/files/system/desktop/usr/lib/systemd/user/flatpak-user-update.service
@@ -3,6 +3,7 @@ Description=Flatpak Automatic Update
 Documentation=man:flatpak(1)
 Wants=network-online.target
 After=network-online.target
+ConditionUser=!@system
 
 [Service]
 Type=oneshot

--- a/files/system/desktop/usr/lib/systemd/user/flatpak-user-update.timer
+++ b/files/system/desktop/usr/lib/systemd/user/flatpak-user-update.timer
@@ -1,6 +1,7 @@
 [Unit]
 Description=Flatpak Automatic Update Trigger
 Documentation=man:flatpak(1)
+ConditionUser=!@system
 
 [Timer]
 RandomizedDelaySec=10m

--- a/files/system/desktop/usr/lib/systemd/user/image-deprecation-notice.service
+++ b/files/system/desktop/usr/lib/systemd/user/image-deprecation-notice.service
@@ -1,7 +1,8 @@
 [Unit]
-Description=Image deprecation notification service 
+Description=Image deprecation notification service
 Wants=dbus.service
 After=dbus.service
+ConditionUser=!@system
 
 [Service]
 Type=oneshot

--- a/files/system/desktop/usr/lib/systemd/user/secureblue-flatpak-setup.service
+++ b/files/system/desktop/usr/lib/systemd/user/secureblue-flatpak-setup.service
@@ -3,6 +3,7 @@ Description=secureblue flatpak setup
 Wants=network-online.target
 After=network-online.target
 ConditionPathExists=!%h/.config/secureblue/secureblue-flatpak-setup.stamp
+ConditionUser=!@system
 
 [Service]
 Type=oneshot

--- a/files/system/desktop/usr/lib/systemd/user/secureblue-flatpak-setup.timer
+++ b/files/system/desktop/usr/lib/systemd/user/secureblue-flatpak-setup.timer
@@ -1,5 +1,6 @@
 [Unit]
 Description=secureblue flatpak setup
+ConditionUser=!@system
 
 [Timer]
 OnStartupSec=5s

--- a/files/system/desktop/usr/lib/systemd/user/secureblue-key-enrollment-verification.service
+++ b/files/system/desktop/usr/lib/systemd/user/secureblue-key-enrollment-verification.service
@@ -1,7 +1,8 @@
 [Unit]
-Description=secureblue secure boot key enrollment verification 
+Description=secureblue secure boot key enrollment verification
 Wants=dbus.service
 After=dbus.service
+ConditionUser=!@system
 
 [Service]
 Type=oneshot

--- a/files/system/desktop/usr/lib/systemd/user/secureblue-key-enrollment-verification.timer
+++ b/files/system/desktop/usr/lib/systemd/user/secureblue-key-enrollment-verification.timer
@@ -1,5 +1,6 @@
 [Unit]
 Description=secureblue secureboot key enrollment verification timer
+ConditionUser=!@system
 
 [Timer]
 RandomizedDelaySec=1m

--- a/files/system/desktop/usr/lib/systemd/user/secureblue-update-verification.service
+++ b/files/system/desktop/usr/lib/systemd/user/secureblue-update-verification.service
@@ -1,7 +1,8 @@
 [Unit]
-Description=secureblue secure boot update verification 
+Description=secureblue secure boot update verification
 Wants=dbus.service
 After=dbus.service
+ConditionUser=!@system
 
 [Service]
 Type=oneshot

--- a/files/system/desktop/usr/lib/systemd/user/secureblue-update-verification.timer
+++ b/files/system/desktop/usr/lib/systemd/user/secureblue-update-verification.timer
@@ -1,5 +1,6 @@
 [Unit]
 Description=secureblue update verification timer
+ConditionUser=!@system
 
 [Timer]
 RandomizedDelaySec=1m

--- a/files/system/kinoite/usr/lib/systemd/user/disable-kde-splash.service
+++ b/files/system/kinoite/usr/lib/systemd/user/disable-kde-splash.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=disable the KDE splash screen as it is broken without XWayland. See https://secureblue.dev/faq#kde-splash-disabled
 Before=dbus-broker.service
+ConditionUser=!@system
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Add `ConditionUser=!@system` to globally enabled systemd user services and timers so they only activate for non-system users. Fixes #1304.