### PR TITLE
feat: don't install Noto fonts by default

### DIFF
--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -28,15 +28,12 @@ install:
   - vim
   - wl-clipboard
   - alsa-firmware
-  
+
   # yubikey enablement
   - pam-u2f
   - pam_yubico
   - pamu2fcfg
   - yubikey-manager
-
-  # ensure universal font coverage
-  - google-noto-fonts-all
 remove:
   - fedora-logos
   - firefox
@@ -44,7 +41,3 @@ remove:
   - fuse
   - passim
   - fedora-chromium-config
-
-
-
-


### PR DESCRIPTION
Installing `google-noto-fonts-all` adds about 400 MB to the image (and to daily update sizes) and includes a huge number of fonts that many users don't need. Users who want these fonts can install them themselves, either as a layered package or locally in their home directory.