### PR TITLE
feat: add support for multiple paths to label-external-drives ujust

### DIFF
--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -223,10 +223,6 @@ label-external-drives:
         for dir in "$media_path"*/
         do
             echo
-            if [[ "$dir" =~ "'" ]]; then
-                echo "WARNING: Single quotes in drive labels are forbidden to avoid command execution, skipping drive \"$dir\"..."
-                continue
-            fi
             if [[ "$(stat -c '%U' "$dir")" != "$USER" ]]; then
                 echo "Drive root folder is not owned by you, skipping drive \"$dir\"..."
                 continue
@@ -243,7 +239,7 @@ label-external-drives:
             fi
             echo "Labeling drive mounted on \"$dir\" with $selabel"
             dir=${dir%*/} # remove trailing slash
-            if ! run0 sh -c "semanage fcontext -a -t $selabel '$dir(/.*)?' && restorecon -r '$dir'"; then
+            if ! run0 sh -c 'semanage fcontext -a -t "$1" "$2(/.*)?" && restorecon -r "$2"' sh "$selabel" "$dir"; then
                 echo 'Execution failed, aborting.'
                 exit 1
             fi

--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -201,7 +201,7 @@ rebase-secureblue:
 label-external-drives:
     #!/usr/bin/bash
     set -euo pipefail
-    media_paths=("/run/media/$USER/" "/var/mnt/")
+    media_paths=("/run/media/$USER/" "/mnt/")
     selabel="user_home_t"
     supported_fs=("ext2" "ext3" "ext4" "jfs" "xfs" "btrfs") # ref: https://wiki.gentoo.org/wiki/SELinux/FAQ#Can_I_use_SELinux_with_any_file_system.3F
 

--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -201,15 +201,11 @@ rebase-secureblue:
 label-external-drives:
     #!/usr/bin/bash
     set -euo pipefail
-    media_path="/run/media/$USER/"
+    media_paths=("/run/media/$USER/" "/var/mnt/")
     selabel="user_home_t"
     supported_fs=("ext2" "ext3" "ext4" "jfs" "xfs" "btrfs") # ref: https://wiki.gentoo.org/wiki/SELinux/FAQ#Can_I_use_SELinux_with_any_file_system.3F
 
-    if [ -z "$( ls -A "$media_path" 2>&- )" ]; then
-        echo "You don't have any drives mounted in \"$media_path\", aborting."
-        exit 0
-    fi
-    echo "Warning: This will label your drives mounted on \"$media_path\" such that they are treated as an extension to your home directory. (You can select which ones to label)"
+    echo "Warning: This will label your drives mounted on paths $(printf '"%s" and ' "${media_paths[@]}" | sed 's/ and $//') such that they are treated as an extension to your home directory. (You can select which ones to label)"
     echo 'If you do not want Trivalent to have access to these drives, do not proceed.'
     read -rp 'Are you sure you want to do this? [y/N] ' warning_proceed
     if ! [[ "$warning_proceed" == [Yy]* ]]; then
@@ -217,33 +213,41 @@ label-external-drives:
         exit 0
     fi
 
-    for dir in "$media_path"*/
-    do
-        echo
-        if [[ "$dir" =~ "'" ]]; then
-            echo "WARNING: Single quotes in drive labels are forbidden to avoid command execution, skipping drive \"$dir\"..."
+    for media_path in "${media_paths[@]}"; do
+        if [ -z "$( ls -A "$media_path" 2>&- )" ]; then
+            echo
+            echo "You don't have any drives mounted in \"$media_path\", skipping..."
             continue
         fi
-        if [[ "$(stat -c '%U' "$dir")" != "$USER" ]]; then
-            echo "Drive root folder is not owned by you, skipping drive \"$dir\"..."
-            continue
-        fi
-        detected_fs="$(df -T "$dir" | awk '{print $2}' | sed -n 2p)"
-        if ! printf "%s\n" "${supported_fs[@]}" | grep -Fxq "$detected_fs"; then
-            echo "SELinux support is unknown for filesystem $detected_fs, skipping drive \"$dir\"..."
-            continue
-        fi
-        read -rp "Do you want to label \"$dir\"? [y/N] " proceed
-        if ! [[ "$proceed" == [Yy]* ]]; then
-            echo 'Skipping...'
-            continue
-        fi
-        echo "Labeling drive mounted on \"$dir\" with $selabel"
-        dir=${dir%*/} # remove trailing slash
-        if ! run0 sh -c "semanage fcontext -a -t $selabel '$dir(/.*)?' && restorecon -r '$dir'"; then
-            echo 'Execution failed, aborting.'
-            exit 1
-        fi
+
+        for dir in "$media_path"*/
+        do
+            echo
+            if [[ "$dir" =~ "'" ]]; then
+                echo "WARNING: Single quotes in drive labels are forbidden to avoid command execution, skipping drive \"$dir\"..."
+                continue
+            fi
+            if [[ "$(stat -c '%U' "$dir")" != "$USER" ]]; then
+                echo "Drive root folder is not owned by you, skipping drive \"$dir\"..."
+                continue
+            fi
+            detected_fs="$(df -T "$dir" | awk '{print $2}' | sed -n 2p)"
+            if ! printf "%s\n" "${supported_fs[@]}" | grep -Fxq "$detected_fs"; then
+                echo "SELinux support is unknown for filesystem $detected_fs, skipping drive \"$dir\"..."
+                continue
+            fi
+            read -rp "Do you want to label \"$dir\"? [y/N] " proceed
+            if ! [[ "$proceed" == [Yy]* ]]; then
+                echo 'Skipping...'
+                continue
+            fi
+            echo "Labeling drive mounted on \"$dir\" with $selabel"
+            dir=${dir%*/} # remove trailing slash
+            if ! run0 sh -c "semanage fcontext -a -t $selabel '$dir(/.*)?' && restorecon -r '$dir'"; then
+                echo 'Execution failed, aborting.'
+                exit 1
+            fi
+        done
     done
 
     echo -e '\nDone.'


### PR DESCRIPTION
ref: https://discord.com/channels/1202086019298500629/1423041499460927538

Things that changed:
- Change `media_path` into array `media_paths` (and add `/mnt/` as new path).
- Add display logic for initial warning such that array elements are pretty-printed separated by `and` and quoted.
- Put all core logic into for-loop to iterate over `media_paths` -> `media_path`. (hence the ugly diff due to indentation changes; core logic is untouched)

Tested locally and ran through shellcheck.