### PR TITLE
build: opt out of Nushell in BlueBuild

### DIFF
--- a/recipes/general/recipe-cosmic-main.yml
+++ b/recipes/general/recipe-cosmic-main.yml
@@ -18,6 +18,8 @@ base-image: quay.io/fedora-ostree-desktops/cosmic-atomic
 
 image-version: 42
 
+nushell-version: none
+
 modules:
   - from-file: common/common-modules.yml
   - from-file: common/cosmic-modules.yml

--- a/recipes/general/recipe-cosmic-nvidia-open.yml
+++ b/recipes/general/recipe-cosmic-nvidia-open.yml
@@ -18,6 +18,8 @@ base-image: ghcr.io/secureblue/cosmic-main-hardened
 
 image-version: latest
 
+nushell-version: none
+
 modules:
   - from-file: common/nvidia-install.yml
   - from-file: common/final-modules.yml

--- a/recipes/general/recipe-cosmic-nvidia.yml
+++ b/recipes/general/recipe-cosmic-nvidia.yml
@@ -18,6 +18,8 @@ base-image: ghcr.io/secureblue/cosmic-main-hardened
 
 image-version: latest
 
+nushell-version: none
+
 modules:
   - from-file: common/nvidia-install.yml
   - from-file: common/final-modules.yml

--- a/recipes/general/recipe-kinoite-main.yml
+++ b/recipes/general/recipe-kinoite-main.yml
@@ -18,6 +18,8 @@ base-image: quay.io/fedora-ostree-desktops/kinoite
 
 image-version: 42
 
+nushell-version: none
+
 modules:
   - from-file: common/common-modules.yml
   - from-file: common/kinoite-modules.yml

--- a/recipes/general/recipe-kinoite-nvidia-open.yml
+++ b/recipes/general/recipe-kinoite-nvidia-open.yml
@@ -18,6 +18,8 @@ base-image: ghcr.io/secureblue/kinoite-main-hardened
 
 image-version: latest
 
+nushell-version: none
+
 modules:
-  - from-file: common/nvidia-install.yml 
+  - from-file: common/nvidia-install.yml
   - from-file: common/final-modules.yml

--- a/recipes/general/recipe-kinoite-nvidia.yml
+++ b/recipes/general/recipe-kinoite-nvidia.yml
@@ -18,6 +18,8 @@ base-image: ghcr.io/secureblue/kinoite-main-hardened
 
 image-version: latest
 
+nushell-version: none
+
 modules:
-  - from-file: common/nvidia-install.yml 
+  - from-file: common/nvidia-install.yml
   - from-file: common/final-modules.yml

--- a/recipes/general/recipe-sericea-main.yml
+++ b/recipes/general/recipe-sericea-main.yml
@@ -18,6 +18,8 @@ base-image: quay.io/fedora-ostree-desktops/sway-atomic
 
 image-version: 42
 
+nushell-version: none
+
 modules:
   - from-file: common/common-modules.yml
   - from-file: common/sericea-modules.yml

--- a/recipes/general/recipe-sericea-nvidia-open.yml
+++ b/recipes/general/recipe-sericea-nvidia-open.yml
@@ -18,8 +18,10 @@ base-image: ghcr.io/secureblue/sericea-main-hardened
 
 image-version: latest
 
+nushell-version: none
+
 modules:
-  - from-file: common/nvidia-install.yml 
+  - from-file: common/nvidia-install.yml
   - from-file: common/final-modules.yml
   - type: script
     scripts:

--- a/recipes/general/recipe-sericea-nvidia.yml
+++ b/recipes/general/recipe-sericea-nvidia.yml
@@ -18,6 +18,8 @@ base-image: ghcr.io/secureblue/sericea-main-hardened
 
 image-version: latest
 
+nushell-version: none
+
 modules:
   - from-file: common/nvidia-install.yml
   - from-file: common/final-modules.yml

--- a/recipes/general/recipe-silverblue-main.yml
+++ b/recipes/general/recipe-silverblue-main.yml
@@ -16,7 +16,9 @@ description: "Silverblue, hardened"
 
 base-image: quay.io/fedora-ostree-desktops/silverblue
 
-image-version: 42 
+image-version: 42
+
+nushell-version: none
 
 modules:
   - from-file: common/common-modules.yml

--- a/recipes/general/recipe-silverblue-nvidia-open.yml
+++ b/recipes/general/recipe-silverblue-nvidia-open.yml
@@ -18,6 +18,8 @@ base-image: ghcr.io/secureblue/silverblue-main-hardened
 
 image-version: latest
 
+nushell-version: none
+
 modules:
-  - from-file: common/nvidia-install.yml 
+  - from-file: common/nvidia-install.yml
   - from-file: common/final-modules.yml

--- a/recipes/general/recipe-silverblue-nvidia.yml
+++ b/recipes/general/recipe-silverblue-nvidia.yml
@@ -18,6 +18,8 @@ base-image: ghcr.io/secureblue/silverblue-main-hardened
 
 image-version: latest
 
+nushell-version: none
+
 modules:
   - from-file: common/nvidia-install.yml
   - from-file: common/final-modules.yml

--- a/recipes/securecore/recipe-securecore-main.yml
+++ b/recipes/securecore/recipe-securecore-main.yml
@@ -18,6 +18,8 @@ base-image: quay.io/fedora/fedora-coreos
 
 image-version: testing
 
+nushell-version: none
+
 modules:
   - from-file: common/common-modules.yml
   - from-file: common/server-modules.yml

--- a/recipes/securecore/recipe-securecore-nvidia-open.yml
+++ b/recipes/securecore/recipe-securecore-nvidia-open.yml
@@ -18,6 +18,8 @@ base-image: ghcr.io/secureblue/securecore-main-hardened
 
 image-version: latest
 
+nushell-version: none
+
 modules:
-  - from-file: common/nvidia-install.yml 
+  - from-file: common/nvidia-install.yml
   - from-file: common/final-modules.yml

--- a/recipes/securecore/recipe-securecore-nvidia.yml
+++ b/recipes/securecore/recipe-securecore-nvidia.yml
@@ -18,6 +18,8 @@ base-image: ghcr.io/secureblue/securecore-main-hardened
 
 image-version: latest
 
+nushell-version: none
+
 modules:
   - from-file: common/nvidia-install.yml
   - from-file: common/final-modules.yml

--- a/recipes/securecore/recipe-securecore-zfs-main.yml
+++ b/recipes/securecore/recipe-securecore-zfs-main.yml
@@ -18,6 +18,8 @@ base-image: ghcr.io/secureblue/securecore-main-hardened
 
 image-version: latest
 
+nushell-version: none
+
 modules:
   - from-file: common/zfs-modules.yml
   - from-file: common/final-modules.yml

--- a/recipes/securecore/recipe-securecore-zfs-nvidia-open.yml
+++ b/recipes/securecore/recipe-securecore-zfs-nvidia-open.yml
@@ -18,6 +18,8 @@ base-image: ghcr.io/secureblue/securecore-nvidia-open-hardened
 
 image-version: latest
 
+nushell-version: none
+
 modules:
   - from-file: common/zfs-modules.yml
   - from-file: common/final-modules.yml

--- a/recipes/securecore/recipe-securecore-zfs-nvidia.yml
+++ b/recipes/securecore/recipe-securecore-zfs-nvidia.yml
@@ -18,6 +18,8 @@ base-image: ghcr.io/secureblue/securecore-nvidia-hardened
 
 image-version: latest
 
+nushell-version: none
+
 modules:
   - from-file: common/zfs-modules.yml
   - from-file: common/final-modules.yml


### PR DESCRIPTION
We don't use any BlueBuild modules that require Nushell. Setting `nushell-version: none` in the recipes opts out of installing Nushell components into the image ([reference](https://blue-build.org/reference/recipe/#nushell-version-optional)). This reduces the final image size by about 200 MB and reduces compressed update sizes by around 65 MB.