### PR TITLE
feat: show INFO in audit script if secure boot is not supported

### DIFF
--- a/files/justfiles/common/kargs.just
+++ b/files/justfiles/common/kargs.just
@@ -39,16 +39,23 @@ set-kargs-hardening:
     else
         echo "Not setting unstable hardening kargs."
     fi
+    # Check for secure boot support, required for some drivers. (e.g. WiFi on some macbooks, plus there would be no way to verify these anyways.)
+    SB_STATE=$(mokutil --sb-state 2>/dev/null)
+    if [[ "$SB_STATE" == "This system doesn't support Secure Boot" ]]; then
+        echo "Secure Boot not supported. Skipping module signature enforcement."
+        SECUREBOOT_KARGS="--append-if-missing=module.sig_enforce=0"
+    else
+        SECUREBOOT_KARGS="--append-if-missing=module.sig_enforce=1"
+    fi
     echo "Applying boot parameters..."
     rpm-ostree kargs \
-      ${UNSTABLE_YES:+$UNSTABLE_YES} ${IAEMU_NO:+$IAEMU_NO} ${NOSMT_YES:+$NOSMT_YES} \
+      ${UNSTABLE_YES:+$UNSTABLE_YES} ${IAEMU_NO:+$IAEMU_NO} ${NOSMT_YES:+$NOSMT_YES} ${SECUREBOOT_KARGS:+$SECUREBOOT_KARGS} \
       --append-if-missing=init_on_alloc=1 \
       --append-if-missing=init_on_free=1 \
       --append-if-missing=slab_nomerge \
       --append-if-missing=page_alloc.shuffle=1 \
       --append-if-missing=randomize_kstack_offset=on \
       --append-if-missing=vsyscall=none \
-      --append-if-missing=lockdown=confidentiality \
       --append-if-missing=random.trust_cpu=off \
       --append-if-missing=random.trust_bootloader=off \
       --append-if-missing=iommu=force \
@@ -56,7 +63,7 @@ set-kargs-hardening:
       --append-if-missing=iommu.passthrough=0 \
       --append-if-missing=iommu.strict=1 \
       --append-if-missing=pti=on \
-      --append-if-missing=module.sig_enforce=1 \
+      --append-if-missing=lockdown=confidentiality \
       --append-if-missing=mitigations=auto,nosmt \
       --append-if-missing=spectre_v2=on \
       --append-if-missing=spec_store_bypass_disable=on \

--- a/files/justfiles/common/kargs.just
+++ b/files/justfiles/common/kargs.just
@@ -40,8 +40,9 @@ set-kargs-hardening:
         echo "Not setting unstable hardening kargs."
     fi
     # Check for secure boot support, required for some drivers. (e.g. WiFi on some macbooks, plus there would be no way to verify these anyways.)
-    SB_STATE=$(mokutil --sb-state 2>/dev/null)
-    if [[ "$SB_STATE" == "This system doesn't support Secure Boot" ]]; then
+    SB_OUTPUT=$(mokutil --sb-state 2>&1)
+    if [[ "$SB_OUTPUT" == "This system doesn't support Secure Boot" ]] || \
+    [[ "$SB_OUTPUT" == *"EFI variables are not supported"* ]]; then
         echo "Secure Boot not supported. Skipping module signature enforcement."
         SECUREBOOT_KARGS="--append-if-missing=module.sig_enforce=0"
     else

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -838,6 +838,7 @@ def audit_secureboot():
     """Ensure secureboot is enabled."""
     import subprocess
     warnings = []
+    recs = []
 
     result = subprocess.run(
         ["mokutil", "--sb-state"],
@@ -865,7 +866,7 @@ def audit_secureboot():
     else:
         status = FAIL
 
-    yield Report(_("Ensuring secure boot is enabled"), status)
+    yield Report(_("Ensuring secure boot is enabled"), status, warnings=warnings, recs=recs)
 
 
 @audit

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -845,7 +845,6 @@ def audit_secureboot():
         stderr=subprocess.PIPE,
         text=True,
     )
-    # sb_state = (result.stdout + result.stderr).strip()
 
     if result.returncode == 0 and result.stdout.strip() == "SecureBoot enabled":
         status = PASS

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -854,7 +854,7 @@ def audit_secureboot():
         warning = _("Your hardware does not support secure boot.")
         rec = (
             warning + "\n" +
-            "The system will be unable to verify that kernel modules are signed or verify the boot process."
+            _("The system will be unable to verify that kernel modules are signed or verify the boot process.")
         )
     else:
         status = FAIL

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -836,22 +836,35 @@ def audit_hardened_malloc():
 @audit
 def audit_secureboot():
     """Ensure secureboot is enabled."""
-    sb_state = command_stdout("mokutil", "--sb-state", check=False) == "SecureBoot enabled"
+    import subprocess
+    warnings = []
+
+    result = subprocess.run(
+        ["mokutil", "--sb-state"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    sb_state = (result.stdout + result.stderr).strip()
+
     if sb_state == "SecureBoot enabled":
         status = PASS
-    elif sb_state == "This system doesn't support Secure Boot":
+    elif "doesn't support Secure Boot" in sb_state:
         status = INFO
         warnings.append(_("Your hardware does not support secure boot."))
         recs.append(
             "\n".join(
                 [
                     _("Your hardware does not support secure boot."),
-                    _("The system will be unable to verify that kernel modules are signed or verify the boot process."),
+                    _(
+                        "The system will be unable to verify that kernel modules are signed or verify the boot process."
+                    ),
                 ]
             )
         )
     else:
         status = FAIL
+
     yield Report(_("Ensuring secure boot is enabled"), status)
 
 

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -841,7 +841,7 @@ def audit_secureboot():
         status = PASS
     elif sb_state == "This system doesn't support Secure Boot":
         status = INFO
-        warnings.append(_("Hardware does not support secure boot."))
+        warnings.append(_("Your hardware does not support secure boot."))
         recs.append(
             "\n".join(
                 [

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -844,16 +844,22 @@ def audit_secureboot():
         capture_output=True,
         text=True,
         check=False,
-    ) # nosec
+    )  # nosec
 
     if result.returncode == 0 and result.stdout.strip() == "SecureBoot enabled":
         status = PASS
-    elif "doesn't support Secure Boot" in result.stderr or "EFI variables are not supported" in result.stderr:
+    elif (
+        "doesn't support Secure Boot" in result.stderr
+        or "EFI variables are not supported" in result.stderr
+    ):
         status = INFO
         warning = _("Your hardware does not support secure boot.")
         rec = (
-            warning + "\n" +
-            _("The system will be unable to verify that kernel modules are signed or the boot process.")
+            warning
+            + "\n"
+            + _(
+                "The system will be unable to verify that kernel modules are signed or the boot process."
+            )
         )
     else:
         status = FAIL

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -837,7 +837,6 @@ def audit_hardened_malloc():
 def audit_secureboot():
     """Ensure secureboot is enabled."""
     import subprocess
-    warnings = []
     recs = []
 
     result = subprocess.run(
@@ -846,17 +845,17 @@ def audit_secureboot():
         stderr=subprocess.PIPE,
         text=True,
     )
-    sb_state = (result.stdout + result.stderr).strip()
+    # sb_state = (result.stdout + result.stderr).strip()
 
-    if sb_state == "SecureBoot enabled":
+    if result.returncode == 0 and result.stdout.strip() == "SecureBoot enabled":
         status = PASS
-    elif "doesn't support Secure Boot" in sb_state:
+    elif "doesn't support Secure Boot" in result.stderr or "EFI variables are not supported" in result.stderr:
         status = INFO
-        warnings.append(_("Your hardware does not support secure boot."))
+        warnings = _("Your hardware does not support secure boot.")
         recs.append(
             "\n".join(
                 [
-                    _("Your hardware does not support secure boot."),
+                    warning,
                     _(
                         "The system will be unable to verify that kernel modules are signed or verify the boot process."
                     ),
@@ -866,7 +865,7 @@ def audit_secureboot():
     else:
         status = FAIL
 
-    yield Report(_("Ensuring secure boot is enabled"), status, warnings=warnings, recs=recs)
+    yield Report(_("Ensuring secure boot is enabled"), status, warnings=warning, recs=recs)
 
 
 @audit

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -836,35 +836,30 @@ def audit_hardened_malloc():
 @audit
 def audit_secureboot():
     """Ensure secureboot is enabled."""
-    import subprocess
-    recs = []
+    warning = None
+    rec = None
 
     result = subprocess.run(
-        ["mokutil", "--sb-state"],
+        ["/usr/bin/mokutil", "--sb-state"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
-    )
+        check=False,
+    ) # nosec
 
     if result.returncode == 0 and result.stdout.strip() == "SecureBoot enabled":
         status = PASS
     elif "doesn't support Secure Boot" in result.stderr or "EFI variables are not supported" in result.stderr:
         status = INFO
-        warnings = _("Your hardware does not support secure boot.")
-        recs.append(
-            "\n".join(
-                [
-                    warning,
-                    _(
-                        "The system will be unable to verify that kernel modules are signed or verify the boot process."
-                    ),
-                ]
-            )
+        warning = _("Your hardware does not support secure boot.")
+        rec = (
+            warning + "\n" +
+            "The system will be unable to verify that kernel modules are signed or verify the boot process."
         )
     else:
         status = FAIL
 
-    yield Report(_("Ensuring secure boot is enabled"), status, warnings=warning, recs=recs)
+    yield Report(_("Ensuring secure boot is enabled"), status, warnings=warning, recs=rec)
 
 
 @audit

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -841,8 +841,7 @@ def audit_secureboot():
 
     result = subprocess.run(
         ["/usr/bin/mokutil", "--sb-state"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
         check=False,
     ) # nosec
@@ -854,7 +853,7 @@ def audit_secureboot():
         warning = _("Your hardware does not support secure boot.")
         rec = (
             warning + "\n" +
-            _("The system will be unable to verify that kernel modules are signed or verify the boot process.")
+            _("The system will be unable to verify that kernel modules are signed or the boot process.")
         )
     else:
         status = FAIL

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -836,8 +836,22 @@ def audit_hardened_malloc():
 @audit
 def audit_secureboot():
     """Ensure secureboot is enabled."""
-    sb_enabled = command_stdout("mokutil", "--sb-state", check=False) == "SecureBoot enabled"
-    status = PASS if sb_enabled else FAIL
+    sb_state = command_stdout("mokutil", "--sb-state", check=False) == "SecureBoot enabled"
+    if sb_state == "SecureBoot enabled":
+        status = PASS
+    elif sb_state == "This system doesn't support Secure Boot":
+        status = INFO
+        warnings.append(_("Hardware does not support secure boot."))
+        recs.append(
+            "\n".join(
+                [
+                    _("Your hardware does not support secure boot."),
+                    _("The system will be unable to verify that kernel modules are signed or verify the boot process."),
+                ]
+            )
+        )
+    else:
+        status = FAIL
     yield Report(_("Ensuring secure boot is enabled"), status)
 
 


### PR DESCRIPTION
Resolves #1378

Note: PR is a draft because I'm still testing this PR on my Macbook.

This PR adds an INFO message to the Secure Boot audit check if your system does not support Secure Boot. For example, some old Macbooks use UEFI but no Secure Boot, so instead of FAILing the check this will just show a message.