### PR TITLE
chore(po): add update_po.py script to update PO/POT files

### DIFF
--- a/files/po/audit_secureblue.pot
+++ b/files/po/audit_secureblue.pot
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-22 11:23-0400\n"
+"POT-Creation-Date: 2025-09-27 16:04-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -245,7 +245,7 @@ msgid "Ensuring system DNS resolution is secure"
 msgstr ""
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:445
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:908
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:934
 #, python-brace-format
 msgid "Unable to read file {0}."
 msgstr ""
@@ -320,7 +320,7 @@ msgstr ""
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:652
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:751
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:902
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:928
 msgid "To disable it, run:"
 msgstr ""
 
@@ -441,91 +441,101 @@ msgstr ""
 msgid "Ensuring hardened_malloc is set to be preloaded"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:841
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:856
+msgid "Your hardware does not support secure boot."
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:861
+msgid ""
+"The system will be unable to verify that kernel modules are signed or the "
+"boot process."
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:867
 msgid "Ensuring secure boot is enabled"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:874
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:900
 msgid "Bash environment is not locked down."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:875
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:901
 msgid "The following files do not appear to be immutable or do not exist:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:877
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:903
 msgid "To fix this, run:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:884
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:910
 msgid "Ensuring current user's bash environment is locked down"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:901
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:906
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:927
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:932
 msgid "Webcam module is enabled."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:911
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:937
 msgid "Checking whether webcam module is disabled"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:933
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:959
 #, python-brace-format
 msgid "{0} is configured with an unknown URL."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:936
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:962
 #, python-brace-format
 msgid "{0} is not a verified flatpak repository."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:939
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:965
 #, python-brace-format
 msgid "Auditing flatpak remote {0}"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:972
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:998
 #, python-brace-format
 msgid "Auditing {0}"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:988
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1014
 msgid "[Audit process interrupted. Exiting.]"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1001
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1027
 msgid "Audit secureblue configuration for security"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1005
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1031
 msgid "skip categories"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1006
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1032
 msgid "display output as JSON"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1010
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1036
 #, python-brace-format
 msgid "Valid arguments to {0} are: {1}"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1018
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1044
 #, python-brace-format
 msgid "*** Error in check '{0}' ***"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1020
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1046
 msgid "*** Continuing... ***"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1023
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1049
 #, python-brace-format
 msgid "Use option '{0}' to skip flatpak recommendations."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1026
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1052
 msgid "*** WARNING: Unexpected error occurred. ***"
 msgstr ""
 

--- a/files/po/de/audit_secureblue.po
+++ b/files/po/de/audit_secureblue.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-25 19:47-0400\n"
+"POT-Creation-Date: 2025-09-27 16:04-0400\n"
 "PO-Revision-Date: 2025-08-05 13:32+0200\n"
 "Last-Translator: MatsG23 <60609373+MatsG23@users.noreply.github.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -57,8 +57,8 @@ msgstr "Prüfe auf gehärtete Kernel-Parameter"
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:150
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:208
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:272
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:688
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:697
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:714
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:723
 #, python-brace-format
 msgid "The file {0} has been modified."
 msgstr "Die Datei {0} wurde geändert."
@@ -185,21 +185,20 @@ msgid "Ensuring USBGuard is active"
 msgstr "Prüfe auf USBGuard"
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:348
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:446
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:477
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:566
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:472
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:503
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:592
 #, python-brace-format
 msgid "{0} is enabled but has failed to run."
 msgstr "{0} ist aktiviert, aber schlug fehl."
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:351
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:571
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:597
 #, python-brace-format
 msgid "{0} is not enabled."
 msgstr "{0} ist nicht aktiviert."
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:352
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:399
 msgid "To start and enable it, run:"
 msgstr "Um es zu starten und aktivieren, führe aus:"
 
@@ -207,235 +206,241 @@ msgstr "Um es zu starten und aktivieren, führe aus:"
 msgid "Ensuring chronyd is active"
 msgstr "Prüfe auf chronyd"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:366
-msgid "System DNS resolution is not secure."
-msgstr "Die systemweite DNS-Auflösung ist nicht sicher."
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:382
+msgid "DNS over HTTPS in Trivalent is disabled."
+msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:376
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:419
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:882
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:386
+msgid "Consider using DNS over HTTPS in Trivalent to hide queries."
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:387
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:402
+msgid "However, if you use a VPN, this may cause DNS leaks."
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:388
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:403
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:417
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:454
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:480
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:509
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:540
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:575
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:600
+msgid "To enable it, run:"
+msgstr "Zum Aktivieren, führe aus:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:397
+msgid "Secure global DNS is not configured."
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:401
+msgid "Consider using secure global DNS."
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:412
+msgid "Local DNSSEC validation is disabled."
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:416
+msgid "You should enable local DNSSEC validation to prevent DNS hijacking."
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:428
+msgid "Ensuring system DNS resolution is secure"
+msgstr "Prüfe auf sichere systemweite DNS-Auflösung"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:445
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:934
 #, python-brace-format
 msgid "Unable to read file {0}."
 msgstr "Datei {0} kann nicht gelesen werden."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:383
-msgid "System DNS resolution is not secure (opportunistic DNS-over-TLS only)."
-msgstr ""
-"Die systemweite DNS-Auflösung ist nicht sicher (nur opportunistisches DNS-"
-"over-TLS)."
-
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:390
-msgid "To select a secure resolver, run:"
-msgstr "Zur Auswahl eines sicheren DNS-Auflösers, führe aus:"
-
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:392
-msgid "If you are using a VPN, you may want to disregard this recommendation."
-msgstr ""
-"Falls du ein VPN verwendest, kannst du diese Empfehlung wahrscheinlich "
-"ignorieren."
-
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:398
-#, python-brace-format
-msgid "{0} is inactive."
-msgstr "{0} ist inaktiv."
-
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:403
-msgid "Ensuring system DNS resolution is secure"
-msgstr "Prüfe auf sichere systemweite DNS-Auflösung"
-
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:427
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:453
 msgid "MAC randomization is not enabled."
 msgstr "MAC-Randomisierung ist nicht aktiv."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:428
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:454
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:483
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:514
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:549
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:574
-msgid "To enable it, run:"
-msgstr "Zum Aktivieren, führe aus:"
-
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:434
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:460
 msgid "Ensuring MAC randomization is enabled"
 msgstr "Prüfe auf aktive MAC-Randomisierung"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:451
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:480
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:477
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:506
 #, python-brace-format
 msgid "{0} is disabled."
 msgstr "{0} ist deaktiviert."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:459
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:488
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:579
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:485
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:514
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:605
 #, python-brace-format
 msgid "Ensuring {0} is enabled"
 msgstr "Prüfe auf {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:506
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:541
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:532
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:567
 #, python-brace-format
 msgid "{0} is enabled globally but has failed to run."
 msgstr "{0} ist systemweit aktiviert, aber schlug fehl."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:511
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:546
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:537
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:572
 #, python-brace-format
 msgid "{0} is not enabled globally."
 msgstr "{0} ist nicht systemweit aktiviert."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:519
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:554
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:545
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:580
 #, python-brace-format
 msgid "Ensuring {0} is enabled globally"
 msgstr "Prüfe auf {0} (systemweit)"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:591
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:617
 msgid "The current user is in the wheel group."
 msgstr "Der aktuelle Benutzer ist in der wheel Gruppe."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:592
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:618
 msgid "To set up a separate wheel account, follow the instructions here:"
 msgstr ""
 "Um ein seperates wheel-Konto zu erstellen, befolge die hier verlinkten "
 "Schritte:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:600
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:626
 msgid "Ensuring user is not a member of the wheel group"
 msgstr "Prüfe auf wheel Gruppenmitgliedschaft"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:609
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:635
 msgid "GNOME"
 msgstr "GNOME"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:612
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:638
 msgid "KDE Plasma"
 msgstr "KDE Plasma"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:615
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:641
 msgid "Sway"
 msgstr "Sway"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:625
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:651
 #, python-brace-format
 msgid "Xwayland is enabled for {0}."
 msgstr "Xwayland ist für {0} aktiviert."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:626
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:725
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:876
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:652
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:751
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:928
 msgid "To disable it, run:"
 msgstr "Zum Deaktivieren, führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:630
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:656
 #, python-brace-format
 msgid "Ensuring {0} is disabled for {1}"
 msgstr "Prüfe {0} Status für {1}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:653
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:679
 msgid "GNOME user extensions are enabled."
 msgstr "GNOME Nutzer-Erweiterungen sind aktiv."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:654
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:680
 msgid "To disable this, run:"
 msgstr "Zum Deaktivieren, führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:658
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:684
 msgid "Ensuring GNOME user extensions are disabled"
 msgstr "Prüfe auf GNOME Nutzer-Erweiterungen"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:670
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:696
 msgid "SELinux is in Permissive mode."
 msgstr "SELinux ist im Permissive Modus."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:671
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:697
 msgid "To set it to Enforcing mode, run:"
 msgstr "Um SELinux in den Enforcing Modus zu wechseln, führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:675
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:701
 msgid "Ensuring SELinux is in Enforcing mode"
 msgstr "Prüfe auf SELinux Enforcing Modus"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:691
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:717
 #, python-brace-format
 msgid "The file {0} has been deleted."
 msgstr "Die Datei {0} wurde gelöscht."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:694
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:720
 #, python-brace-format
 msgid "The file {0} cannot be read."
 msgstr "Die Datei {0} kann nicht gelesen werden."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:698
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:724
 msgid "To reset it, run:"
 msgstr "Um sie zurückzusetzen, führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:702
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:728
 msgid "Ensuring no environment file overrides"
 msgstr "Prüfe auf modifizierte Umgebungsdateien"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:718
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:744
 #, python-brace-format
 msgid "The file {0} was not found or inaccessible."
 msgstr "Die Datei {0} wurde nicht gefunden oder der Zugriff wurde verweigert."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:724
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:750
 msgid "KDE GNHS is enabled."
 msgstr "KDE GNHS ist aktiv."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:731
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:757
 msgid "Ensuring KDE GHNS is disabled"
 msgstr "Prüfe auf KDE GHNS"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:745
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:771
 #, python-brace-format
 msgid "The file {0} was not found."
 msgstr "Die Datei {0} wurde nicht gefunden."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:752
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:778
 #, python-brace-format
 msgid "{0} has mode {1:o} (expected {2:o})"
 msgstr "{0} hat den Modus {1:o} ({2:o} erwartet)"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:756
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:782
 #, python-brace-format
 msgid "{0} is owned by a non-root user!"
 msgstr "{0} gehört nicht dem root-Benutzer!"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:759
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:785
 #, python-brace-format
 msgid "The file {0} has been modified or deleted."
 msgstr "Die Datei {0} wurde geändert oder gelöscht."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:760
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:786
 msgid "To reset it and enable hardened_malloc for system processes, run:"
 msgstr ""
 "Um sie zurückzusetzen und hardened_malloc für Systemprozesse zu aktivieren, "
 "führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:765
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:791
 #, python-brace-format
 msgid "Ensuring {0} has expected permissions"
 msgstr "Prüfe auf erwartete Dateiberechtigungen für {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:783
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:809
 #, python-brace-format
 msgid "{0} is set, but {1} has been modified."
 msgstr "{0} ist gesetzt, aber {1} wurde geändert."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:788
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:791
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:814
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:817
 #, python-brace-format
 msgid "The '{0}' variant of {1} has been set."
 msgstr "Die '{0}' Variante von {1} wurde gesetzt."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:794
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:820
 #, python-brace-format
 msgid "{0} has not been set."
 msgstr "{0} wurde nicht gesetzt."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:797
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:823
 #, python-brace-format
 msgid ""
 "The environment variable {0} has been modified or is unset.\n"
@@ -446,98 +451,108 @@ msgstr ""
 "                Prüfe, dass {1} nicht in {2} oder zugehörigen\n"
 "                Konfigurationsdateien überschrieben wurde."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:803
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:829
 msgid "Ensuring hardened_malloc is set to be preloaded"
 msgstr "Prüfe auf hardened_malloc"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:815
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:856
+msgid "Your hardware does not support secure boot."
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:861
+msgid ""
+"The system will be unable to verify that kernel modules are signed or the "
+"boot process."
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:867
 msgid "Ensuring secure boot is enabled"
 msgstr "Prüfe auf Secure Boot"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:848
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:900
 msgid "Bash environment is not locked down."
 msgstr "Die Bash-Umgebung ist nicht abgesichert."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:849
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:901
 msgid "The following files do not appear to be immutable or do not exist:"
 msgstr ""
 "Die folgenden Dateien scheinen nicht schreibgeschützt zu sein oder "
 "existieren nicht:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:851
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:903
 msgid "To fix this, run:"
 msgstr "Um dies zu beheben, führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:858
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:910
 msgid "Ensuring current user's bash environment is locked down"
 msgstr "Prüfe auf abgesicherte Bash-Umgebung"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:875
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:880
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:927
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:932
 msgid "Webcam module is enabled."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:885
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:937
 msgid "Checking whether webcam module is disabled"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:907
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:959
 #, python-brace-format
 msgid "{0} is configured with an unknown URL."
 msgstr "{0} ist mit einer unbekannten URL konfiguriert."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:910
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:962
 #, python-brace-format
 msgid "{0} is not a verified flatpak repository."
 msgstr "{0} ist kein geprüftes Flatpak-Repository."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:913
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:965
 #, python-brace-format
 msgid "Auditing flatpak remote {0}"
 msgstr "Prüfe Flatpak Remote {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:946
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:998
 #, python-brace-format
 msgid "Auditing {0}"
 msgstr "Prüfe {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:962
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1014
 msgid "[Audit process interrupted. Exiting.]"
 msgstr "[Prüfprozess wurde unterbrochen. Abbruch.]"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:975
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1027
 msgid "Audit secureblue configuration for security"
 msgstr "Prüft die secureblue Konfiguration auf Sicherheit"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:979
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1031
 msgid "skip categories"
 msgstr "überspringe Kategorien"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:980
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1032
 msgid "display output as JSON"
 msgstr "Ausgabe als JSON anzeigen"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:984
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1036
 #, python-brace-format
 msgid "Valid arguments to {0} are: {1}"
 msgstr "Gültige Argumente für {0} sind: {1}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:992
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1044
 #, python-brace-format
 msgid "*** Error in check '{0}' ***"
 msgstr "*** Fehler in Test '{0}' ***"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:994
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1046
 msgid "*** Continuing... ***"
 msgstr "*** Fortfahren... ***"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:997
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1049
 #, python-brace-format
 msgid "Use option '{0}' to skip flatpak recommendations."
 msgstr ""
 "Verwende die Option '{0}' um Empfehlungen für Flatpaks zu überspringen."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1000
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1052
 msgid "*** WARNING: Unexpected error occurred. ***"
 msgstr "*** WARNUNG: Ein unerwarteter Fehler trat auf. ***"
 
@@ -597,20 +612,20 @@ msgid "The following flatpak app(s) have {0}:"
 msgstr "Folgende Flatpak-Anwendungen haben {0}:"
 
 #: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:165
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:313
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:376
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:415
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:348
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:411
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:452
 msgid "To remove this permission from an app, use Flatseal or run:"
 msgstr ""
 "Um diese Berechtigung von einer Anwendung zu entfernen, verwende Flatseal "
 "oder führe aus:"
 
 #: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:167
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:296
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:315
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:378
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:398
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:417
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:297
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:350
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:413
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:433
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:454
 #, python-brace-format
 msgid "(replacing \"{0}\" with the flatpak app ID)"
 msgstr "(ersetze \"{0}\" mit der ID der Flatpak-Anwendung)"
@@ -682,104 +697,111 @@ msgstr "Zugriff auf Bluetooth"
 msgid "ptrace access"
 msgstr "Zugriff auf ptrace"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:263
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:264
 #, python-brace-format
 msgid "{0} can acquire arbitrary permissions."
 msgstr "{0} kann beliebige Berechtigungen erlangen."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:266
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:267
 msgid "However, this is required for its functionality."
 msgstr "Dies ist jedoch für die Funktionalität erforderlich."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:280
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:281
 #, python-brace-format
 msgid "{0} is not requesting {1}"
 msgstr "{0} fragt nicht {1} an"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:284
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:288
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:285
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:289
 #, python-brace-format
 msgid "{0} is requesting {1}"
 msgstr "{0} fragt {1} an"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:292
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:293
 #, python-brace-format
 msgid "The following flatpak app(s) are not requesting {0}:"
 msgstr "Folgende Flatpak-Anwendungen fragen {0} nicht an:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:294
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:295
 msgid "To enable it for an app, run:"
 msgstr "Um es für eine Anwendung zu aktivieren, führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:308
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:341
 #, python-brace-format
 msgid "The following flatpak app(s) can talk to {0} on the session bus:"
 msgstr ""
 "Folgende Flatpak-Anwendungen können mit {0} auf dem Session Bus "
 "kommunizieren:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:312
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:414
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:343
+#, fuzzy, python-brace-format
+msgid "The following flatpak app(s) can talk to {0} on the system bus:"
+msgstr ""
+"Folgende Flatpak-Anwendungen können mit {0} auf dem Session Bus "
+"kommunizieren:"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:347
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:451
 msgid "This grants the ability to acquire arbitrary permissions."
 msgstr ""
 "Dies ermöglicht es fer Anwendung, beliebige Berechtigungen zu erlangen."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:353
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:388
 msgid "all system files"
 msgstr "alle Systemdateien"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:354
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:389
 msgid "all user files"
 msgstr "alle Benutzerdateien"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:355
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:390
 msgid "other applications' configuration files"
 msgstr "Konfigurationsdateien anderer Anwendungen"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:356
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:391
 msgid "other applications' cache files"
 msgstr "Cachedateien anderer Anwendungen"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:357
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:392
 msgid "other applications' data files"
 msgstr "Speicherdateien anderer Anwendungen"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:368
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:403
 #, python-brace-format
 msgid "{0} has {1} permission"
 msgstr "{0} hat die {1} Berechtigung"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:371
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:406
 #, python-brace-format
 msgid "The following flatpak app(s) have {0} permission:"
 msgstr "Folgende Flatpak-Anwendungen haben die {0} Berechtigung:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:375
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:410
 #, python-brace-format
 msgid "This grants access to {0}."
 msgstr "Dies gewährt Zugriff auf {0}."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:391
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:426
 #, python-brace-format
 msgid "{0} is missing {1} permission"
 msgstr "{0} fehlt die {1} Berechtigung"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:393
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:428
 #, python-brace-format
 msgid "The following flatpak app(s) are missing {0} permission:"
 msgstr "Folgenden Flatpak-Anwendungen fehlt die {0} Berechtigung:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:395
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:430
 msgid "This is required to load hardened_malloc."
 msgstr "Dies ist erforderlich um hardened_malloc zu laden."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:396
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:431
 msgid "To add this permission to an app, use Flatseal or run:"
 msgstr ""
 "Um einer App diese Berechtigung zu gewähren, verwende Flatseal oder führe "
 "aus:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:412
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:449
 msgid "The following flatpak app(s) can modify flatpak overrides:"
 msgstr ""
 "Folgende Flatpak-Anwendungen können Flatpak-Überschreibungen vornehmen:"
@@ -880,3 +902,25 @@ msgstr ""
 "als auffällig gemeldete Berechtigungen bedeuten nicht notwendigerweise,\n"
 "            dass eine Änderung vorgenommen werden sollte.\n"
 "            "
+
+#~ msgid "System DNS resolution is not secure."
+#~ msgstr "Die systemweite DNS-Auflösung ist nicht sicher."
+
+#~ msgid ""
+#~ "System DNS resolution is not secure (opportunistic DNS-over-TLS only)."
+#~ msgstr ""
+#~ "Die systemweite DNS-Auflösung ist nicht sicher (nur opportunistisches DNS-"
+#~ "over-TLS)."
+
+#~ msgid "To select a secure resolver, run:"
+#~ msgstr "Zur Auswahl eines sicheren DNS-Auflösers, führe aus:"
+
+#~ msgid ""
+#~ "If you are using a VPN, you may want to disregard this recommendation."
+#~ msgstr ""
+#~ "Falls du ein VPN verwendest, kannst du diese Empfehlung wahrscheinlich "
+#~ "ignorieren."
+
+#, python-brace-format
+#~ msgid "{0} is inactive."
+#~ msgstr "{0} ist inaktiv."

--- a/files/po/en/audit_secureblue.po
+++ b/files/po/en/audit_secureblue.po
@@ -16,8 +16,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-22 11:23-0400\n"
-"PO-Revision-Date: 2025-09-22 11:23-0400\n"
+"POT-Creation-Date: 2025-09-27 16:04-0400\n"
+"PO-Revision-Date: 2025-09-27 16:04-0400\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en_US\n"
@@ -250,7 +250,7 @@ msgid "Ensuring system DNS resolution is secure"
 msgstr "Ensuring system DNS resolution is secure"
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:445
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:908
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:934
 #, python-brace-format
 msgid "Unable to read file {0}."
 msgstr "Unable to read file {0}."
@@ -325,7 +325,7 @@ msgstr "Xwayland is enabled for {0}."
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:652
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:751
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:902
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:928
 msgid "To disable it, run:"
 msgstr "To disable it, run:"
 
@@ -449,91 +449,103 @@ msgstr ""
 msgid "Ensuring hardened_malloc is set to be preloaded"
 msgstr "Ensuring hardened_malloc is set to be preloaded"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:841
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:856
+msgid "Your hardware does not support secure boot."
+msgstr "Your hardware does not support secure boot."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:861
+msgid ""
+"The system will be unable to verify that kernel modules are signed or the "
+"boot process."
+msgstr ""
+"The system will be unable to verify that kernel modules are signed or the "
+"boot process."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:867
 msgid "Ensuring secure boot is enabled"
 msgstr "Ensuring secure boot is enabled"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:874
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:900
 msgid "Bash environment is not locked down."
 msgstr "Bash environment is not locked down."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:875
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:901
 msgid "The following files do not appear to be immutable or do not exist:"
 msgstr "The following files do not appear to be immutable or do not exist:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:877
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:903
 msgid "To fix this, run:"
 msgstr "To fix this, run:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:884
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:910
 msgid "Ensuring current user's bash environment is locked down"
 msgstr "Ensuring current user's bash environment is locked down"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:901
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:906
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:927
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:932
 msgid "Webcam module is enabled."
 msgstr "Webcam module is enabled."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:911
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:937
 msgid "Checking whether webcam module is disabled"
 msgstr "Checking whether webcam module is disabled"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:933
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:959
 #, python-brace-format
 msgid "{0} is configured with an unknown URL."
 msgstr "{0} is configured with an unknown URL."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:936
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:962
 #, python-brace-format
 msgid "{0} is not a verified flatpak repository."
 msgstr "{0} is not a verified flatpak repository."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:939
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:965
 #, python-brace-format
 msgid "Auditing flatpak remote {0}"
 msgstr "Auditing flatpak remote {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:972
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:998
 #, python-brace-format
 msgid "Auditing {0}"
 msgstr "Auditing {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:988
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1014
 msgid "[Audit process interrupted. Exiting.]"
 msgstr "[Audit process interrupted. Exiting.]"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1001
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1027
 msgid "Audit secureblue configuration for security"
 msgstr "Audit secureblue configuration for security"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1005
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1031
 msgid "skip categories"
 msgstr "skip categories"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1006
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1032
 msgid "display output as JSON"
 msgstr "display output as JSON"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1010
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1036
 #, python-brace-format
 msgid "Valid arguments to {0} are: {1}"
 msgstr "Valid arguments to {0} are: {1}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1018
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1044
 #, python-brace-format
 msgid "*** Error in check '{0}' ***"
 msgstr "*** Error in check '{0}' ***"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1020
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1046
 msgid "*** Continuing... ***"
 msgstr "*** Continuing... ***"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1023
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1049
 #, python-brace-format
 msgid "Use option '{0}' to skip flatpak recommendations."
 msgstr "Use option '{0}' to skip flatpak recommendations."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1026
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1052
 msgid "*** WARNING: Unexpected error occurred. ***"
 msgstr "*** WARNING: Unexpected error occurred. ***"
 

--- a/files/po/es/audit_secureblue.po
+++ b/files/po/es/audit_secureblue.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-22 11:23-0400\n"
+"POT-Creation-Date: 2025-09-27 16:04-0400\n"
 "PO-Revision-Date: 2025-09-22 23:20-0400\n"
 "Last-Translator: Cup-png <232283931+Cup-png@users.noreply.github.com>\n"
 "Language-Team: none\n"
@@ -80,7 +80,8 @@ msgid ""
 "            from the secureblue GitHub repository."
 msgstr ""
 "La imagen actual no está firmada.\n"
-"            Para cambiar a una imagen firmada, descargue y ejecute o vuelva a ejecutar {0}\n"
+"            Para cambiar a una imagen firmada, descargue y ejecute o vuelva "
+"a ejecutar {0}\n"
 "            desde el repositorio de GitHub de secureblue."
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:182
@@ -113,7 +114,8 @@ msgstr "Para prohibir ptrace, ejecute:"
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:235
 msgid "To allow restricted ptrace, run the above command twice."
-msgstr "Para permitir ptrace restringido, ejecute el comando de arriba doble vez."
+msgstr ""
+"Para permitir ptrace restringido, ejecute el comando de arriba doble vez."
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:241
 #, python-brace-format
@@ -139,7 +141,9 @@ msgstr "Asegurando que no hayan sobreescrituras de políticas de contenedores"
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:289
 msgid "Unconfined domain user namespace creation is permitted."
-msgstr "Creación del dominio de espacios de nombres de usuarios no confinados está permitido."
+msgstr ""
+"Creación del dominio de espacios de nombres de usuarios no confinados está "
+"permitido."
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:290
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:307
@@ -148,15 +152,21 @@ msgstr "Para prohibirlo, ejecute:"
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:294
 msgid "Ensuring unconfined user namespace creation disallowed"
-msgstr "Asegurando que la creación de espacios de nombres de usuarios no confinados está prohibida"
+msgstr ""
+"Asegurando que la creación de espacios de nombres de usuarios no confinados "
+"está prohibida"
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:306
 msgid "Container domain user namespace creation is permitted."
-msgstr "Creación del dominio de espacios de nombres de usuarios para el uso de contenedores está permitida."
+msgstr ""
+"Creación del dominio de espacios de nombres de usuarios para el uso de "
+"contenedores está permitida."
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:311
 msgid "Ensuring container user namespace creation disallowed"
-msgstr "Asegurando que la creación del dominio de espacios de nombres de usuarios para el uso de contenedores está prohibida"
+msgstr ""
+"Asegurando que la creación del dominio de espacios de nombres de usuarios "
+"para el uso de contenedores está prohibida"
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:323
 msgid "USBGuard is enabled but has failed to run."
@@ -175,8 +185,8 @@ msgid ""
 "Caution: if you have already set up USBGuard, this will overwrite the "
 "existing policy."
 msgstr ""
-"Precaución: si ya tiene activado USBGuard, esto sobreescribirá la "
-"política existente."
+"Precaución: si ya tiene activado USBGuard, esto sobreescribirá la política "
+"existente."
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:336
 msgid "Ensuring USBGuard is active"
@@ -210,7 +220,9 @@ msgstr "DNS mediante HTTPS en Trivalent está deshabilitado."
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:386
 msgid "Consider using DNS over HTTPS in Trivalent to hide queries."
-msgstr "Considere usar DNS mediante HTTPS en Trivalent para esconder consultas de búsqueda web."
+msgstr ""
+"Considere usar DNS mediante HTTPS en Trivalent para esconder consultas de "
+"búsqueda web."
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:387
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:402
@@ -243,14 +255,16 @@ msgstr "La validación de DNSSEC local está deshabilitada."
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:416
 msgid "You should enable local DNSSEC validation to prevent DNS hijacking."
-msgstr "De preferencia habilite la validación de DNSSEC local para prevenir envenenamiento de DNS."
+msgstr ""
+"De preferencia habilite la validación de DNSSEC local para prevenir "
+"envenenamiento de DNS."
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:428
 msgid "Ensuring system DNS resolution is secure"
 msgstr "Asegurando que la resolución de conexión DNS sea segura"
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:445
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:908
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:934
 #, python-brace-format
 msgid "Unable to read file {0}."
 msgstr "No es posible leer el archivo {0}."
@@ -325,7 +339,7 @@ msgstr "Xwayland está habilitado para {0}"
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:652
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:751
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:902
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:928
 msgid "To disable it, run:"
 msgstr "Para deshabilitarlo, ejecute:"
 
@@ -344,7 +358,8 @@ msgstr "Para deshabilitar esto, ejecute:"
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:684
 msgid "Ensuring GNOME user extensions are disabled"
-msgstr "Asegurando que las extensiones de usuarios de GNOME están deshabilitadas"
+msgstr ""
+"Asegurando que las extensiones de usuarios de GNOME están deshabilitadas"
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:696
 msgid "SELinux is in Permissive mode."
@@ -374,7 +389,8 @@ msgstr "Para restablecerlo, ejecute:"
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:728
 msgid "Ensuring no environment file overrides"
-msgstr "Asegurando que no hayan sobreescrituras de variables de entorno de archivos"
+msgstr ""
+"Asegurando que no hayan sobreescrituras de variables de entorno de archivos"
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:744
 #, python-brace-format
@@ -411,7 +427,9 @@ msgstr "El archivo {0} ha sido modificado o eliminado."
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:786
 msgid "To reset it and enable hardened_malloc for system processes, run:"
-msgstr "Para restablecer y habilitar hardened_malloc para procesos del sistema, ejecute:"
+msgstr ""
+"Para restablecer y habilitar hardened_malloc para procesos del sistema, "
+"ejecute:"
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:791
 #, python-brace-format
@@ -449,91 +467,103 @@ msgstr ""
 msgid "Ensuring hardened_malloc is set to be preloaded"
 msgstr "Asegurando que hardened_malloc está listo para ser precargado"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:841
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:856
+msgid "Your hardware does not support secure boot."
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:861
+msgid ""
+"The system will be unable to verify that kernel modules are signed or the "
+"boot process."
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:867
 msgid "Ensuring secure boot is enabled"
 msgstr "Asegurando que el arranque seguro está habilitado"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:874
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:900
 msgid "Bash environment is not locked down."
 msgstr "Las variables de entorno de Bash no están confinadas."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:875
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:901
 msgid "The following files do not appear to be immutable or do not exist:"
 msgstr "Los siguientes archivos no parecen ser inmutables o no existen:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:877
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:903
 msgid "To fix this, run:"
 msgstr "Para solucionar esto, ejecute:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:884
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:910
 msgid "Ensuring current user's bash environment is locked down"
-msgstr "Asegurando que las variables de entorno de Bash del usuario están confinadas"
+msgstr ""
+"Asegurando que las variables de entorno de Bash del usuario están confinadas"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:901
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:906
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:927
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:932
 msgid "Webcam module is enabled."
 msgstr "El módulo de la cámara web está habilitado."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:911
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:937
 msgid "Checking whether webcam module is disabled"
 msgstr "Verificando si el módulo de la cámara web está habilitado."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:933
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:959
 #, python-brace-format
 msgid "{0} is configured with an unknown URL."
 msgstr "{0} está configurado con una URL desconocida."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:936
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:962
 #, python-brace-format
 msgid "{0} is not a verified flatpak repository."
 msgstr "{0} no es un repositorio de flatpaks verificados."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:939
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:965
 #, python-brace-format
 msgid "Auditing flatpak remote {0}"
 msgstr "Verificando repositorio remoto de flatpaks {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:972
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:998
 #, python-brace-format
 msgid "Auditing {0}"
 msgstr "Verificando {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:988
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1014
 msgid "[Audit process interrupted. Exiting.]"
 msgstr "[Proceso de verificación interrumpido. Saliendo.]"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1001
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1027
 msgid "Audit secureblue configuration for security"
 msgstr "Verificando la configuración de secureblue para seguridad"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1005
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1031
 msgid "skip categories"
 msgstr "saltarse categorías"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1006
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1032
 msgid "display output as JSON"
 msgstr "mostrar salida de datos como JSON"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1010
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1036
 #, python-brace-format
 msgid "Valid arguments to {0} are: {1}"
 msgstr "Argumentos válidos de {0} son: {1}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1018
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1044
 #, python-brace-format
 msgid "*** Error in check '{0}' ***"
 msgstr "*** Error en la verificación '{0}' ***"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1020
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1046
 msgid "*** Continuing... ***"
 msgstr "*** Continuando... ***"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1023
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1049
 #, python-brace-format
 msgid "Use option '{0}' to skip flatpak recommendations."
-msgstr "Use la opción '{0}' para saltarse las recomendaciones para los flatpaks."
+msgstr ""
+"Use la opción '{0}' para saltarse las recomendaciones para los flatpaks."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1026
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1052
 msgid "*** WARNING: Unexpected error occurred. ***"
 msgstr "*** ADVERTENCIA: Ha ocurrido un error inesperado. ***"
 
@@ -642,8 +672,7 @@ msgstr "acceso al protocolo SSH agent"
 
 #: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:201
 msgid "This grants access to input devices, GPUs, raw USB, and virtualization."
-msgstr ""
-"Esto otorga acceso a periféricos, GPUs, USB raw, y virtualización."
+msgstr "Esto otorga acceso a periféricos, GPUs, USB raw, y virtualización."
 
 #: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:203
 #, python-brace-format
@@ -706,12 +735,14 @@ msgstr "Para habilitarlo para una aplicación, ejecute:"
 #: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:341
 #, python-brace-format
 msgid "The following flatpak app(s) can talk to {0} on the session bus:"
-msgstr "Los siguientes flatpaks pueden comunicarse con {0} en el bus de sesión:"
+msgstr ""
+"Los siguientes flatpaks pueden comunicarse con {0} en el bus de sesión:"
 
 #: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:343
 #, python-brace-format
 msgid "The following flatpak app(s) can talk to {0} on the system bus:"
-msgstr "Los siguientes flatpaks pueden comunicarse con {0} en el bus de sesión:"
+msgstr ""
+"Los siguientes flatpaks pueden comunicarse con {0} en el bus de sesión:"
 
 #: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:347
 #: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:451
@@ -773,11 +804,14 @@ msgstr "Para añadir este permiso a una aplicación, use Flatseal o ejecute:"
 
 #: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:449
 msgid "The following flatpak app(s) can modify flatpak overrides:"
-msgstr "Los siguientes flatpaks pueden modificar los permisos de otros flatpaks:"
+msgstr ""
+"Los siguientes flatpaks pueden modificar los permisos de otros flatpaks:"
 
 #: files/system/usr/libexec/secureblue/utils/__init__.py:54
 msgid "*** WARNING: Running audit script as root is not recommended. ***"
-msgstr "*** ADVERTENCIA: Ejecutar el script de verificación como usuario root no es recomendado. ***"
+msgstr ""
+"*** ADVERTENCIA: Ejecutar el script de verificación como usuario root no es "
+"recomendado. ***"
 
 #: files/system/usr/libexec/secureblue/utils/__init__.py:55
 msgid "*** Some results may be misleading or incomplete. ***"
@@ -787,7 +821,8 @@ msgstr "*** Algunos resultados pueden ser engañosos o estar imcompletos. ***"
 msgid ""
 "The following status indicators accompany checks run by the audit script:"
 msgstr ""
-"Los siguientes indicadores de estado están acompañados de revisión por el script de verificación:"
+"Los siguientes indicadores de estado están acompañados de revisión por el "
+"script de verificación:"
 
 #: files/system/usr/libexec/secureblue/utils/__init__.py:86
 msgid "check failed - the configuration may be less secure."
@@ -803,11 +838,15 @@ msgstr "la verificación approbó - ningún problema detectado."
 
 #: files/system/usr/libexec/secureblue/utils/__init__.py:89
 msgid "unable to perform check (usually due to a file permission issue)."
-msgstr "no es posible realizar la verificación (usualmente debido a un problema de permisos del archivo)."
+msgstr ""
+"no es posible realizar la verificación (usualmente debido a un problema de "
+"permisos del archivo)."
 
 #: files/system/usr/libexec/secureblue/utils/__init__.py:94
 msgid "For flatpak checks, the status indicators have more specific meanings:"
-msgstr "Para revisión de flatpaks, los indicadores de estado tienen significados más especificos:"
+msgstr ""
+"Para revisión de flatpaks, los indicadores de estado tienen significados más "
+"especificos:"
 
 #: files/system/usr/libexec/secureblue/utils/__init__.py:97
 msgid ""
@@ -816,9 +855,10 @@ msgid ""
 "system (e.g. access\n"
 "            to certain directories, direct D-Bus access, X11)."
 msgstr ""
-"la aplicación tiene permisos que pueden ser usados para escapar del sandbox, permitirle\n"
-"            que modifique sus propios permisos, u otorgarle acceso muy amplio al sistema "
-"(ej. acceso\n"
+"la aplicación tiene permisos que pueden ser usados para escapar del sandbox, "
+"permitirle\n"
+"            que modifique sus propios permisos, u otorgarle acceso muy "
+"amplio al sistema (ej. acceso\n"
 "            a ciertos directorios, acceso directo a D-Bus, X11)."
 
 #: files/system/usr/libexec/secureblue/utils/__init__.py:100
@@ -827,9 +867,10 @@ msgid ""
 "            weaken security (e.g. PulseAudio, Bluetooth, not using "
 "hardened_malloc)."
 msgstr ""
-"la aplicación tiene permisos con potencial para ser usados para escapar del sandbox o\n"
-"            que puedan reducir la seguridad (ej. PulseAudio, Bluetooth, no usar "
-"hardened_malloc)."
+"la aplicación tiene permisos con potencial para ser usados para escapar del "
+"sandbox o\n"
+"            que puedan reducir la seguridad (ej. PulseAudio, Bluetooth, no "
+"usar hardened_malloc)."
 
 #: files/system/usr/libexec/secureblue/utils/__init__.py:102
 msgid ""
@@ -837,13 +878,16 @@ msgid ""
 "            attack surface or have privacy implications (e.g. network "
 "access)."
 msgstr ""
-"no se detectaron posibles vectores de escape del sandbox pero algunos permisos podrían incrementar\n"
-"            la superficie de ataque o tener implicaciones de privacidad (ej. acceso"
-"a la red)."
+"no se detectaron posibles vectores de escape del sandbox pero algunos "
+"permisos podrían incrementar\n"
+"            la superficie de ataque o tener implicaciones de privacidad (ej. "
+"accesoa la red)."
 
 #: files/system/usr/libexec/secureblue/utils/__init__.py:104
 msgid "no app permissions flagged (however, not all permissions are audited)."
-msgstr "ningún permiso de aplicación fue señalado (sin embargo, no todos los permisos son verificados)."
+msgstr ""
+"ningún permiso de aplicación fue señalado (sin embargo, no todos los "
+"permisos son verificados)."
 
 #: files/system/usr/libexec/secureblue/utils/__init__.py:110
 msgid ""
@@ -853,8 +897,8 @@ msgid ""
 "should be taken.\n"
 "            "
 msgstr ""
-"            Note que algunos flatpaks requieren permisos amplios para"
-" funcionar. Los permisos señalados\n"
-"            por el script de verificación no necesariamente indican que"
-" se debería tomar alguna acción.\n"
+"            Note que algunos flatpaks requieren permisos amplios para "
+"funcionar. Los permisos señalados\n"
+"            por el script de verificación no necesariamente indican que se "
+"debería tomar alguna acción.\n"
 "            "

--- a/files/po/po-source-files.json
+++ b/files/po/po-source-files.json
@@ -1,0 +1,8 @@
+{
+    "audit_secureblue": [
+        "files/system/usr/libexec/secureblue/audit_secureblue.py",
+        "files/system/usr/libexec/secureblue/auditor/__init__.py",
+        "files/system/usr/libexec/secureblue/audit_flatpak/__init__.py",
+        "files/system/usr/libexec/secureblue/utils/__init__.py"
+    ]
+}

--- a/files/po/update_po.py
+++ b/files/po/update_po.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+"""
+Run this script to update POT and PO files to reflect source code changes.
+"""
+
+import glob
+import json
+import os
+import subprocess  # nosec
+import sys
+from typing import Final
+
+COPYRIGHT_HEADER: Final[bytes] = b"""\
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+
+DEFAULT_COPYRIGHT_HEADER: Final[bytes] = b"""\
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+"""
+
+SOURCE_FILES_PATH: Final[str] = "files/po/po-source-files.json"
+
+
+def command_stdout(*args: str) -> bytes:
+    """Run a command in the shell and return the contents of stdout."""
+    # We only call this with trusted inputs and do not set shell=True.
+    # nosemgrep: dangerous-subprocess-use-audit
+    return subprocess.run(args, check=True, capture_output=True).stdout.strip()  # nosec
+
+
+os.chdir(os.path.dirname(sys.argv[0]))
+git_root = command_stdout("git", "rev-parse", "--show-toplevel")
+os.chdir(git_root)
+
+with open(SOURCE_FILES_PATH, encoding="utf8") as f:
+    domain_map = json.load(f)
+
+for domain, source_files in domain_map.items():
+    pot_path = f"files/po/{domain}.pot"
+    pot_contents = command_stdout("xgettext", "-d", domain, "-o", "-", *source_files)
+    pot_contents = pot_contents.replace(DEFAULT_COPYRIGHT_HEADER, COPYRIGHT_HEADER, 1)
+    if not pot_contents.endswith(b"\n"):
+        pot_contents += b"\n"
+    with open(pot_path, "wb") as f:
+        f.write(pot_contents)
+
+    for po_path in glob.iglob(f"files/po/*/{glob.escape(domain)}.po"):
+        if po_path.startswith("files/po/en/"):
+            subprocess.run(
+                ["msginit", "-i", pot_path, "-o", po_path, "--no-translator"], check=True
+            )  # nosec
+        else:
+            subprocess.run(["msgmerge", "--backup=none", "--update", po_path, pot_path], check=True)  # nosec

--- a/ruff.toml
+++ b/ruff.toml
@@ -41,5 +41,8 @@ pycodestyle.max-doc-length = 100
 pylint.max-statements = 40
 
 [lint.per-file-ignores]
-# Don't require audit checks' function signatures to have type hints
+# Don't require audit checks' function signatures to have type hints.
 "files/system/usr/libexec/secureblue/audit_secureblue.py" = ["ANN"]
+
+# Allow partial executable paths in subprocess invocations in this script.
+"files/po/update_po.py" = ["S607"]


### PR DESCRIPTION
The script at `files/po/update_po.py` carries out the following steps for each gettext domain (which currently only includes `audit_secureblue` but in the future will presumably include others):

* Use `xgettext` to update the POT file to reflect changes to the source code.
* Use `msginit` to update the English-language PO file (which doesn't require a translator).
* Use `msgmerge` to update other locales' PO files based on the updated POT file; new or modified strings will then need to be filled in by the translators.

The list of domains and their corresponding source files is stored in `files/po/po-source-files.json`.

These steps were previously done individually, and it's easier to just run this script, which also keeps track of which source files are associated to which gettext domain. PR authors will still need to run this script manually unless we figure out a way to automate it.

Also update PO/POT files using this script.