### PR TITLE
feat(securedns): add systemd-resolved support to dns-selector

### DIFF
--- a/files/system/etc/NetworkManager/dispatcher.d/pre-up.d/secureblue_vpn.py
+++ b/files/system/etc/NetworkManager/dispatcher.d/pre-up.d/secureblue_vpn.py
@@ -68,18 +68,17 @@ class NMConnection:
                 ["/usr/bin/nmcli", "connection", "modify", "uuid", self.nm_uuid, key, value],
                 check=False,
                 text=True,
-                capture_output=True,
+                stdout=subprocess.PIPE,
             )
             if nm_proc.returncode:
                 print(
-                    f'Failed to set "{key}" = "{value}" on connection "{self.nm_uuid}".',
+                    f'Failed to set "{key}" = "{value}" on connection "{self.nm_id}".',
                     file=sys.stderr,
                 )
-                print(nm_proc.stderr, file=sys.stderr)
                 # Don't quit just because a single setting fails.
                 # Sometimes we have to try applying ipv6.dns to an ipv6=disabled
                 # VPN, which throws an error.
-            print(f'Set "{key}" = "{value}" on connection "{self.nm_uuid}".')
+            print(f'Set "{key}" = "{value}" on connection "{self.nm_id}".')
 
         self._mark_processed()
         self._reapply_to_interfaces()
@@ -105,13 +104,12 @@ class NMConnection:
             ["/usr/bin/nmcli", "device", "reapply", self.nm_interface],
             check=False,
             text=True,
-            capture_output=True,
+            stdout=subprocess.PIPE,
         )
         if nm_proc.returncode:
             print(
                 f"Failed to reapply connection to interface {self.nm_interface}.", file=sys.stderr
             )
-            print(nm_proc.stderr, file=sys.stderr)
             sys.exit(nm_proc.returncode)
         print(f"Reapplied settings to interface {self.nm_interface}.")
 
@@ -122,7 +120,7 @@ class NMConnection:
         if len(sys.argv) != REQUIRED_ARGV_COUNT:
             print(
                 f"Invalid number of arguments: expected {REQUIRED_ARGV_COUNT}, ",
-                "got {len(sys.argv)}.",
+                f"got {len(sys.argv)}.",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -153,11 +151,10 @@ class NMConnection:
             ["/usr/bin/nmcli", "-g", "connection.type", "connection", "show", "uuid", nm_uuid],
             check=False,
             text=True,
-            capture_output=True,
+            stdout=subprocess.PIPE,
         )
         if nm_proc.returncode:
             print(f"Unable to get type for connection {nm_id}.", file=sys.stderr)
-            print(nm_proc.stderr, file=sys.stderr)
             sys.exit(nm_proc.returncode)
         nm_type = nm_proc.stdout.strip()
 
@@ -201,8 +198,25 @@ def defaults_from_file() -> dict[str, str]:
     return dict(parser.items(CONFIG_SECTION))
 
 
+def using_unsupported_resolver() -> bool:
+    """Returns True iff dnsconfd.service is disabled."""
+
+    # nosemgrep: dangerous-subprocess-use-audit
+    systemctl = subprocess.run(  # nosec
+        ["/usr/bin/systemctl", "is-enabled", "--quiet", "dnsconfd.service"],
+        check=False,
+        capture_output=True,
+    )
+    return systemctl.returncode
+
+
 def main() -> None:
     """Apply the defaults from DEFAULTS_FILE to the connection given to this dispatcher."""
+
+    if using_unsupported_resolver():
+        print("This dispatcher only runs when Unbound is enabled.")
+        return
+
     connection = NMConnection.from_environment()
     if connection.nm_type not in VPN_TYPES:
         print(f"Dispatcher not running for type {connection.nm_type}.", file=sys.stderr)

--- a/files/system/etc/NetworkManager/dispatcher.d/pre-up.d/secureblue_vpn.py
+++ b/files/system/etc/NetworkManager/dispatcher.d/pre-up.d/secureblue_vpn.py
@@ -199,7 +199,7 @@ def defaults_from_file() -> dict[str, str]:
 
 
 def using_unsupported_resolver() -> bool:
-    """Returns True iff dnsconfd.service is disabled."""
+    """Returns True if the dnsconfd (Unbound control) service is disabled."""
 
     # nosemgrep: dangerous-subprocess-use-audit
     systemctl = subprocess.run(  # nosec
@@ -207,7 +207,7 @@ def using_unsupported_resolver() -> bool:
         check=False,
         capture_output=True,
     )
-    return systemctl.returncode
+    return systemctl.returncode != 0
 
 
 def main() -> None:

--- a/files/system/usr/libexec/secureblue/dns_selector.py
+++ b/files/system/usr/libexec/secureblue/dns_selector.py
@@ -16,31 +16,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import configparser
 import ipaddress
 import json
 import sys
 import textwrap
-from argparse import ArgumentParser
+from dataclasses import dataclass
+from enum import Enum, auto
 from pathlib import Path
-from typing import Final
+from typing import Final, Optional
 from urllib.parse import urlparse
 
 import sandbox
 from sandbox import SandboxedFunction
 
-DNSCONFD_CONF_FILE: Final[Path] = Path("/etc/dnsconfd.conf")
-NM_GLOBALDNS_CONF_FILE: Final[Path] = Path("/etc/NetworkManager/conf.d/global-dns.conf")
-TRIVALENT_POLICY_FILE: Final[Path] = Path(
+RESET: Final[str] = "\033[0m"
+BOLD: Final[str] = "\033[1m"
+DNSCONFD_CONF_PATH: Final[Path] = Path("/etc/dnsconfd.conf")
+NM_GLOBALDNS_CONF_PATH: Final[Path] = Path("/etc/NetworkManager/conf.d/global-dns.conf")
+RESOLVCONF_PATH: Final[Path] = Path("/etc/resolv.conf")
+TRIVALENT_POLICY_PATH: Final[Path] = Path(
     "/etc/trivalent/policies/managed/10-securedns-browser.json"
 )
-SERVERS_JSON_FILE: Final[Path] = Path("/usr/share/secureblue/secure-dns-providers.json")
+SERVERS_JSON_PATH: Final[Path] = Path("/usr/share/secureblue/secure-dns-providers.json")
 
-dns_function = SandboxedFunction("dns.py", read_write_paths=["/etc"])
+dns_function = SandboxedFunction(
+    "dns.py",
+    read_write_paths=["/etc"],
+    capabilities=["CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN", "CAP_FOWNER"],
+    additional_sandbox_properties=["--property=SystemCallFilter=@chown", "--background="],
+)
 
 
 def ask_option(options_count: int) -> int:
-    """Returns the user's chosen number between 1 and options_count: int from STDIN."""
+    """Returns the user's chosen number between 1 and options_count."""
 
     while True:
         raw_option = interruptible_ask(f"Choose an option [1-{options_count}]: ")
@@ -53,7 +63,7 @@ def ask_option(options_count: int) -> int:
 
 
 def ask_yes_no(prompt: str) -> bool:
-    """Returns the user's preference between 'yes'/'y' (True) and 'no'/'n' (False)."""
+    """Returns the user's preference between yes/y (True) and no/n (False)."""
 
     while True:
         ans = interruptible_ask(prompt + " [y/n] ").casefold()
@@ -63,16 +73,13 @@ def ask_yes_no(prompt: str) -> bool:
 
 
 def ask_should_use_doh() -> bool:
-    """Returns the user's preference for Trivalent DoH enforcement (yes = true, no = false)."""
-
+    """Returns the user's preference for Trivalent DoH enforcement (yes = True, no = False)."""
     print(
         textwrap.dedent(
-            """
+            f"""
             Would you like to enable DNS over HTTPS (DoH) in the Trivalent browser?
-            This tool already configures encrypted DNS over TLS, but DoH looks like HTTPS
-            traffic to outsiders, which could have privacy benefits.
-            1. Enable DoH for Trivalent (masks DNS queries);
-            2. Use the same encrypted DNS as the rest of the system in Trivalent.
+            {BOLD}1. Enable:{RESET}  Send Trivalent's DNS queries to your chosen HTTPS endpoint.
+            {BOLD}2. Disable:{RESET} Use the same encrypted DNS as the rest of the system.
             """
         ).strip()
     )
@@ -81,19 +88,16 @@ def ask_should_use_doh() -> bool:
 
 
 def ask_should_validate_dnssec() -> bool:
-    """Returns the user's preference for local DNSSEC validation (yes = true, no = false)."""
+    """Returns the user's preference for local DNSSEC validation (yes = True, no = False)."""
 
     print(
         textwrap.dedent(
-            """
-            Would you like to enable DNSSEC validation?
-            1. Yes (most secure): Use the Internet's 'root zone' trust anchors to check all
-               DNS responses. The servers suggested by this tool will work, but some default
-               or custom servers give 'bogus' results that cause resolution to fail.
-            2. No (less secure, more compatible): Trust your chosen DNS server to validate
-               for you. If you use a default or insecure DNS server, you will not be
-               protected from forged responses. This is needed for some public WiFi networks
-               to redirect you to their captive portal.
+            f"""
+            Would you like to enable local DNSSEC validation?
+            {BOLD}1. Enable:{RESET}  Validate your chosen server's responses for all signed domains.
+               Uses the Internet's "root trust anchors" for zero-trust lookups.
+            {BOLD}2. Disable:{RESET} Trust your chosen nameserver to validate DNSSEC for you.
+               Our suggested servers validate DNSSEC, but custom providers may not.
             """
         ).strip()
     )
@@ -101,28 +105,92 @@ def ask_should_validate_dnssec() -> bool:
     return option == 1
 
 
-def ask_nm_servers() -> tuple[str, str]:
-    """
-    Get user to choose DNS servers from SERVERS_JSON_FILE as a numbered option from STDIN.
+@dataclass(frozen=True)
+class DNSServers:
+    """A DNS server to be set as a global upstream by NetworkManager."""
 
-    Returns tuple[
-        nm_servers: str, -- a comma-delimited list of DNS servers in NetworkManager format.
-        https_endpoint: str -- a validated HTTPS URL for use as a DoH endpoint.
-    ]
+    servers_csv: Optional[str]
+    https_endpoint: Optional[str]
+
+
+def _ask_custom_ips() -> str:
+    """
+    Returns a comma-separated list of IPs and protocols representing the user's custom servers.
+
+    Example output:
+        `dns+tls://1.1.1.1#domain.com,dns+tls://[::1]#domain.com,dns+udp://2.2.2.2`
     """
 
-    data = json.loads(SERVERS_JSON_FILE.read_text(encoding="utf-8"))
+    ipv4_primary = ask_valid_ipv4("Enter the resolver's IPv4 address (e.g. 1.1.1.1): ")
+    ipv4_secondary = ""
+    has_secondary = ask_yes_no("Does the resolver provide a second IPv4 address?")
+    if has_secondary:
+        ipv4_secondary = ask_valid_ipv4("Enter the secondary IPv4 address: ")
+
+    ipv6_primary = ipv6_secondary = ""
+    has_ipv6 = ask_yes_no("Does the resolver support IPv6 (e.g. 2620:fe::fe)?")
+    if has_ipv6:
+        ipv6_primary = ask_valid_ipv6("Enter the resolver's IPv6 address: ")
+        if has_secondary:
+            ipv6_secondary = ask_valid_ipv6("Enter the resolver's second IPv6 address: ")
+
+    hostname = None
+    has_dot = ask_yes_no(
+        "Does the resolver provide a TLS hostname/SNI to verify its authenticity?\n"
+        "(e.g. cloudflare-dns.com)"
+    )
+    if has_dot:
+        hostname = interruptible_ask("Enter the resolver's TLS hostname/SNI: ")
+
+    tokens = []
+    for ip in (ipv4_primary, ipv4_secondary, ipv6_primary, ipv6_secondary):
+        if ip:
+            tokens.append(f"dns+tls://{ip}#{hostname}" if hostname else f"dns+tls://{ip}")
+    return ",".join(tokens)
+
+
+def ask_custom_servers(https_only: bool) -> DNSServers:
+    """
+    Ask for valid primary (+/- secondary) IPv4 (+/- IPv6) global DNS servers.
+
+    Args
+        https_only (bool): Whether to ask only for a DoH URL. In this case,
+        DNSServers is returned with servers_csv = None.
+    """
+
+    servers_csv = None if https_only else _ask_custom_ips()
+
+    https_endpoint = None
+    has_https_endpoint = https_only or ask_yes_no(
+        "Does the resolver provide a DNS over HTTPS URL?\n"
+        "(e.g. https://cloudflare-dns.com/dns-query)"
+    )
+    if has_https_endpoint:
+        https_endpoint = ask_valid_https("Enter the resolver's DoH URL: ")
+
+    return DNSServers(servers_csv, https_endpoint)
+
+
+def ask_servers(https_only: bool = False) -> DNSServers:
+    """
+    Ask user to choose a DNS server, either from SERVERS_JSON_FILE or custom.
+
+    Args
+        https_only (bool): Whether to only prompt for a HTTPS endpoint if needed.
+    """
+
+    data = json.loads(SERVERS_JSON_PATH.read_text(encoding="utf-8"))
     providers = data["providers"]
 
     print("Select a DNS provider:")
     custom_option = len(providers) + 1
     for i, p in enumerate(providers, start=1):
-        print(f"{i}. {p.get('providerName')}: {p.get('providerDescription')}")
-    print(f"{custom_option}. Choose custom DNS resolvers")
+        print(f"{BOLD}{i}. {p.get('providerName')}:{RESET} {p.get('providerDescription')}")
+    print(f"{BOLD}{custom_option}.{RESET} Choose custom DNS resolvers")
 
     provider_selection = ask_option(len(providers) + 1)
     if provider_selection == custom_option:
-        return ask_custom_nm_servers()
+        return ask_custom_servers(https_only)
     provider = providers[provider_selection - 1]
 
     servers = provider["servers"]
@@ -135,64 +203,163 @@ def ask_nm_servers() -> tuple[str, str]:
         server_selection = 1
 
     server = servers[server_selection - 1]
-    nm_servers = ",".join([*server.get("ipv4", []), *server.get("ipv6", [])])
+    servers_csv = ",".join([*server.get("ipv4", []), *server.get("ipv6", [])])
     https_endpoint = server.get("https")
-    return (nm_servers, https_endpoint)
+    return DNSServers(servers_csv, https_endpoint)
 
 
-def run_interactive() -> int:
-    """
-    Prompt to (1) reset, (2) set global DNS, DNSSEC and Trivalent DoT, or (3) set DNSSEC only.
-    """
+class DNSResolver(Enum):
+    """A DNS resolver."""
 
+    UNBOUND = auto()
+    RESOLVED = auto()
+    UNKNOWN = auto()
+
+    @classmethod
+    def detect(cls) -> "DNSResolver":
+        """Returns the current resolver based on the contents of /etc/resolv.conf."""
+        # Unlike in dns.py, the exact services running are unimportant, as we
+        # need to be VPN aware and measure the effective configuration.
+        try:
+            with open(RESOLVCONF_PATH, encoding="utf-8") as f:
+                for raw_line in f:
+                    line = raw_line.strip()
+                    if line.startswith("nameserver"):
+                        _, addr, *_ = line.split()
+                        if addr == "127.0.0.1": return cls.UNBOUND
+                        if addr == "127.0.0.53": return cls.RESOLVED
+            return cls.UNKNOWN
+
+        except (OSError, UnicodeDecodeError):
+            print("Unable to open and parse /etc/resolv.conf.", file=sys.stderr)
+            return cls.UNKNOWN
+
+
+def ask_resolver() -> DNSResolver:
+    """Asks for the user's choice of resolver."""
     print(
         textwrap.dedent(
-            """
-            Would you like to:
-            1. Reset global DNS to automatic mode (likely insecure);
-            2. Enforce secure DNS servers for all connections (can cause VPN DNS leaks
-               or break local services, but allows for DoH in stealth/censorship scenarios);
-            3. Toggle local DNSSEC validation.
-            4. Print current DNS status.
+            f"""
+            Which DNS resolver would you like to use?
+            {BOLD}1. Unbound:{RESET}  Cache and prefetch DNS records for performance.
+               Typically more reliable and supports local DNSSEC validation.
+            {BOLD}2. resolved:{RESET} Use the Fedora default, systemd-resolved.
+               Better compatibility with some VPNs.
             """
         ).strip()
     )
-    mode = ask_option(4)
+    option = ask_option(2)
+    return DNSResolver.UNBOUND if option == 1 else DNSResolver.RESOLVED
 
+
+def run_interactive() -> int:
+    """Interactive menu with the same functions as `ujust dns-selector --help`."""
+    print(f"{BOLD}Current status:{RESET}")
+    print_all_status()
+    print()
+
+    print(
+        textwrap.dedent(
+            f"""
+            What DNS settings would you like to modify?
+            {BOLD}1. Reset to defaults.{RESET}
+               Uses the Unbound resolver with DNSSEC disabled.
+            {BOLD}2. Configure DNS over HTTPS in Trivalent.{RESET}
+               Masks your DNS queries as regular HTTPS requests when web browsing.
+            """
+        ).strip()
+    )
+    if DNSResolver.detect() == DNSResolver.RESOLVED:
+        mode = ask_option(2)
+    else:
+        print(
+            textwrap.dedent(
+                f"""
+                {BOLD}3. Configure DNSSEC.{RESET}
+                   Toggle local validation, to allow/block spoofed responses.
+                {BOLD}4. Configure global DNS.{RESET}
+                   Enforce secure DNS for all connections, including VPNs.
+                {BOLD}5. Change the resolver.{RESET}
+                   Switch from Unbound (usually more reliable, supports DNSSEC) to
+                   systemd-resolved for better compatibility with some VPNs.
+                """
+            ).strip()
+        )
+        mode = ask_option(5)
+
+    exit_code = 1
     match mode:
         case 1:
-            # Reset.
-            return sandbox.run(dns_function, "reset")
+            # Reset to defaults.
+            exit_code = sandbox.run(dns_function, "reset")
 
         case 2:
-            # Enforce globally.
-            nm_servers, https_endpoint = ask_nm_servers()
-            should_validate_dnssec = "true" if ask_should_validate_dnssec() else "false"
-            if https_endpoint and not ask_should_use_doh():
-                https_endpoint = ""
-            return sandbox.run(
-                dns_function, "set-global", nm_servers, should_validate_dnssec, https_endpoint
-            )
+            # Trivalent DoH.
+            use_doh = ask_should_use_doh()
+            server = ask_servers(https_only=True).https_endpoint if use_doh else ""
+            exit_code = sandbox.run(dns_function, "set-trivalent-doh", server)
 
         case 3:
-            # Toggle DNSSEC.
+            # Configure DNSSEC.
             should_validate_dnssec = "true" if ask_should_validate_dnssec() else "false"
-            return sandbox.run(dns_function, "set-dnssec", should_validate_dnssec)
+            exit_code = sandbox.run(dns_function, "set-dnssec", should_validate_dnssec)
 
         case 4:
-            # Print status.
-            # Successful exits of run_interactive() lead to a print_all_status() in main().
-            return 0
+            # Configure global DNS. Unbound only.
+            servers = ask_servers()
+            should_validate_dnssec = "true" if ask_should_validate_dnssec() else "false"
+            https_endpoint = (
+                servers.https_endpoint
+                if servers.https_endpoint is not None
+                and ask_should_use_doh()
+                else None
+            )
+            exit_code = sandbox.run(
+                dns_function,
+                "set-global",
+                servers.servers_csv,
+                should_validate_dnssec,
+                https_endpoint,
+            )
 
+        case 5:
+            # Switch to systemd-resolved.
+            exit_code = sandbox.run(dns_function, "set-resolver", "resolved")
+
+    print(f"\n{BOLD}Finished configuring DNS.{RESET}")
+    return exit_code
+
+
+def print_current_resolver() -> None:
+    """
+    Prints current DNS resolver.
+
+    Example:
+        DNS Resolver: Unbound|systemd-resolved|unknown/vpn
+    """
+    match DNSResolver.detect():
+        case DNSResolver.UNBOUND:
+            print("DNS Resolver: Unbound")
+        case DNSResolver.RESOLVED:
+            print("DNS Resolver: systemd-resolved")
         case _:
-            return 1
+            print("DNS Resolver: unknown/vpn")
 
 
 def print_dnssec_status() -> None:
-    """Print DNSSEC status to STDOUT, i.e. 'DNSSEC: <enabled|disabled>'."""
+    """
+    Print DNSSEC status.
+
+    Example:
+        DNSSEC: enabled|disabled
+    """
+    if DNSResolver.detect() != DNSResolver.UNBOUND:
+        print("DNSSEC: unavailable")
+        return
+
     try:
         dnssec_enabled = False
-        with DNSCONFD_CONF_FILE.open("r", encoding="utf-8") as f:
+        with DNSCONFD_CONF_PATH.open("r", encoding="utf-8") as f:
             for raw_line in f:
                 line = raw_line.strip()
                 if not line or line.startswith("#"):
@@ -205,22 +372,27 @@ def print_dnssec_status() -> None:
     except FileNotFoundError:
         print("DNSSEC: disabled")
     except (OSError, UnicodeDecodeError):
-        print("DNSSEC: unable to open and parse configuration")
+        print("DNSSEC: unable to open and parse configuration", file=sys.stderr)
 
 
 def print_nm_globaldns_status() -> None:
     """
     Print global DNS enablement status and indented server list to STDOUT.
 
-    For example:
-    Global DNS: <enabled|disabled>
-    Global DNS servers:
-        dns+tls://1.2.3.4#host
-        dns+tls://[::1]#host
+    Example:
+        Global DNS: enabled|disabled
+
+        Global DNS servers:
+            dns+tls://1.2.3.4#host
+            dns+tls://[::1]#host
     """
+    if DNSResolver.detect() != DNSResolver.UNBOUND:
+        print("Global DNS: unavailable")
+        return
+
     nm_parser = configparser.ConfigParser(strict=False, delimiters=("=",))
     nm_parser.optionxform = str
-    nm_parser.read(NM_GLOBALDNS_CONF_FILE.as_posix())
+    nm_parser.read(NM_GLOBALDNS_CONF_PATH.as_posix())
 
     if not nm_parser.has_section("global-dns"):
         print("Global DNS: disabled")
@@ -240,14 +412,14 @@ def print_nm_globaldns_status() -> None:
 
 def print_trivalent_doh_status() -> None:
     """
-    Print Trivalent DNS over HTTPS enablement status and endpoint to STDOUT.
+    Print Trivalent DNS over HTTPS enablement status and endpoint.
 
-    For example:
-    Trivalent DoH: <enabled|disabled>
-    Trivalent DoH endpoint: https://host/endpoint
+    Example:
+        Trivalent DoH: enabled|disabled
+        Trivalent DoH endpoint: https://host/endpoint
     """
     try:
-        with TRIVALENT_POLICY_FILE.open("r", encoding="utf-8") as f:
+        with TRIVALENT_POLICY_PATH.open("r", encoding="utf-8") as f:
             policy = json.load(f)
             doh_mode = policy.get("DnsOverHttpsMode")
             doh_endpoint = policy.get("DnsOverHttpsTemplates")
@@ -258,13 +430,13 @@ def print_trivalent_doh_status() -> None:
     except FileNotFoundError:
         print("Trivalent DoH: disabled")
     except json.JSONDecodeError:
-        print("Trivalent DoH: configuration invalid")
+        print("Trivalent DoH: configuration invalid", file=sys.stderr)
     except (OSError, UnicodeDecodeError):
-        print("Trivalent DoH: unable to open and parse configuration")
+        print("Trivalent DoH: unable to open and parse configuration", file=sys.stderr)
 
 
 def interruptible_ask(prompt: str) -> str:
-    """Get a string input from STDIN, strip whitespace, and exit gracefully on SIGINT."""
+    """Ask for a string input, strip whitespace, and exit gracefully if interrupted."""
     try:
         return input(prompt).strip()
     except (KeyboardInterrupt, EOFError):
@@ -273,7 +445,7 @@ def interruptible_ask(prompt: str) -> str:
 
 
 def ask_valid_ipv4(prompt: str) -> str:
-    """Returns a valid IPv4 address as a string."""
+    """Returns a valid IPv4 address."""
     while True:
         ip = interruptible_ask(prompt)
         try:
@@ -284,7 +456,7 @@ def ask_valid_ipv4(prompt: str) -> str:
 
 
 def ask_valid_ipv6(prompt: str) -> str:
-    """Returns a valid IPv6 address enclosed in square brackets as a string."""
+    """Returns a valid IPv6 address enclosed in square brackets."""
     while True:
         ip = interruptible_ask(prompt).strip(" []")
         try:
@@ -294,12 +466,12 @@ def ask_valid_ipv6(prompt: str) -> str:
             print("Invalid IPv6 address, try again.")
 
 
-def ask_valid_https(prompt: str) -> str:
+def ask_valid_https(prompt: str) -> Optional[str]:
     """Returns a valid HTTPS URL."""
     while True:
         raw_url = interruptible_ask(prompt)
         if not raw_url:  # Allow empty.
-            return ""
+            return None
         url = urlparse(raw_url)
         if url.scheme == "https" and url.netloc:
             print()
@@ -307,113 +479,85 @@ def ask_valid_https(prompt: str) -> str:
         print("Invalid HTTPS endpoint, try again.")
 
 
-def ask_custom_nm_servers() -> tuple[str, str]:
-    """
-    Get valid primary (+/- secondary) IPv4 (+/- IPv6) global DNS servers from STDIN.
-
-    Returns tuple[
-        nm_servers: str, -- a comma-delimited list of DNS servers in NetworkManager format.
-        https_endpoint: str -- a validated HTTPS URL for use as a DoH endpoint.
-    ]
-    """
-
-    ipv4_primary = ask_valid_ipv4("Enter the resolver's IPv4 address (e.g. 1.1.1.1): ")
-    ipv4_secondary = ""
-    has_secondary = ask_yes_no("Does the resolver provide a second IPv4 address?")
-    if has_secondary:
-        ipv4_secondary = ask_valid_ipv4("Enter the secondary IPv4 address: ")
-
-    ipv6_primary = ipv6_secondary = ""
-    has_ipv6 = ask_yes_no("Does the resolver support IPv6 (e.g. 2620:fe::fe)?")
-    if has_ipv6:
-        ipv6_primary = ask_valid_ipv6("Enter the resolver's IPv6 address: ")
-        if has_secondary:
-            ipv6_secondary = ask_valid_ipv6("Enter the resolver's second IPv6 address: ")
-
-    hostname = ""
-    has_hostname = ask_yes_no(
-        "Does the resolver provide a TLS hostname/SNI to verify its authenticity?\n"
-        "(e.g. cloudflare-dns.com)"
-    )
-    if has_hostname:
-        hostname = interruptible_ask("Enter the resolver's TLS hostname/SNI: ")
-
-    https_endpoint = ""
-    has_https_endpoint = ask_yes_no(
-        "Does the resolver provide a DNS over HTTPS URL?\n"
-        "(e.g. https://cloudflare-dns.com/dns-query)"
-    )
-    if has_https_endpoint:
-        https_endpoint = ask_valid_https("Enter the resolver's DoH URL:")
-
-    tokens = []
-    for ip in (ipv4_primary, ipv4_secondary, ipv6_primary, ipv6_secondary):
-        if ip:
-            tokens.append(f"dns+tls://{ip}#{hostname}" if hostname else f"dns+tls://{ip}")
-    nm_servers = ",".join(tokens)
-    print()
-    return nm_servers, https_endpoint
-
-
 def print_all_status() -> None:
-    """Prints report on global DNS status, servers, DNSSEC and Trivalent DoH status to STDOUT."""
+    """Prints the entire DNS state tracked by `ujust dns-selector` for audit."""
 
-    print_nm_globaldns_status()
+    print_current_resolver()
     print_dnssec_status()
+    print_nm_globaldns_status()
     print_trivalent_doh_status()
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line input to `ujust dns-selector`. Doesn't expose Global DNS."""
+
+    p = argparse.ArgumentParser(
+        prog="ujust dns-selector", description="Sets global DoT servers, DNSSEC and Trivalent DoH."
+    )
+
+    cmd_p = p.add_subparsers(dest="cmd", required=False)
+    cmd_p.add_parser("reset", help="Resets all settings to default/automatic.")
+    cmd_p.add_parser("status", help="Reads status from config files.")
+
+    dnssec_p = cmd_p.add_parser("dnssec", help="Sets local DNSSEC validation.")
+    dnssec_p.add_argument("enable_dnssec", choices=["on", "off"])
+
+    unbound_p = cmd_p.add_parser("resolver", help="Sets which DNS resolver is used.")
+    unbound_p.add_argument("backend", choices=["unbound", "resolved"])
+
+    args = p.parse_args()
+    if args.cmd == "resolver":
+        if args.backend == "unbound":
+            args.backend = DNSResolver.UNBOUND
+        else:
+            args.backend = DNSResolver.RESOLVED
+    if args.cmd == "dnssec":
+        args.enable_dnssec = args.enable_dnssec == "on"
+
+    return args
 
 
 def main() -> int:
     """
     Sets DNS configuration.
 
-    ujust dns-selector -- Interactive.
-    ujust dns-selector reset
-    ujust dns-selector dnssec <on|off>
-    ujust dns-selector status
+    Examples:
+        $ ujust dns-selector
+        $ ujust dns-selector reset
+        $ ujust dns-selector dnssec <on|off>
+        $ ujust dns-selector resolver <unbound|resolved>
+        $ ujust dns-selector status
     """
+    args = parse_args()
 
-    p = ArgumentParser(
-        prog="ujust dns-selector", description="Sets global DoT servers, DNSSEC and Trivalent DoH."
-    )
-    cmd_p = p.add_subparsers(dest="cmd", required=False)
-    cmd_p.add_parser("reset", help="Resets all settings to default/automatic.")
-    cmd_p.add_parser(
-        "status",
-        help="Reads status from config files. Lists active servers and "
-        "shows global DNS, DNSSEC and Trivalent DoH enablement.",
-    )
-    dnssec_p = cmd_p.add_parser("dnssec", help="Sets local DNSSEC validation.")
-    dnssec_p.add_argument("state", choices=["on", "off"])
-    args = p.parse_args()
-
+    exit_code = 0
     match args.cmd:
         case None:
             exit_code = run_interactive()
-            if exit_code == 0:
-                print_all_status()
-            return exit_code
 
         case "status":
-            print_all_status()
-            return 0
+            pass
 
         case "dnssec":
-            dnssec = "true" if sys.argv[2] == "on" else "false"
+            if DNSResolver.detect() != DNSResolver.UNBOUND:
+                print("DNSSEC unavailable with current resolver.", file=sys.stderr)
+                return 1
+            dnssec = "true" if args.enable_dnssec else "false"
             exit_code = sandbox.run(dns_function, "set-dnssec", dnssec)
-            if exit_code == 0:
-                print_all_status()
-            return exit_code
 
         case "reset":
             exit_code = sandbox.run(dns_function, "reset")
-            if exit_code == 0:
-                print_all_status()
-            return exit_code
+
+        case "resolver":
+            resolver = "unbound" if args.backend == DNSResolver.UNBOUND else "resolved"
+            exit_code = sandbox.run(dns_function, "set-resolver", resolver)
 
         case _:
             print("Invalid option selected. Try --help.", file=sys.stderr)
             return 1
+
+    print_all_status()
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/files/system/usr/libexec/secureblue/dns_selector.py
+++ b/files/system/usr/libexec/secureblue/dns_selector.py
@@ -226,8 +226,10 @@ class DNSResolver(Enum):
                     line = raw_line.strip()
                     if line.startswith("nameserver"):
                         _, addr, *_ = line.split()
-                        if addr == "127.0.0.1": return cls.UNBOUND
-                        if addr == "127.0.0.53": return cls.RESOLVED
+                        if addr == "127.0.0.1":
+                            return cls.UNBOUND
+                        if addr == "127.0.0.53":
+                            return cls.RESOLVED
             return cls.UNKNOWN
 
         except (OSError, UnicodeDecodeError):
@@ -310,8 +312,7 @@ def run_interactive() -> int:
             should_validate_dnssec = "true" if ask_should_validate_dnssec() else "false"
             https_endpoint = (
                 servers.https_endpoint
-                if servers.https_endpoint is not None
-                and ask_should_use_doh()
+                if servers.https_endpoint is not None and ask_should_use_doh()
                 else None
             )
             exit_code = sandbox.run(

--- a/files/system/usr/libexec/secureblue/inner/dns.py
+++ b/files/system/usr/libexec/secureblue/inner/dns.py
@@ -17,136 +17,308 @@
 # limitations under the License.
 
 # We only make fixed subprocess calls to /usr/bin/systemctl.
+import argparse
 import json
+import os
+import pwd
 import subprocess  # nosec
 import sys
+import textwrap
+import time
+from dataclasses import dataclass
+from enum import Enum
+from functools import partialmethod
 from pathlib import Path
-from typing import Final
+from typing import Final, Optional
 
-DNSCONFD_CONF_FILE: Final[Path] = Path("/etc/dnsconfd.conf")
-NM_GLOBALDNS_CONF_FILE: Final[Path] = Path("/etc/NetworkManager/conf.d/global-dns.conf")
-TRIVALENT_POLICY_FILE: Final[Path] = Path(
+DNSCONFD_CONF_PATH: Final[Path] = Path("/etc/dnsconfd.conf")
+DNSCONFD_MANAGER_PATH: Final[Path] = Path("/etc/NetworkManager/conf.d/dnsconfd.conf")
+NM_GLOBALDNS_CONF_PATH: Final[Path] = Path("/etc/NetworkManager/conf.d/global-dns.conf")
+RESOLVCONF_PATH: Final[Path] = Path("/etc/resolv.conf")
+RESOLVED_RESOLVCONF_PATH: Final[Path] = Path("/run/systemd/resolve/stub-resolv.conf")
+RESOLVED_SECUREDNS_PATH: Final[Path] = Path("/etc/systemd/resolved.conf.d/10-securedns.conf")
+TRIVALENT_POLICY_PATH: Final[Path] = Path(
     "/etc/trivalent/policies/managed/10-securedns-browser.json"
 )
 
 
-def restart_stack() -> int:
-    """Reset dnsconfd (which manages Unbound) and NetworkManager."""
-    try:
-        # We're calling system binaries with fixed arguments and no shell.
+@dataclass(frozen=True)
+class SystemdService:
+    """
+    A systemd service.
+
+    Attributes:
+        name (str): The unit name, e.g. "dnsconfd.service".
+    """
+
+    name: str
+
+    def _do_systemctl_action(self, *actions: str) -> None:
+        """
+        Perform an action on a systemd service. Retry and eventually log on failure.
+
+        Args:
+            action (str): systemctl action (e.g. "start")
+        """
         # nosemgrep: dangerous-subprocess-use-audit
-        subprocess.run(["/usr/bin/systemctl", "restart", "dnsconfd.service"], check=True)  # nosec
+        systemctl = subprocess.run(  # nosec
+            ["/usr/bin/systemctl", *actions, self.name], check=False, capture_output=True
+        )
+
+        if not systemctl.returncode:
+            # All good.
+            return
+
+        # Error, so wait a few seconds and try again.
+        time.sleep(3)
         # nosemgrep: dangerous-subprocess-use-audit
-        subprocess.run(["/usr/bin/systemctl", "restart", "NetworkManager.service"], check=True)  # nosec
-    except subprocess.CalledProcessError:
-        return 1
-    return 0
+        systemctl = subprocess.run(  # nosec
+            ["/usr/bin/systemctl", *actions, self.name], check=False, stdout=subprocess.PIPE
+        )
+
+        if systemctl.returncode:
+            print(f"Failed to {' '.join(actions)} {self.name}.", file=sys.stderr)
+            sys.exit(systemctl.returncode)
+
+    disable = partialmethod(_do_systemctl_action, "disable")
+    disable_now = partialmethod(_do_systemctl_action, "disable", "--now")
+    enable = partialmethod(_do_systemctl_action, "enable")
+    enable_now = partialmethod(_do_systemctl_action, "enable", "--now")
+    stop = partialmethod(_do_systemctl_action, "stop")
+    start = partialmethod(_do_systemctl_action, "start")
+    mask = partialmethod(_do_systemctl_action, "mask")
+    unmask = partialmethod(_do_systemctl_action, "unmask")
+
+    def is_enabled(self) -> bool:
+        """Returns whether the systemd service is enabled."""
+        # nosemgrep: dangerous-subprocess-use-audit
+        systemctl = subprocess.run(  # nosec
+            ["/usr/bin/systemctl", "is-enabled", "--quiet", self.name],
+            check=False,
+            capture_output=True,
+        )
+        return not systemctl.returncode
 
 
-def set_global_nm_servers(nm_servers: str) -> None:
+class DNSResolver(Enum):
+    """A DNS resolver, such as Unbound or systemd-resolved."""
+
+    UNBOUND = "dnsconfd.service"
+    RESOLVED = "systemd-resolved.service"
+
+    @property
+    def service(self) -> SystemdService:
+        """Gets the systemd service associated with this resolver."""
+        return SystemdService(self.value)
+
+    @staticmethod
+    def get_current() -> "DNSResolver":
+        """Gets the resolver whose systemd service is enabled."""
+        return (
+            DNSResolver.UNBOUND
+            if DNSResolver.UNBOUND.service.is_enabled()
+            else DNSResolver.RESOLVED
+        )
+
+
+def set_resolver(resolver: DNSResolver) -> None:
+    """
+    Sets the DNS resolver (e.g. dnsconfd-unbound, systemd-resolved) to use.
+
+    Args:
+        resolver (DNSResolver): The DNS resolver to use.
+    """
+
+    match resolver:
+        case DNSResolver.UNBOUND:
+            DNSResolver.RESOLVED.service.mask()
+            DNSResolver.RESOLVED.service.disable()
+
+            # NetworkManager needs to be told to use dnsconfd.
+            DNSCONFD_MANAGER_PATH.write_text("[main]\ndns=dnsconfd\n", encoding="utf-8")
+            DNSCONFD_MANAGER_PATH.chmod(0o644)
+            # resolv.conf needs to be a real file owned by dnsconfd:root.
+            RESOLVCONF_PATH.unlink(missing_ok=True)
+            RESOLVCONF_PATH.touch()  # Cannot set mode here because of umask.
+            RESOLVCONF_PATH.chmod(0o644)
+            dnsconfd_uid = pwd.getpwnam("dnsconfd").pw_uid  # For unprivileged dnsconfd.
+            os.chown(RESOLVCONF_PATH, uid=dnsconfd_uid, gid=0)  # gid 0 is default behavior.
+
+            SystemdService("unbound.socket").enable_now()
+            SystemdService("unbound-control.socket").enable_now()
+            DNSResolver.UNBOUND.service.unmask()
+            DNSResolver.UNBOUND.service.enable()
+
+        case DNSResolver.RESOLVED:
+            DNSResolver.UNBOUND.service.disable()
+            DNSResolver.UNBOUND.service.mask()
+            SystemdService("unbound.socket").disable_now()
+            SystemdService("unbound-control.socket").disable_now()
+
+            DNSCONFD_MANAGER_PATH.unlink(missing_ok=True)
+            # systemd-resolved is implicitly detected by NetworkManager based on
+            # a resolv.conf symlink.
+            RESOLVCONF_PATH.unlink(missing_ok=True)
+            RESOLVCONF_PATH.symlink_to(RESOLVED_RESOLVCONF_PATH.as_posix())
+
+            DNSResolver.RESOLVED.service.unmask()
+            DNSResolver.RESOLVED.service.enable()
+
+
+def set_global_nm_servers(servers: Optional[str] = None) -> None:
     """
     Set NetworkManager global DNS servers.
 
-    nm_servers: str -- servers in the format "dns+tls://1.2.3.4#host,[::1]#host".
+    Args:
+        nm_servers (str): servers in the format "dns+tls://1.2.3.4#host,[::1]#host".
     """
-    if not nm_servers:
-        NM_GLOBALDNS_CONF_FILE.unlink(missing_ok=True)
+    if not servers:
+        NM_GLOBALDNS_CONF_PATH.unlink(missing_ok=True)
         return
 
-    nm_globaldns_config = (
-        f"[global-dns]\nresolve-mode=exclusive\n\n[global-dns-domain-*]\nservers={nm_servers}\n"
-    )
-    NM_GLOBALDNS_CONF_FILE.parent.mkdir(parents=True, exist_ok=True)
-    NM_GLOBALDNS_CONF_FILE.write_text(nm_globaldns_config, encoding="utf-8")
-    NM_GLOBALDNS_CONF_FILE.chmod(0o644)
+    nm_globaldns_config = textwrap.dedent(
+        f"""
+        [global-dns]
+        resolve-mode=exclusive
+
+        [global-dns-domain-*]
+        servers={servers}
+        """
+    ).strip()
+    NM_GLOBALDNS_CONF_PATH.parent.mkdir(parents=True, exist_ok=True)
+    NM_GLOBALDNS_CONF_PATH.write_text(f"{nm_globaldns_config}\n", encoding="utf-8")
+    NM_GLOBALDNS_CONF_PATH.chmod(0o644)
 
 
-def set_trivalent_doh_endpoint(https_endpoint: str) -> None:
+def set_trivalent_doh_endpoint(https_endpoint: Optional[str] = None) -> None:
     """
     Sets Trivalent DNS over HTTPS policy.
 
-    https_endpoint: str -- A valid HTTPS URL as the endpoint.
+    Args:
+        https_endpoint (str): A valid HTTPS URL as the endpoint.
     """
     if not https_endpoint:
-        TRIVALENT_POLICY_FILE.unlink(missing_ok=True)
+        TRIVALENT_POLICY_PATH.unlink(missing_ok=True)
         return
 
-    trivalent_policy_json: str = (
-        json.dumps(
-            {"DnsOverHttpsMode": "secure", "DnsOverHttpsTemplates": https_endpoint}, indent=4
-        )
-        + "\n"
+    trivalent_policy_json = json.dumps(
+        {"DnsOverHttpsMode": "secure", "DnsOverHttpsTemplates": https_endpoint}, indent=4
     )
-    TRIVALENT_POLICY_FILE.parent.mkdir(parents=True, exist_ok=True)
-    TRIVALENT_POLICY_FILE.write_text(trivalent_policy_json, encoding="utf-8")
-    TRIVALENT_POLICY_FILE.chmod(0o644)
+    TRIVALENT_POLICY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    TRIVALENT_POLICY_PATH.write_text(f"{trivalent_policy_json}\n", encoding="utf-8")
+    TRIVALENT_POLICY_PATH.chmod(0o644)
 
 
 def set_dnssec_enabled(should_validate: bool) -> None:
     """
     Enables/disables local DNSSEC validation by Unbound.
 
-    should_validate: bool -- True to enable validation, False to disable.
+    Args:
+        should_validate (bool): True to enable validation, False to disable.
     """
     if not should_validate:
-        DNSCONFD_CONF_FILE.unlink(missing_ok=True)
+        DNSCONFD_CONF_PATH.unlink(missing_ok=True)
         return
 
-    DNSCONFD_CONF_FILE.write_text("dnssec_enabled: yes\n", encoding="utf-8")
-    DNSCONFD_CONF_FILE.chmod(0o644)
+    DNSCONFD_CONF_PATH.write_text("dnssec_enabled: yes\n", encoding="utf-8")
+    DNSCONFD_CONF_PATH.chmod(0o644)
 
 
-def main() -> int:
-    """
-    Sets DNS configuration.
+def parse_args() -> argparse.Namespace:
+    """Parse command-line inputs."""
 
-    dns.py reset -- Resets all settings to default/automatic.
-    dns.py set-dnssec <true|false>
-        Enables or disables local DNSSEC validation respectively.
-    dns.py set-global <servers> <dnssec-enabled> [<doh-url>]
-        Sets servers where servers is comma-separated,
-        servers -- e.g. "dns+tls://1.2.3.4#host,dns+tls://[::1]#host"
-        dnssec-enabled -- <true|false>
-        doh-url -- a valid HTTPS URL.
-    """
-    # If this gets more complex, may move to argparse?
-    args_min = 2
-    args_set_dnssec = 3
-    args_set_global_min = 4
-    args_set_global_max = 5
-    bool_strings = ("true", "false")
+    p = argparse.ArgumentParser(prog="dns.py", description="Sets DNS configuration.")
+    cmd_p = p.add_subparsers(dest="cmd", required=True)
+    cmd_p.add_parser("reset", help="Reset all settings to defaults.")
 
-    if len(sys.argv) < args_min:
-        return 1
+    dnssec_p = cmd_p.add_parser("set-dnssec", help="Enable or disable DNSSEC.")
+    dnssec_p.add_argument(
+        "dnssec_enabled",
+        help="'true' to enable DNSSEC, 'false' to disable.",
+        choices=["true", "false"],
+    )
 
-    if sys.argv[1] == "reset" and len(sys.argv) == args_min:
-        set_global_nm_servers("")
-        set_dnssec_enabled(False)
-        set_trivalent_doh_endpoint("")
-        return restart_stack()
+    global_p = cmd_p.add_parser("set-global", help="Set global DNS.")
+    global_p.add_argument("servers", help="Comma-separated list of NetworkManager DNS servers.")
+    global_p.add_argument(
+        "dnssec_enabled",
+        help="'true' to enable DNSSEC, 'false' to disable.",
+        choices=["true", "false"],
+    )
+    global_p.add_argument("doh_url", nargs="?", help="Valid HTTPS URL for DoH.")
 
-    if (
-        sys.argv[1] == "set-dnssec"
-        and len(sys.argv) == args_set_dnssec
-        and sys.argv[2] in bool_strings
-    ):
-        set_dnssec_enabled(sys.argv[2] == "true")
-        return restart_stack()
+    resolver_p = cmd_p.add_parser("set-resolver", help="Change the stub resolver.")
+    resolver_p.add_argument(
+        "resolver",
+        help="'unbound' for dnsconfd-unbound, 'resolved' for systemd-resolved.",
+        choices=["unbound", "resolved"],
+    )
 
-    if sys.argv[1] == "set-global" and len(sys.argv) in (args_set_global_min, args_set_global_max):
-        should_validate_dnssec = sys.argv[3]
-        if should_validate_dnssec not in bool_strings:
-            return 1
-        nm_servers = sys.argv[2]
-        https_endpoint = sys.argv[4] if len(sys.argv) == args_set_global_max else ""
+    doh_p = cmd_p.add_parser("set-trivalent-doh", help="Toggle Trivalent DoH.")
+    doh_p.add_argument("doh_url", help="Valid HTTPS URL.")
 
-        set_global_nm_servers(nm_servers)
-        set_dnssec_enabled(should_validate_dnssec == "true")
-        set_trivalent_doh_endpoint(https_endpoint)
-        return restart_stack()
+    return p.parse_args()
 
-    return 1
+
+def main() -> None:
+    """Configure DNS according to command-line arguments."""
+
+    args = parse_args()
+
+    if args.cmd == "set-trivalent-doh":
+        # Do this early because we don't need to bring down the network stack.
+        set_trivalent_doh_endpoint(args.doh_url)
+        print("Configured DNS over HTTPS in Trivalent only.")
+        return
+
+    # Stop everything.
+    print("Configuring DNS. Your connection will be reset. This may take a few moments.")
+    nm = SystemdService("NetworkManager.service")
+    nm.stop()
+    DNSResolver.get_current().service.stop()
+    time.sleep(2)
+
+    match args.cmd:
+        case "reset":
+            set_resolver(DNSResolver.UNBOUND)
+            set_global_nm_servers(None)
+            set_dnssec_enabled(False)
+            set_trivalent_doh_endpoint(None)
+
+        case "set-dnssec":
+            set_resolver(DNSResolver.UNBOUND)
+            set_dnssec_enabled(args.dnssec_enabled == "true")
+
+        case "set-global":
+            # Only support global DNS for Unbound. The purpose of allowing
+            # rollback to resolved is that VPN clients want to push dynamic
+            # DNS configuration to it (e.g. depending on connection state). If
+            # global DNS were acceptable, the user could still use Unbound.
+            if DNSResolver.get_current() != DNSResolver.UNBOUND:
+                print("Global DNS is only supported with Unbound.", file=sys.stderr)
+                return
+
+            set_global_nm_servers(args.servers)
+            set_dnssec_enabled(args.dnssec_enabled == "true")
+            set_trivalent_doh_endpoint(args.doh_url)
+
+        case "set-resolver":
+            # DNS servers and DNSSEC are not interchangeable. See migrate_dns.py.
+            set_global_nm_servers(None)
+            set_dnssec_enabled(False)
+            if args.resolver == "resolved":
+                set_resolver(DNSResolver.RESOLVED)
+            else:
+                set_resolver(DNSResolver.UNBOUND)
+
+        case _:
+            print("Invalid option selected. Try --help.", file=sys.stderr)
+            sys.exit(1)
+
+    time.sleep(2)
+    DNSResolver.get_current().service.start()
+    nm.start()
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/files/system/usr/libexec/secureblue/inner/dns.py
+++ b/files/system/usr/libexec/secureblue/inner/dns.py
@@ -111,14 +111,34 @@ class DNSResolver(Enum):
         """Gets the systemd service associated with this resolver."""
         return SystemdService(self.value)
 
-    @staticmethod
-    def get_current() -> "DNSResolver":
-        """Gets the resolver whose systemd service is enabled."""
-        return (
-            DNSResolver.UNBOUND
-            if DNSResolver.UNBOUND.service.is_enabled()
-            else DNSResolver.RESOLVED
-        )
+    @classmethod
+    def get_current(cls) -> "DNSResolver":
+        """
+        Gets the resolver whose systemd service is enabled.
+
+        Warns and returns `DNSResolver.UNBOUND` if an unsupported configuration is detected.
+        """
+
+        unbound_enabled = cls.UNBOUND.service.is_enabled()
+        resolved_enabled = cls.RESOLVED.service.is_enabled()
+
+        if unbound_enabled and resolved_enabled:
+            print(
+                "Warning: multiple DNS resolvers are enabled.\n"
+                "Continuing anyway. You may need to restart your device after this change.",
+                file=sys.stderr,
+            )
+            return cls.UNBOUND
+
+        if not unbound_enabled and not resolved_enabled:
+            print(
+                "Warning: dnsconfd.service and systemd-resolved.service are disabled.\n"
+                "Continuing anyway. You may need to restart your device after this change.",
+                file=sys.stderr,
+            )
+            return cls.UNBOUND
+
+        return cls.UNBOUND if unbound_enabled else cls.RESOLVED
 
 
 def set_resolver(resolver: DNSResolver) -> None:
@@ -272,7 +292,7 @@ def main() -> None:
         return
 
     # Stop everything.
-    print("Configuring DNS. Your connection will be reset. This may take a few moments.")
+    print("Configuring DNS. Your connection will be reset. Please wait.")
     nm = SystemdService("NetworkManager.service")
     nm.stop()
     DNSResolver.get_current().service.stop()

--- a/files/system/usr/libexec/secureblue/migrate_dns.py
+++ b/files/system/usr/libexec/secureblue/migrate_dns.py
@@ -27,7 +27,6 @@ from pathlib import Path
 from typing import Final
 
 RESOLVED_SECUREDNS_PATH: Final[Path] = Path("/etc/systemd/resolved.conf.d/10-securedns.conf")
-RESOLVED_VESTIGIAL_PATH: Final[Path] = Path("/etc/systemd/resolved.conf.d/10-disable-llmnr.conf")
 NM_GLOBALDNS_PATH: Final[Path] = Path("/etc/NetworkManager/conf.d/global-dns.conf")
 DNSCONFD_PATH: Final[Path] = Path("/etc/dnsconfd.conf")
 RESOLVCONF_PATH: Final[Path] = Path("/etc/resolv.conf")
@@ -130,10 +129,6 @@ def main() -> None:
     (nm_servers, is_dnssec_enabled) = read_from_resolved()
     write_to_nm(nm_servers, is_dnssec_enabled)
     RESOLVED_SECUREDNS_PATH.unlink()
-
-    # The only other resolved config shipped by secureblue is
-    # 10-disable-llmnr.conf. Clean it up here to complete migration.
-    RESOLVED_VESTIGIAL_PATH.unlink(missing_ok=True)
 
     print("Finished migrating secureblue DNS to NetworkManager.")
 


### PR DESCRIPTION
Although Unbound works with more consistency than systemd-resolved, several VPNs have a hard dependency on it, so they consistently fail (see #1383). This PR allows users to switch between DNS resolvers in `ujust dns-selector`.

Changelog:
- Add limited systemd-resolved support to `ujust dns-selector`, for resolver switching without exposing incompatible options.
  - resolved is typically only used when runtime VPN DNS configuration is needed, so global resolved configuration is not supported.
  - resolved does not support DNSSEC, so this is disabled.
- Disable the NetworkManager VPN dispatcher when systemd-resolved is in use.
  - The dispatcher fixes many VPNs, but gives mixed results with some third-party clients.
  - Keeping the dispatcher means more VPNs work without resolved so can benefit from DNSSEC and extended hardening.
  - In future, the dispatcher may allow for use of per-connection DNS settings with a secure default profile.
- Robustness: systemd service restarts are re-attempted, more sanity-checking and local testing.
- Maintainability: Google-style docstrings, some refactoring.

Note: no changes have been made to the audit. `ujust dns-selector status` is backwards-compatible, so no changes were needed. Currently, with systemd-resolved enabled, it returns FAIL for missing DNSSEC.

Not included in this PR:
- DNS integration testing? (see `ujust dns-selector --help`).

<img width="459" height="558" alt="image" src="https://github.com/user-attachments/assets/41fe0e9c-7de3-4075-bbf0-ee6e0e7b2017" />
