### PR TITLE
build: retry image pushing step if it fails

### DIFF
--- a/.github/workflows/build-one-recipe.yml
+++ b/.github/workflows/build-one-recipe.yml
@@ -65,10 +65,10 @@ jobs:
           pubkey: 'https://raw.githubusercontent.com/secureblue/secureblue/refs/heads/live/cosign.pub'
 
       - name: Build secureblue
-        uses: blue-build/github-action@968216e45d3f5f23de24f7804259e1384cf5f358 # v1.8.3
+        uses: blue-build/github-action@785ecb253aee6ead01454ed5bd070c2921010602 # v1.9.1
         env:
           KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
-        with:          
+        with:
           cli_version: v0.9.22
           recipe: ${{ inputs.recipe }}
           cosign_private_key: ${{ secrets.SIGNING_SECRET }}
@@ -78,3 +78,4 @@ jobs:
           squash: true
           skip_checkout: true
           use_cache: false
+          retry_push_count: 3


### PR DESCRIPTION
Probably the most common cause of build failures is the image failing to push due to transient network errors. This sets BlueBuild options so that, if pushing the image fails, it will be retried a few times, which is more efficient than having to redo the entire build process.