### PR TITLE
fix: unbreak local initramfs regeneration

### DIFF
--- a/files/scripts/regenerateinitramfs.sh
+++ b/files/scripts/regenerateinitramfs.sh
@@ -16,8 +16,8 @@ set -oue pipefail
 
 QUALIFIED_KERNEL="$(rpm -qa | grep -P 'kernel-(\d+\.\d+\.\d+)' | sed 's/kernel-//')"
 
-temp_conf_dir="$(mktemp -d)"
-cat >"${temp_conf_dir}/loglevels.conf" <<'EOF'
+temp_conf_file="$(mktemp '/etc/dracut.conf.d/zzz-loglevels-XXXXXXXXXX.conf')"
+cat >"${temp_conf_file}" <<'EOF'
 stdloglvl=4
 sysloglvl=0
 kmsgloglvl=0
@@ -28,9 +28,10 @@ EOF
     --kver "${QUALIFIED_KERNEL}" \
     --force \
     --add 'ostree' \
-    --add-confdir "${temp_conf_dir}" \
     --no-hostonly \
     --reproducible \
     "/lib/modules/${QUALIFIED_KERNEL}/initramfs.img"
+
+rm -- "${temp_conf_file}"
 
 chmod 0600 "/lib/modules/${QUALIFIED_KERNEL}/initramfs.img"


### PR DESCRIPTION
For some reason, an additional conf directory passed to dracut is stored in the generated initramfs, which means local initramfs regeneration will fail since the temporary conf directory no longer exists. Instead, we use a temporary conf *file* in `/etc/dracut.conf.d`, which can be safely deleted after running dracut.