### PR TITLE
feat: provide the option to disable the IPv6 stack

### DIFF
--- a/files/justfiles/common/kargs.just
+++ b/files/justfiles/common/kargs.just
@@ -28,6 +28,13 @@ set-kargs-hardening:
     else
         echo "Not force disabling SMT/Hyperthreading."
     fi
+    read -rp "Do you want to disable the IPv6 stack as a precaution while potentially reducing network performance? [y/N]: " YES
+    if [[ "$YES" == [Yy]* ]]; then
+        IPV6_NO="--append-if-missing=ipv6.disable=1"
+        echo "Disabling the IPv6 network stack."
+    else
+        echo "Retaining all IPv6 functionality."
+    fi
     read -rp "Would you like to set additional (unstable) hardening kargs? (Warning: Setting these kargs may lead to boot or stability issues on some hardware.) [y/N]: " YES
     if [[ "$YES" == [Yy]* ]]; then
     UNSTABLE_YES="--append-if-missing=efi=disable_early_pci_dma \
@@ -50,7 +57,7 @@ set-kargs-hardening:
     fi
     echo "Applying boot parameters..."
     rpm-ostree kargs \
-      ${UNSTABLE_YES:+$UNSTABLE_YES} ${IAEMU_NO:+$IAEMU_NO} ${NOSMT_YES:+$NOSMT_YES} ${SECUREBOOT_KARGS:+$SECUREBOOT_KARGS} \
+      ${UNSTABLE_YES:+$UNSTABLE_YES} ${IAEMU_NO:+$IAEMU_NO} ${NOSMT_YES:+$NOSMT_YES} ${IPV6_NO:+IPV6_NO} ${SECUREBOOT_KARGS:+$SECUREBOOT_KARGS} \
       --append-if-missing=init_on_alloc=1 \
       --append-if-missing=init_on_free=1 \
       --append-if-missing=slab_nomerge \
@@ -108,6 +115,7 @@ remove-kargs-hardening:
       --delete-if-present="l1tf=full,force" \
       --delete-if-present="kvm-intel.vmentry_l1d_flush=always" \
       --delete-if-present="nosmt=force" \
+      --delete-if-present="ipv6.disable=1" \
       --delete-if-present="oops=panic" \
       --delete-if-present="loglevel=0" \
       --delete-if-present="rd.shell=0" \

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -116,6 +116,11 @@ def audit_kargs():
         status = status.downgrade_to(WARN)
         warnings.append(_("Missing kernel argument: {0} (force-disable SMT)").format(karg_nosmt))
 
+    karg_nosmt = "ipv6.disable=1"
+    if karg_nosmt not in kargs_current:
+        status = status.downgrade_to(WARN)
+        warnings.append(_("Missing kernel argument: {0} (disable IPv6 support)").format(karg_nosmt))
+        
     kargs_expected_unstable = (
         "amd_iommu=force_isolation",
         "debugfs=off",


### PR DESCRIPTION
Partially closes https://github.com/secureblue/secureblue/issues/1393#issuecomment-3342428217.

As discussed in the issue, there are several networking performance related downsides to disabling IPv6. 

For example, this is one of the reasons why https://github.com/secureblue/secureblue/pull/1078 was done since refusing to accept router advertisement (RAs) by default can be considered to have downsides such as it discriminates against IPv6 over IPv4. Another perspective is shown in https://github.com/Kicksecure/security-misc/pull/323 where I provide alternative details and references regarding why the continued disabling of RAs by default might still be advantageous.

Therefore, as discussed in the related issue, this PR simply provides the option to people that want to outright disable the whole networking stack entirely if they do not need to keep it active.