### PR TITLE
fix: Update hardenlogindefs.patch yescrypt factor

### DIFF
--- a/files/scripts/hardenlogindefs.patch
+++ b/files/scripts/hardenlogindefs.patch
@@ -14,7 +14,7 @@
  # The value must be within the 1-11 range.
  #
 -#YESCRYPT_COST_FACTOR 5
-+YESCRYPT_COST_FACTOR 11
++YESCRYPT_COST_FACTOR 8
  
  # Currently CONSOLE_GROUPS is not supported
  


### PR DESCRIPTION
yescrypt factor of 11 is excessive and slows down user experience for questionable security benefit. Note that users will need to rehash their password (they can just use passwd to set the same password), to benefit from this change.