### PR TITLE
fix(securedns): restore root.key if missing

### DIFF
--- a/files/scripts/enableunboundservices.sh
+++ b/files/scripts/enableunboundservices.sh
@@ -17,3 +17,9 @@
 set -oue pipefail
 
 systemctl enable secureblue-migrate-dns.service
+
+# Sometimes /var/lib/unbound/root.key goes missing on CoreOS systems.
+# In that case, unbound-checkconf fails in anticipation of unbound-anchor
+# being unable to bootstrap. This service installs root.key if missing so that
+# dnsconfd-unbound can still work.
+systemctl enable secureblue-unbound-key.service

--- a/files/system/usr/lib/systemd/system/secureblue-unbound-key.service
+++ b/files/system/usr/lib/systemd/system/secureblue-unbound-key.service
@@ -1,0 +1,36 @@
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Restore /var/lib/unbound/root.key from its immutable default in
+# /usr/etc/unbound/dnssec-root.key if it goes missing.
+
+[Unit]
+Description=Secureblue Unbound Root Key Installation Service
+ConditionPathExists=!/var/lib/unbound/root.key
+After=local-fs.target
+Before=unbound.service unbound-anchor.service
+RequiresMountsFor=/var/lib
+RequiresMountsFor=/usr/etc
+
+[Service]
+Type=oneshot
+ExecStartPre=/usr/bin/mkdir -p /var/lib/unbound
+ExecStart=/usr/bin/cp /usr/etc/unbound/dnssec-root.key /var/lib/unbound/root.key
+ExecStartPost=/usr/bin/chown -R unbound:unbound /var/lib/unbound
+ExecStartPost=/usr/bin/chmod 0644 /var/lib/unbound/root.key
+ExecStartPost=/usr/bin/restorecon -R /var/lib/unbound
+
+[Install]
+WantedBy=unbound.service
+WantedBy=unbound-anchor.service

--- a/recipes/common/common-scripts.yml
+++ b/recipes/common/common-scripts.yml
@@ -21,4 +21,4 @@ scripts:
   - enablecommonautoupdate.sh
   - localization.sh
   - addimageinfo.sh
-  - enableunboundmigration.sh
+  - enableunboundservices.sh


### PR DESCRIPTION
For some reason, /var/lib/unbound/root.key does not install properly on CoreOS.

This systemd service restores root.key from the read-only bootstrap copy in /usr/etc.