### PR TITLE
fix: install Noto fonts by default again

### DIFF
--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -34,6 +34,9 @@ install:
   - pam_yubico
   - pamu2fcfg
   - yubikey-manager
+
+  # ensure universal font coverage
+  - google-noto-fonts-all
 remove:
   - fedora-logos
   - firefox


### PR DESCRIPTION
Commit 4438c9c25d2cbbb77bcc2ed2b4002342d2cc6a29 caused issues for users using
a variety of languages including Italian and Arabic. Until a more granular
optimization can be made (to cut image size by excluding rarely-used Unicode
characters) without sacrificing usability, we can add then back in.

@RoyalOughtness 