### PR TITLE
build: set dracut log levels for efficiency

### DIFF
--- a/files/scripts/regenerateinitramfs.sh
+++ b/files/scripts/regenerateinitramfs.sh
@@ -15,5 +15,22 @@
 set -oue pipefail
 
 QUALIFIED_KERNEL="$(rpm -qa | grep -P 'kernel-(\d+\.\d+\.\d+)' | sed 's/kernel-//')"
-/usr/bin/dracut --no-hostonly --kver "$QUALIFIED_KERNEL" --reproducible -v --add ostree -f "/lib/modules/$QUALIFIED_KERNEL/initramfs.img"
-chmod 0600 "/lib/modules/$QUALIFIED_KERNEL/initramfs.img"
+
+temp_conf_dir="$(mktemp -d)"
+cat >"${temp_conf_dir}/loglevels.conf" <<'EOF'
+stdloglvl=4
+sysloglvl=0
+kmsgloglvl=0
+fileloglvl=0
+EOF
+
+/usr/bin/dracut \
+    --kver "${QUALIFIED_KERNEL}" \
+    --force \
+    --add 'ostree' \
+    --add-confdir "${temp_conf_dir}" \
+    --no-hostonly \
+    --reproducible \
+    "/lib/modules/${QUALIFIED_KERNEL}/initramfs.img"
+
+chmod 0600 "/lib/modules/${QUALIFIED_KERNEL}/initramfs.img"


### PR DESCRIPTION
Dracut is configured by default to set `sysloglvl=5`, which results in a large amount of debug info being sent to the system journal during the build process. This is also implemented inefficiently in shell script, and has a major performance impact. Since we don't care about system journal output at all during the build process, we can just disable all logging to everywhere except stderr using a temporary dracut conf file.

This saves about 90 seconds in the initramfs generation step in each image build.