### PR TITLE
fix(securedns): pass correct type to sandbox

### DIFF
--- a/files/system/usr/libexec/secureblue/dns_selector.py
+++ b/files/system/usr/libexec/secureblue/dns_selector.py
@@ -313,7 +313,7 @@ def run_interactive() -> int:
             https_endpoint = (
                 servers.https_endpoint
                 if servers.https_endpoint is not None and ask_should_use_doh()
-                else None
+                else ""
             )
             exit_code = sandbox.run(
                 dns_function,


### PR DESCRIPTION
Fixes a regression in setting custom global DNS servers.

The sentinel value in `ask_custom_servers()` was previously changed from `""` to `None`, but without changing what was passed to the sandbox function, which cannot handle None arguments.