### PR TITLE
fix(audit): unformatted placeholder in environment audit

### DIFF
--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -720,7 +720,7 @@ def audit_environment_file():
         warning = _("The file {0} cannot be read.").format(env_file)
     if status != PASS:
         rec_lines = (
-            _("The file {0} has been modified."),
+            _("The file {0} has been modified.").format(env_file),
             _("To reset it, run:"),
             f"$ run0 cp -p /usr{env_file} {env_file}",
         )


### PR DESCRIPTION
If /etc/environment is modified, `ujust audit-secureblue` gives the following recommendation:
```
The file {0} has been modified.
  To reset it, run:
  $ run0 cp -p /usr/etc/environment /etc/environment
```

New behavior after PR:
```
The file /etc/environment has been modified.
  To reset it, run:
  $ run0 cp -p /usr/etc/environment /etc/environment
```