### PR TITLE
feat: add ujust completions for fish

### DIFF
--- a/files/scripts/createjustcompletions.sh
+++ b/files/scripts/createjustcompletions.sh
@@ -12,6 +12,12 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-set -oue pipefail
+set -euo pipefail
 
-just --completions bash | sed -E 's/([\(_" ])just/\1ujust/g' > /usr/share/bash-completion/completions/ujust
+umask 022
+
+mkdir -p /usr/share/bash-completion/completions
+just --completions bash | sed -E 's/([\(_" ])just\>/\1ujust/g' > /usr/share/bash-completion/completions/ujust
+
+mkdir -p /usr/share/fish/vendor_completions.d
+just --completions fish | sed -E 's/([\(_" ])just\>/\1ujust/g' > /usr/share/fish/vendor_completions.d/ujust.fish


### PR DESCRIPTION
ujust completions are already added for bash. This adds completions for fish as well; they are added to `/usr/share/fish/vendor_completions.d`, which fish searches for completions. This makes ujust easier to use for users who choose to install fish.

Also tweak replacement regex to avoid unintentionally replacing "justfile" with "ujustfile".