### PR TITLE
chore: add back fzf

### DIFF
--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -28,6 +28,7 @@ install:
   - vim
   - wl-clipboard
   - alsa-firmware
+  - fzf
 
   # yubikey enablement
   - pam-u2f


### PR DESCRIPTION
This restores `ujust --choose` functionality without brew, which is a reasonable tradeoff given the push towards fapolicyd.