### PR TITLE
feat: enable IPv6 privacy extensions in NetworkManager conf

### DIFF
--- a/files/system/usr/lib/NetworkManager/conf.d/40-secureblue.conf
+++ b/files/system/usr/lib/NetworkManager/conf.d/40-secureblue.conf
@@ -1,0 +1,3 @@
+[connection]
+# RFC 4941 IPv6 privacy extensions: enabled (prefer temporary addresses)
+ipv6.ip6-privacy=2


### PR DESCRIPTION
RFC 4941 IPv6 privacy extensions are already enabled via sysctl; however, we should also set this in NetworkManager's conf to ensure NM respects this setting by default as well. For reference, see: https://www.networkmanager.dev/docs/api/latest/nm-settings-nmcli.html#nm-settings-nmcli.property.ipv6.ip6-privacy