### PR TITLE
fix: move https mirrors early in the build

### DIFF
--- a/recipes/common/common-modules.yml
+++ b/recipes/common/common-modules.yml
@@ -14,6 +14,7 @@ modules:
     - type: script
       scripts:
         - createautostartdir.sh
+        - httpsmirrors.sh
         - unprotectsudo.sh
     - from-file: common/common-packages.yml
     - type: script

--- a/recipes/common/common-scripts.yml
+++ b/recipes/common/common-scripts.yml
@@ -14,7 +14,6 @@ type: script
 scripts:
   - authselect.sh
   - setfilepermissions.sh
-  - httpsmirrors.sh
   - createmissingdirectories.sh
   - disablegeoclue.sh
   - createjustcompletions.sh


### PR DESCRIPTION
This ensures all rpm installations in the build are pulled using https