### PR TITLE
fix(securedns): clearly inform user when VPN DNS is in use

### DIFF
--- a/files/po/audit_secureblue.pot
+++ b/files/po/audit_secureblue.pot
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-27 16:04-0400\n"
+"POT-Creation-Date: 2025-10-03 22:30+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,53 +26,53 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:107
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:108
 #, python-brace-format
 msgid "Missing kernel argument: {0}"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:112
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:113
 #, python-brace-format
 msgid "Missing kernel argument: {0} (32-bit support)"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:117
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:118
 #, python-brace-format
 msgid "Missing kernel argument: {0} (force-disable SMT)"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:129
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:130
 #, python-brace-format
 msgid "Missing kernel argument (unstable): {0}"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:132
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:133
 msgid "To set hardened kernel arguments, run:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:134
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:135
 msgid "Checking for hardened kernel arguments"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:150
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:208
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:272
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:714
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:723
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:151
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:209
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:273
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:732
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:741
 #, python-brace-format
 msgid "The file {0} has been modified."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:162
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:163
 #, python-brace-format
 msgid "{0} should be {1}, but is actually {2}."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:165
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:166
 msgid "Ensuring no sysctl overrides"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:179
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:180
 #, python-brace-format
 msgid ""
 "The current image is not signed.\n"
@@ -80,356 +80,369 @@ msgid ""
 "            from the secureblue GitHub repository."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:182
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:183
 msgid "Ensuring a signed image is in use"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:212
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:213
 #, python-brace-format
 msgid "The module {0} is in {1}, but it is loaded."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:215
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:216
 msgid "Ensuring no modprobe overrides"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:230
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:231
 #, python-brace-format
 msgid "ptrace is allowed and **unrestricted** ({0})!"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:231
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:244
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:232
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:245
 msgid "For more info on what this means, see:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:233
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:246
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:234
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:247
 msgid "To forbid ptrace, run:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:235
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:236
 msgid "To allow restricted ptrace, run the above command twice."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:241
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:242
 #, python-brace-format
 msgid "ptrace is allowed, but restricted ({0})."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:251
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:252
 msgid "Ensuring ptrace is forbidden"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:261
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:262
 msgid "Ensuring no authselect overrides"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:276
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:277
 #, python-brace-format
 msgid "{0} exists."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:277
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:278
 msgid "Ensuring no container policy overrides"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:289
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:290
 msgid "Unconfined domain user namespace creation is permitted."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:290
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:307
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:291
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:308
 msgid "To disallow it, run:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:294
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:295
 msgid "Ensuring unconfined user namespace creation disallowed"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:306
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:307
 msgid "Container domain user namespace creation is permitted."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:311
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:312
 msgid "Ensuring container user namespace creation disallowed"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:323
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:324
 msgid "USBGuard is enabled but has failed to run."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:326
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:327
 msgid "USBGuard is not enabled."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:329
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:330
 msgid "To set up USBGuard, run:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:332
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:333
 msgid ""
 "Caution: if you have already set up USBGuard, this will overwrite the "
 "existing policy."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:336
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:337
 msgid "Ensuring USBGuard is active"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:348
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:472
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:503
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:592
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:349
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:490
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:521
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:610
 #, python-brace-format
 msgid "{0} is enabled but has failed to run."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:351
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:597
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:352
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:615
 #, python-brace-format
 msgid "{0} is not enabled."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:352
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:353
 msgid "To start and enable it, run:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:354
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:355
 msgid "Ensuring chronyd is active"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:382
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:385
 msgid "DNS over HTTPS in Trivalent is disabled."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:386
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:389
 msgid "Consider using DNS over HTTPS in Trivalent to hide queries."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:387
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:402
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:390
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:405
 msgid "However, if you use a VPN, this may cause DNS leaks."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:388
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:403
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:417
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:454
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:480
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:509
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:540
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:575
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:600
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:391
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:406
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:420
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:472
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:498
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:527
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:558
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:593
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:618
 msgid "To enable it, run:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:397
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:400
 msgid "Secure global DNS is not configured."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:401
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:404
 msgid "Consider using secure global DNS."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:412
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:415
 msgid "Local DNSSEC validation is disabled."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:416
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:419
 msgid "You should enable local DNSSEC validation to prevent DNS hijacking."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:428
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:427
+msgid "The secure DNS resolver is not in use, possibly for a VPN."
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:432
+msgid ""
+"If you use a VPN, consider using it with secure DNS. For instructions, see:"
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:435
+msgid "Otherwise, to view or reset your current DNS configuration, run:"
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:446
 msgid "Ensuring system DNS resolution is secure"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:445
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:934
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:463
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:952
 #, python-brace-format
 msgid "Unable to read file {0}."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:453
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:471
 msgid "MAC randomization is not enabled."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:460
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:478
 msgid "Ensuring MAC randomization is enabled"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:477
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:506
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:495
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:524
 #, python-brace-format
 msgid "{0} is disabled."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:485
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:514
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:605
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:503
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:532
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:623
 #, python-brace-format
 msgid "Ensuring {0} is enabled"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:532
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:567
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:550
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:585
 #, python-brace-format
 msgid "{0} is enabled globally but has failed to run."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:537
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:572
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:555
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:590
 #, python-brace-format
 msgid "{0} is not enabled globally."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:545
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:580
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:563
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:598
 #, python-brace-format
 msgid "Ensuring {0} is enabled globally"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:617
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:635
 msgid "The current user is in the wheel group."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:618
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:636
 msgid "To set up a separate wheel account, follow the instructions here:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:626
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:644
 msgid "Ensuring user is not a member of the wheel group"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:635
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:653
 msgid "GNOME"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:638
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:656
 msgid "KDE Plasma"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:641
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:659
 msgid "Sway"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:651
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:669
 #, python-brace-format
 msgid "Xwayland is enabled for {0}."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:652
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:751
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:928
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:670
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:769
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:946
 msgid "To disable it, run:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:656
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:674
 #, python-brace-format
 msgid "Ensuring {0} is disabled for {1}"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:679
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:697
 msgid "GNOME user extensions are enabled."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:680
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:698
 msgid "To disable this, run:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:684
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:702
 msgid "Ensuring GNOME user extensions are disabled"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:696
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:714
 msgid "SELinux is in Permissive mode."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:697
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:715
 msgid "To set it to Enforcing mode, run:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:701
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:719
 msgid "Ensuring SELinux is in Enforcing mode"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:717
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:735
 #, python-brace-format
 msgid "The file {0} has been deleted."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:720
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:738
 #, python-brace-format
 msgid "The file {0} cannot be read."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:724
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:742
 msgid "To reset it, run:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:728
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:746
 msgid "Ensuring no environment file overrides"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:744
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:762
 #, python-brace-format
 msgid "The file {0} was not found or inaccessible."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:750
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:768
 msgid "KDE GNHS is enabled."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:757
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:775
 msgid "Ensuring KDE GHNS is disabled"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:771
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:789
 #, python-brace-format
 msgid "The file {0} was not found."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:778
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:796
 #, python-brace-format
 msgid "{0} has mode {1:o} (expected {2:o})"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:782
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:800
 #, python-brace-format
 msgid "{0} is owned by a non-root user!"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:785
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:803
 #, python-brace-format
 msgid "The file {0} has been modified or deleted."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:786
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:804
 msgid "To reset it and enable hardened_malloc for system processes, run:"
-msgstr ""
-
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:791
-#, python-brace-format
-msgid "Ensuring {0} has expected permissions"
 msgstr ""
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:809
 #, python-brace-format
+msgid "Ensuring {0} has expected permissions"
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:827
+#, python-brace-format
 msgid "{0} is set, but {1} has been modified."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:814
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:817
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:832
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:835
 #, python-brace-format
 msgid "The '{0}' variant of {1} has been set."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:820
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:838
 #, python-brace-format
 msgid "{0} has not been set."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:823
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:841
 #, python-brace-format
 msgid ""
 "The environment variable {0} has been modified or is unset.\n"
@@ -437,105 +450,105 @@ msgid ""
 "                {2} or related configuration files."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:829
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:847
 msgid "Ensuring hardened_malloc is set to be preloaded"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:856
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:874
 msgid "Your hardware does not support secure boot."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:861
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:879
 msgid ""
 "The system will be unable to verify that kernel modules are signed or the "
 "boot process."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:867
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:885
 msgid "Ensuring secure boot is enabled"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:900
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:918
 msgid "Bash environment is not locked down."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:901
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:919
 msgid "The following files do not appear to be immutable or do not exist:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:903
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:921
 msgid "To fix this, run:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:910
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:928
 msgid "Ensuring current user's bash environment is locked down"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:927
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:932
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:945
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:950
 msgid "Webcam module is enabled."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:937
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:955
 msgid "Checking whether webcam module is disabled"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:959
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:977
 #, python-brace-format
 msgid "{0} is configured with an unknown URL."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:962
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:980
 #, python-brace-format
 msgid "{0} is not a verified flatpak repository."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:965
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:983
 #, python-brace-format
 msgid "Auditing flatpak remote {0}"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:998
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1016
 #, python-brace-format
 msgid "Auditing {0}"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1014
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1032
 msgid "[Audit process interrupted. Exiting.]"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1027
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1045
 msgid "Audit secureblue configuration for security"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1031
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1049
 msgid "skip categories"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1032
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1050
 msgid "display output as JSON"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1036
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1054
 #, python-brace-format
 msgid "Valid arguments to {0} are: {1}"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1044
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1062
 #, python-brace-format
 msgid "*** Error in check '{0}' ***"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1046
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1064
 msgid "*** Continuing... ***"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1049
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1067
 #, python-brace-format
 msgid "Use option '{0}' to skip flatpak recommendations."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1052
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1070
 msgid "*** WARNING: Unexpected error occurred. ***"
 msgstr ""
 

--- a/files/po/de/audit_secureblue.po
+++ b/files/po/de/audit_secureblue.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-27 16:04-0400\n"
+"POT-Creation-Date: 2025-10-05 00:12+0100\n"
 "PO-Revision-Date: 2025-08-05 13:32+0200\n"
 "Last-Translator: MatsG23 <60609373+MatsG23@users.noreply.github.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -26,53 +26,53 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:107
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:108
 #, python-brace-format
 msgid "Missing kernel argument: {0}"
 msgstr "Fehlender Kernel-Parameter: {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:112
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:113
 #, python-brace-format
 msgid "Missing kernel argument: {0} (32-bit support)"
 msgstr "Fehlender Kernel-Parameter: {0} (32-bit Support)"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:117
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:118
 #, python-brace-format
 msgid "Missing kernel argument: {0} (force-disable SMT)"
 msgstr "Fehlender Kernel-Parameter: {0} (erzwinge Deaktivierung von SMT)"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:129
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:130
 #, python-brace-format
 msgid "Missing kernel argument (unstable): {0}"
 msgstr "Fehlender Kernel-Parameter (instabil): {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:132
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:133
 msgid "To set hardened kernel arguments, run:"
 msgstr "Um gehärtete Kernel-Parameter anzuwenden, führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:134
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:135
 msgid "Checking for hardened kernel arguments"
 msgstr "Prüfe auf gehärtete Kernel-Parameter"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:150
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:208
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:272
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:714
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:723
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:151
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:209
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:273
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:732
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:741
 #, python-brace-format
 msgid "The file {0} has been modified."
 msgstr "Die Datei {0} wurde geändert."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:162
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:163
 #, python-brace-format
 msgid "{0} should be {1}, but is actually {2}."
 msgstr "{0} sollte {1} sein, ist aber {2}."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:165
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:166
 msgid "Ensuring no sysctl overrides"
 msgstr "Prüfe auf sysctl Modifikationen"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:179
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:180
 #, python-brace-format
 msgid ""
 "The current image is not signed.\n"
@@ -84,95 +84,95 @@ msgstr ""
 "{0}\n"
 "            aus dem secureblue GitHub Repository aus (gegebenenfalls erneut)."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:182
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:183
 msgid "Ensuring a signed image is in use"
 msgstr "Prüfe auf signiertes Image"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:212
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:213
 #, python-brace-format
 msgid "The module {0} is in {1}, but it is loaded."
 msgstr "Das Modul {0} ist in {1}, ist aber geladen."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:215
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:216
 msgid "Ensuring no modprobe overrides"
 msgstr "Prüfe auf modprobe Modifikationen"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:230
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:231
 #, python-brace-format
 msgid "ptrace is allowed and **unrestricted** ({0})!"
 msgstr "ptrace ist erlaubt und **nicht eingeschränkt** ({0})!"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:231
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:244
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:232
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:245
 msgid "For more info on what this means, see:"
 msgstr "Siehe hier für weitere Informationen:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:233
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:246
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:234
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:247
 msgid "To forbid ptrace, run:"
 msgstr "Um ptrace zu verbieten, führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:235
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:236
 msgid "To allow restricted ptrace, run the above command twice."
 msgstr ""
 "Um ptrace eingeschränkt zu erlauben, führe den obigen Befehl zweimal aus."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:241
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:242
 #, python-brace-format
 msgid "ptrace is allowed, but restricted ({0})."
 msgstr "ptrace ist erlaubt, aber eingeschränkt ({0})."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:251
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:252
 msgid "Ensuring ptrace is forbidden"
 msgstr "Prüfe auf ptrace Verbot"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:261
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:262
 msgid "Ensuring no authselect overrides"
 msgstr "Prüfe auf authselect Modifikationen"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:276
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:277
 #, python-brace-format
 msgid "{0} exists."
 msgstr "{0} existiert."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:277
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:278
 msgid "Ensuring no container policy overrides"
 msgstr "Prüfe auf Container-Richtlinien Modifikationen"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:289
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:290
 msgid "Unconfined domain user namespace creation is permitted."
 msgstr "Das uneingeschränkte Erstellen von User Namespaces ist erlaubt."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:290
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:307
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:291
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:308
 msgid "To disallow it, run:"
 msgstr "Um dies zu verbieten, führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:294
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:295
 msgid "Ensuring unconfined user namespace creation disallowed"
 msgstr "Prüfe auf Verbot des uneingeschränkten Erstellens von User Namespaces"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:306
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:307
 msgid "Container domain user namespace creation is permitted."
 msgstr "Containern ist das Erstellen von User Namespaces erlaubt."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:311
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:312
 msgid "Ensuring container user namespace creation disallowed"
 msgstr "Prüfe auf Verbot des Erstellens von User Namespaces für Container"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:323
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:324
 msgid "USBGuard is enabled but has failed to run."
 msgstr "USBGuard ist aktiviert, aber schlug fehl."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:326
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:327
 msgid "USBGuard is not enabled."
 msgstr "USBGuard ist nicht aktiviert."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:329
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:330
 msgid "To set up USBGuard, run:"
 msgstr "Um USBGuard einzurichten, führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:332
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:333
 msgid ""
 "Caution: if you have already set up USBGuard, this will overwrite the "
 "existing policy."
@@ -180,267 +180,280 @@ msgstr ""
 "Warnung: Falls USBGuard bereits eingerichtet wurde, wird dies die bestehende "
 "Richtlinie überschreiben."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:336
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:337
 msgid "Ensuring USBGuard is active"
 msgstr "Prüfe auf USBGuard"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:348
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:472
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:503
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:592
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:349
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:490
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:521
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:610
 #, python-brace-format
 msgid "{0} is enabled but has failed to run."
 msgstr "{0} ist aktiviert, aber schlug fehl."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:351
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:597
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:352
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:615
 #, python-brace-format
 msgid "{0} is not enabled."
 msgstr "{0} ist nicht aktiviert."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:352
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:353
 msgid "To start and enable it, run:"
 msgstr "Um es zu starten und aktivieren, führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:354
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:355
 msgid "Ensuring chronyd is active"
 msgstr "Prüfe auf chronyd"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:382
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:385
 msgid "DNS over HTTPS in Trivalent is disabled."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:386
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:389
 msgid "Consider using DNS over HTTPS in Trivalent to hide queries."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:387
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:402
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:390
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:405
 msgid "However, if you use a VPN, this may cause DNS leaks."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:388
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:403
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:417
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:454
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:480
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:509
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:540
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:575
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:600
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:391
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:406
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:420
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:472
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:498
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:527
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:558
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:593
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:618
 msgid "To enable it, run:"
 msgstr "Zum Aktivieren, führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:397
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:400
 msgid "Secure global DNS is not configured."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:401
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:404
 msgid "Consider using secure global DNS."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:412
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:415
 msgid "Local DNSSEC validation is disabled."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:416
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:419
 msgid "You should enable local DNSSEC validation to prevent DNS hijacking."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:428
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:427
+msgid "The secure DNS resolver is not in use, possibly for a VPN."
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:432
+msgid ""
+"If you use a VPN, consider using it with secure DNS. For instructions, see:"
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:435
+msgid "Otherwise, to view or reset your current DNS configuration, run:"
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:446
 msgid "Ensuring system DNS resolution is secure"
 msgstr "Prüfe auf sichere systemweite DNS-Auflösung"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:445
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:934
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:463
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:952
 #, python-brace-format
 msgid "Unable to read file {0}."
 msgstr "Datei {0} kann nicht gelesen werden."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:453
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:471
 msgid "MAC randomization is not enabled."
 msgstr "MAC-Randomisierung ist nicht aktiv."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:460
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:478
 msgid "Ensuring MAC randomization is enabled"
 msgstr "Prüfe auf aktive MAC-Randomisierung"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:477
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:506
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:495
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:524
 #, python-brace-format
 msgid "{0} is disabled."
 msgstr "{0} ist deaktiviert."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:485
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:514
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:605
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:503
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:532
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:623
 #, python-brace-format
 msgid "Ensuring {0} is enabled"
 msgstr "Prüfe auf {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:532
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:567
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:550
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:585
 #, python-brace-format
 msgid "{0} is enabled globally but has failed to run."
 msgstr "{0} ist systemweit aktiviert, aber schlug fehl."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:537
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:572
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:555
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:590
 #, python-brace-format
 msgid "{0} is not enabled globally."
 msgstr "{0} ist nicht systemweit aktiviert."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:545
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:580
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:563
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:598
 #, python-brace-format
 msgid "Ensuring {0} is enabled globally"
 msgstr "Prüfe auf {0} (systemweit)"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:617
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:635
 msgid "The current user is in the wheel group."
 msgstr "Der aktuelle Benutzer ist in der wheel Gruppe."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:618
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:636
 msgid "To set up a separate wheel account, follow the instructions here:"
 msgstr ""
 "Um ein seperates wheel-Konto zu erstellen, befolge die hier verlinkten "
 "Schritte:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:626
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:644
 msgid "Ensuring user is not a member of the wheel group"
 msgstr "Prüfe auf wheel Gruppenmitgliedschaft"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:635
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:653
 msgid "GNOME"
 msgstr "GNOME"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:638
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:656
 msgid "KDE Plasma"
 msgstr "KDE Plasma"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:641
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:659
 msgid "Sway"
 msgstr "Sway"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:651
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:669
 #, python-brace-format
 msgid "Xwayland is enabled for {0}."
 msgstr "Xwayland ist für {0} aktiviert."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:652
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:751
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:928
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:670
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:769
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:946
 msgid "To disable it, run:"
 msgstr "Zum Deaktivieren, führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:656
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:674
 #, python-brace-format
 msgid "Ensuring {0} is disabled for {1}"
 msgstr "Prüfe {0} Status für {1}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:679
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:697
 msgid "GNOME user extensions are enabled."
 msgstr "GNOME Nutzer-Erweiterungen sind aktiv."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:680
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:698
 msgid "To disable this, run:"
 msgstr "Zum Deaktivieren, führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:684
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:702
 msgid "Ensuring GNOME user extensions are disabled"
 msgstr "Prüfe auf GNOME Nutzer-Erweiterungen"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:696
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:714
 msgid "SELinux is in Permissive mode."
 msgstr "SELinux ist im Permissive Modus."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:697
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:715
 msgid "To set it to Enforcing mode, run:"
 msgstr "Um SELinux in den Enforcing Modus zu wechseln, führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:701
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:719
 msgid "Ensuring SELinux is in Enforcing mode"
 msgstr "Prüfe auf SELinux Enforcing Modus"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:717
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:735
 #, python-brace-format
 msgid "The file {0} has been deleted."
 msgstr "Die Datei {0} wurde gelöscht."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:720
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:738
 #, python-brace-format
 msgid "The file {0} cannot be read."
 msgstr "Die Datei {0} kann nicht gelesen werden."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:724
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:742
 msgid "To reset it, run:"
 msgstr "Um sie zurückzusetzen, führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:728
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:746
 msgid "Ensuring no environment file overrides"
 msgstr "Prüfe auf modifizierte Umgebungsdateien"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:744
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:762
 #, python-brace-format
 msgid "The file {0} was not found or inaccessible."
 msgstr "Die Datei {0} wurde nicht gefunden oder der Zugriff wurde verweigert."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:750
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:768
 msgid "KDE GNHS is enabled."
 msgstr "KDE GNHS ist aktiv."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:757
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:775
 msgid "Ensuring KDE GHNS is disabled"
 msgstr "Prüfe auf KDE GHNS"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:771
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:789
 #, python-brace-format
 msgid "The file {0} was not found."
 msgstr "Die Datei {0} wurde nicht gefunden."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:778
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:796
 #, python-brace-format
 msgid "{0} has mode {1:o} (expected {2:o})"
 msgstr "{0} hat den Modus {1:o} ({2:o} erwartet)"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:782
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:800
 #, python-brace-format
 msgid "{0} is owned by a non-root user!"
 msgstr "{0} gehört nicht dem root-Benutzer!"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:785
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:803
 #, python-brace-format
 msgid "The file {0} has been modified or deleted."
 msgstr "Die Datei {0} wurde geändert oder gelöscht."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:786
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:804
 msgid "To reset it and enable hardened_malloc for system processes, run:"
 msgstr ""
 "Um sie zurückzusetzen und hardened_malloc für Systemprozesse zu aktivieren, "
 "führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:791
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:809
 #, python-brace-format
 msgid "Ensuring {0} has expected permissions"
 msgstr "Prüfe auf erwartete Dateiberechtigungen für {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:809
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:827
 #, python-brace-format
 msgid "{0} is set, but {1} has been modified."
 msgstr "{0} ist gesetzt, aber {1} wurde geändert."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:814
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:817
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:832
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:835
 #, python-brace-format
 msgid "The '{0}' variant of {1} has been set."
 msgstr "Die '{0}' Variante von {1} wurde gesetzt."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:820
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:838
 #, python-brace-format
 msgid "{0} has not been set."
 msgstr "{0} wurde nicht gesetzt."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:823
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:841
 #, python-brace-format
 msgid ""
 "The environment variable {0} has been modified or is unset.\n"
@@ -451,108 +464,108 @@ msgstr ""
 "                Prüfe, dass {1} nicht in {2} oder zugehörigen\n"
 "                Konfigurationsdateien überschrieben wurde."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:829
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:847
 msgid "Ensuring hardened_malloc is set to be preloaded"
 msgstr "Prüfe auf hardened_malloc"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:856
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:874
 msgid "Your hardware does not support secure boot."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:861
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:879
 msgid ""
 "The system will be unable to verify that kernel modules are signed or the "
 "boot process."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:867
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:885
 msgid "Ensuring secure boot is enabled"
 msgstr "Prüfe auf Secure Boot"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:900
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:918
 msgid "Bash environment is not locked down."
 msgstr "Die Bash-Umgebung ist nicht abgesichert."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:901
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:919
 msgid "The following files do not appear to be immutable or do not exist:"
 msgstr ""
 "Die folgenden Dateien scheinen nicht schreibgeschützt zu sein oder "
 "existieren nicht:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:903
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:921
 msgid "To fix this, run:"
 msgstr "Um dies zu beheben, führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:910
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:928
 msgid "Ensuring current user's bash environment is locked down"
 msgstr "Prüfe auf abgesicherte Bash-Umgebung"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:927
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:932
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:945
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:950
 msgid "Webcam module is enabled."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:937
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:955
 msgid "Checking whether webcam module is disabled"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:959
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:977
 #, python-brace-format
 msgid "{0} is configured with an unknown URL."
 msgstr "{0} ist mit einer unbekannten URL konfiguriert."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:962
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:980
 #, python-brace-format
 msgid "{0} is not a verified flatpak repository."
 msgstr "{0} ist kein geprüftes Flatpak-Repository."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:965
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:983
 #, python-brace-format
 msgid "Auditing flatpak remote {0}"
 msgstr "Prüfe Flatpak Remote {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:998
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1016
 #, python-brace-format
 msgid "Auditing {0}"
 msgstr "Prüfe {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1014
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1032
 msgid "[Audit process interrupted. Exiting.]"
 msgstr "[Prüfprozess wurde unterbrochen. Abbruch.]"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1027
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1045
 msgid "Audit secureblue configuration for security"
 msgstr "Prüft die secureblue Konfiguration auf Sicherheit"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1031
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1049
 msgid "skip categories"
 msgstr "überspringe Kategorien"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1032
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1050
 msgid "display output as JSON"
 msgstr "Ausgabe als JSON anzeigen"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1036
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1054
 #, python-brace-format
 msgid "Valid arguments to {0} are: {1}"
 msgstr "Gültige Argumente für {0} sind: {1}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1044
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1062
 #, python-brace-format
 msgid "*** Error in check '{0}' ***"
 msgstr "*** Fehler in Test '{0}' ***"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1046
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1064
 msgid "*** Continuing... ***"
 msgstr "*** Fortfahren... ***"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1049
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1067
 #, python-brace-format
 msgid "Use option '{0}' to skip flatpak recommendations."
 msgstr ""
 "Verwende die Option '{0}' um Empfehlungen für Flatpaks zu überspringen."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1052
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1070
 msgid "*** WARNING: Unexpected error occurred. ***"
 msgstr "*** WARNUNG: Ein unerwarteter Fehler trat auf. ***"
 

--- a/files/po/en/audit_secureblue.po
+++ b/files/po/en/audit_secureblue.po
@@ -16,63 +16,63 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-27 16:04-0400\n"
-"PO-Revision-Date: 2025-09-27 16:04-0400\n"
+"POT-Creation-Date: 2025-10-05 00:12+0100\n"
+"PO-Revision-Date: 2025-10-05 00:12+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
-"Language: en_US\n"
+"Language: en_GB\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:107
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:108
 #, python-brace-format
 msgid "Missing kernel argument: {0}"
 msgstr "Missing kernel argument: {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:112
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:113
 #, python-brace-format
 msgid "Missing kernel argument: {0} (32-bit support)"
 msgstr "Missing kernel argument: {0} (32-bit support)"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:117
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:118
 #, python-brace-format
 msgid "Missing kernel argument: {0} (force-disable SMT)"
 msgstr "Missing kernel argument: {0} (force-disable SMT)"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:129
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:130
 #, python-brace-format
 msgid "Missing kernel argument (unstable): {0}"
 msgstr "Missing kernel argument (unstable): {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:132
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:133
 msgid "To set hardened kernel arguments, run:"
 msgstr "To set hardened kernel arguments, run:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:134
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:135
 msgid "Checking for hardened kernel arguments"
 msgstr "Checking for hardened kernel arguments"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:150
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:208
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:272
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:714
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:723
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:151
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:209
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:273
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:732
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:741
 #, python-brace-format
 msgid "The file {0} has been modified."
 msgstr "The file {0} has been modified."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:162
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:163
 #, python-brace-format
 msgid "{0} should be {1}, but is actually {2}."
 msgstr "{0} should be {1}, but is actually {2}."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:165
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:166
 msgid "Ensuring no sysctl overrides"
 msgstr "Ensuring no sysctl overrides"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:179
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:180
 #, python-brace-format
 msgid ""
 "The current image is not signed.\n"
@@ -83,94 +83,94 @@ msgstr ""
 "            To rebase to a signed image, download and run or re-run {0}\n"
 "            from the secureblue GitHub repository."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:182
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:183
 msgid "Ensuring a signed image is in use"
 msgstr "Ensuring a signed image is in use"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:212
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:213
 #, python-brace-format
 msgid "The module {0} is in {1}, but it is loaded."
 msgstr "The module {0} is in {1}, but it is loaded."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:215
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:216
 msgid "Ensuring no modprobe overrides"
 msgstr "Ensuring no modprobe overrides"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:230
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:231
 #, python-brace-format
 msgid "ptrace is allowed and **unrestricted** ({0})!"
 msgstr "ptrace is allowed and **unrestricted** ({0})!"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:231
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:244
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:232
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:245
 msgid "For more info on what this means, see:"
 msgstr "For more info on what this means, see:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:233
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:246
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:234
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:247
 msgid "To forbid ptrace, run:"
 msgstr "To forbid ptrace, run:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:235
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:236
 msgid "To allow restricted ptrace, run the above command twice."
 msgstr "To allow restricted ptrace, run the above command twice."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:241
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:242
 #, python-brace-format
 msgid "ptrace is allowed, but restricted ({0})."
 msgstr "ptrace is allowed, but restricted ({0})."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:251
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:252
 msgid "Ensuring ptrace is forbidden"
 msgstr "Ensuring ptrace is forbidden"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:261
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:262
 msgid "Ensuring no authselect overrides"
 msgstr "Ensuring no authselect overrides"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:276
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:277
 #, python-brace-format
 msgid "{0} exists."
 msgstr "{0} exists."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:277
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:278
 msgid "Ensuring no container policy overrides"
 msgstr "Ensuring no container policy overrides"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:289
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:290
 msgid "Unconfined domain user namespace creation is permitted."
 msgstr "Unconfined domain user namespace creation is permitted."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:290
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:307
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:291
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:308
 msgid "To disallow it, run:"
 msgstr "To disallow it, run:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:294
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:295
 msgid "Ensuring unconfined user namespace creation disallowed"
 msgstr "Ensuring unconfined user namespace creation disallowed"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:306
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:307
 msgid "Container domain user namespace creation is permitted."
 msgstr "Container domain user namespace creation is permitted."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:311
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:312
 msgid "Ensuring container user namespace creation disallowed"
 msgstr "Ensuring container user namespace creation disallowed"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:323
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:324
 msgid "USBGuard is enabled but has failed to run."
 msgstr "USBGuard is enabled but has failed to run."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:326
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:327
 msgid "USBGuard is not enabled."
 msgstr "USBGuard is not enabled."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:329
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:330
 msgid "To set up USBGuard, run:"
 msgstr "To set up USBGuard, run:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:332
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:333
 msgid ""
 "Caution: if you have already set up USBGuard, this will overwrite the "
 "existing policy."
@@ -178,263 +178,277 @@ msgstr ""
 "Caution: if you have already set up USBGuard, this will overwrite the "
 "existing policy."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:336
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:337
 msgid "Ensuring USBGuard is active"
 msgstr "Ensuring USBGuard is active"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:348
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:472
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:503
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:592
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:349
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:490
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:521
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:610
 #, python-brace-format
 msgid "{0} is enabled but has failed to run."
 msgstr "{0} is enabled but has failed to run."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:351
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:597
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:352
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:615
 #, python-brace-format
 msgid "{0} is not enabled."
 msgstr "{0} is not enabled."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:352
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:353
 msgid "To start and enable it, run:"
 msgstr "To start and enable it, run:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:354
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:355
 msgid "Ensuring chronyd is active"
 msgstr "Ensuring chronyd is active"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:382
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:385
 msgid "DNS over HTTPS in Trivalent is disabled."
 msgstr "DNS over HTTPS in Trivalent is disabled."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:386
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:389
 msgid "Consider using DNS over HTTPS in Trivalent to hide queries."
 msgstr "Consider using DNS over HTTPS in Trivalent to hide queries."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:387
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:402
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:390
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:405
 msgid "However, if you use a VPN, this may cause DNS leaks."
 msgstr "However, if you use a VPN, this may cause DNS leaks."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:388
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:403
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:417
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:454
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:480
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:509
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:540
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:575
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:600
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:391
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:406
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:420
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:472
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:498
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:527
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:558
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:593
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:618
 msgid "To enable it, run:"
 msgstr "To enable it, run:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:397
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:400
 msgid "Secure global DNS is not configured."
 msgstr "Secure global DNS is not configured."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:401
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:404
 msgid "Consider using secure global DNS."
 msgstr "Consider using secure global DNS."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:412
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:415
 msgid "Local DNSSEC validation is disabled."
 msgstr "Local DNSSEC validation is disabled."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:416
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:419
 msgid "You should enable local DNSSEC validation to prevent DNS hijacking."
 msgstr "You should enable local DNSSEC validation to prevent DNS hijacking."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:428
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:427
+msgid "The secure DNS resolver is not in use, possibly for a VPN."
+msgstr "The secure DNS resolver is not in use, possibly for a VPN."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:432
+msgid ""
+"If you use a VPN, consider using it with secure DNS. For instructions, see:"
+msgstr ""
+"If you use a VPN, consider using it with secure DNS. For instructions, see:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:435
+msgid "Otherwise, to view or reset your current DNS configuration, run:"
+msgstr "Otherwise, to view or reset your current DNS configuration, run:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:446
 msgid "Ensuring system DNS resolution is secure"
 msgstr "Ensuring system DNS resolution is secure"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:445
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:934
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:463
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:952
 #, python-brace-format
 msgid "Unable to read file {0}."
 msgstr "Unable to read file {0}."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:453
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:471
 msgid "MAC randomization is not enabled."
 msgstr "MAC randomization is not enabled."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:460
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:478
 msgid "Ensuring MAC randomization is enabled"
 msgstr "Ensuring MAC randomization is enabled"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:477
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:506
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:495
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:524
 #, python-brace-format
 msgid "{0} is disabled."
 msgstr "{0} is disabled."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:485
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:514
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:605
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:503
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:532
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:623
 #, python-brace-format
 msgid "Ensuring {0} is enabled"
 msgstr "Ensuring {0} is enabled"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:532
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:567
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:550
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:585
 #, python-brace-format
 msgid "{0} is enabled globally but has failed to run."
 msgstr "{0} is enabled globally but has failed to run."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:537
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:572
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:555
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:590
 #, python-brace-format
 msgid "{0} is not enabled globally."
 msgstr "{0} is not enabled globally."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:545
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:580
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:563
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:598
 #, python-brace-format
 msgid "Ensuring {0} is enabled globally"
 msgstr "Ensuring {0} is enabled globally"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:617
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:635
 msgid "The current user is in the wheel group."
 msgstr "The current user is in the wheel group."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:618
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:636
 msgid "To set up a separate wheel account, follow the instructions here:"
 msgstr "To set up a separate wheel account, follow the instructions here:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:626
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:644
 msgid "Ensuring user is not a member of the wheel group"
 msgstr "Ensuring user is not a member of the wheel group"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:635
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:653
 msgid "GNOME"
 msgstr "GNOME"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:638
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:656
 msgid "KDE Plasma"
 msgstr "KDE Plasma"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:641
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:659
 msgid "Sway"
 msgstr "Sway"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:651
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:669
 #, python-brace-format
 msgid "Xwayland is enabled for {0}."
 msgstr "Xwayland is enabled for {0}."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:652
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:751
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:928
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:670
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:769
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:946
 msgid "To disable it, run:"
 msgstr "To disable it, run:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:656
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:674
 #, python-brace-format
 msgid "Ensuring {0} is disabled for {1}"
 msgstr "Ensuring {0} is disabled for {1}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:679
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:697
 msgid "GNOME user extensions are enabled."
 msgstr "GNOME user extensions are enabled."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:680
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:698
 msgid "To disable this, run:"
 msgstr "To disable this, run:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:684
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:702
 msgid "Ensuring GNOME user extensions are disabled"
 msgstr "Ensuring GNOME user extensions are disabled"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:696
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:714
 msgid "SELinux is in Permissive mode."
 msgstr "SELinux is in Permissive mode."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:697
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:715
 msgid "To set it to Enforcing mode, run:"
 msgstr "To set it to Enforcing mode, run:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:701
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:719
 msgid "Ensuring SELinux is in Enforcing mode"
 msgstr "Ensuring SELinux is in Enforcing mode"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:717
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:735
 #, python-brace-format
 msgid "The file {0} has been deleted."
 msgstr "The file {0} has been deleted."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:720
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:738
 #, python-brace-format
 msgid "The file {0} cannot be read."
 msgstr "The file {0} cannot be read."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:724
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:742
 msgid "To reset it, run:"
 msgstr "To reset it, run:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:728
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:746
 msgid "Ensuring no environment file overrides"
 msgstr "Ensuring no environment file overrides"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:744
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:762
 #, python-brace-format
 msgid "The file {0} was not found or inaccessible."
 msgstr "The file {0} was not found or inaccessible."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:750
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:768
 msgid "KDE GNHS is enabled."
 msgstr "KDE GNHS is enabled."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:757
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:775
 msgid "Ensuring KDE GHNS is disabled"
 msgstr "Ensuring KDE GHNS is disabled"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:771
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:789
 #, python-brace-format
 msgid "The file {0} was not found."
 msgstr "The file {0} was not found."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:778
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:796
 #, python-brace-format
 msgid "{0} has mode {1:o} (expected {2:o})"
 msgstr "{0} has mode {1:o} (expected {2:o})"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:782
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:800
 #, python-brace-format
 msgid "{0} is owned by a non-root user!"
 msgstr "{0} is owned by a non-root user!"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:785
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:803
 #, python-brace-format
 msgid "The file {0} has been modified or deleted."
 msgstr "The file {0} has been modified or deleted."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:786
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:804
 msgid "To reset it and enable hardened_malloc for system processes, run:"
 msgstr "To reset it and enable hardened_malloc for system processes, run:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:791
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:809
 #, python-brace-format
 msgid "Ensuring {0} has expected permissions"
 msgstr "Ensuring {0} has expected permissions"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:809
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:827
 #, python-brace-format
 msgid "{0} is set, but {1} has been modified."
 msgstr "{0} is set, but {1} has been modified."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:814
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:817
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:832
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:835
 #, python-brace-format
 msgid "The '{0}' variant of {1} has been set."
 msgstr "The '{0}' variant of {1} has been set."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:820
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:838
 #, python-brace-format
 msgid "{0} has not been set."
 msgstr "{0} has not been set."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:823
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:841
 #, python-brace-format
 msgid ""
 "The environment variable {0} has been modified or is unset.\n"
@@ -445,15 +459,15 @@ msgstr ""
 "                Check that {1} has not been overridden in\n"
 "                {2} or related configuration files."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:829
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:847
 msgid "Ensuring hardened_malloc is set to be preloaded"
 msgstr "Ensuring hardened_malloc is set to be preloaded"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:856
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:874
 msgid "Your hardware does not support secure boot."
 msgstr "Your hardware does not support secure boot."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:861
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:879
 msgid ""
 "The system will be unable to verify that kernel modules are signed or the "
 "boot process."
@@ -461,91 +475,91 @@ msgstr ""
 "The system will be unable to verify that kernel modules are signed or the "
 "boot process."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:867
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:885
 msgid "Ensuring secure boot is enabled"
 msgstr "Ensuring secure boot is enabled"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:900
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:918
 msgid "Bash environment is not locked down."
 msgstr "Bash environment is not locked down."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:901
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:919
 msgid "The following files do not appear to be immutable or do not exist:"
 msgstr "The following files do not appear to be immutable or do not exist:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:903
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:921
 msgid "To fix this, run:"
 msgstr "To fix this, run:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:910
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:928
 msgid "Ensuring current user's bash environment is locked down"
 msgstr "Ensuring current user's bash environment is locked down"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:927
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:932
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:945
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:950
 msgid "Webcam module is enabled."
 msgstr "Webcam module is enabled."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:937
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:955
 msgid "Checking whether webcam module is disabled"
 msgstr "Checking whether webcam module is disabled"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:959
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:977
 #, python-brace-format
 msgid "{0} is configured with an unknown URL."
 msgstr "{0} is configured with an unknown URL."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:962
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:980
 #, python-brace-format
 msgid "{0} is not a verified flatpak repository."
 msgstr "{0} is not a verified flatpak repository."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:965
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:983
 #, python-brace-format
 msgid "Auditing flatpak remote {0}"
 msgstr "Auditing flatpak remote {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:998
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1016
 #, python-brace-format
 msgid "Auditing {0}"
 msgstr "Auditing {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1014
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1032
 msgid "[Audit process interrupted. Exiting.]"
 msgstr "[Audit process interrupted. Exiting.]"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1027
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1045
 msgid "Audit secureblue configuration for security"
 msgstr "Audit secureblue configuration for security"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1031
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1049
 msgid "skip categories"
 msgstr "skip categories"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1032
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1050
 msgid "display output as JSON"
 msgstr "display output as JSON"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1036
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1054
 #, python-brace-format
 msgid "Valid arguments to {0} are: {1}"
 msgstr "Valid arguments to {0} are: {1}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1044
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1062
 #, python-brace-format
 msgid "*** Error in check '{0}' ***"
 msgstr "*** Error in check '{0}' ***"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1046
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1064
 msgid "*** Continuing... ***"
 msgstr "*** Continuing... ***"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1049
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1067
 #, python-brace-format
 msgid "Use option '{0}' to skip flatpak recommendations."
 msgstr "Use option '{0}' to skip flatpak recommendations."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1052
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1070
 msgid "*** WARNING: Unexpected error occurred. ***"
 msgstr "*** WARNING: Unexpected error occurred. ***"
 

--- a/files/po/es/audit_secureblue.po
+++ b/files/po/es/audit_secureblue.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-27 16:04-0400\n"
+"POT-Creation-Date: 2025-10-05 00:12+0100\n"
 "PO-Revision-Date: 2025-09-22 23:20-0400\n"
 "Last-Translator: Cup-png <232283931+Cup-png@users.noreply.github.com>\n"
 "Language-Team: none\n"
@@ -26,53 +26,53 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:107
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:108
 #, python-brace-format
 msgid "Missing kernel argument: {0}"
 msgstr "Argumento del kernel faltante: {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:112
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:113
 #, python-brace-format
 msgid "Missing kernel argument: {0} (32-bit support)"
 msgstr "Argumento del kernel faltante: {0} (soporte de 32 bits)"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:117
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:118
 #, python-brace-format
 msgid "Missing kernel argument: {0} (force-disable SMT)"
 msgstr "Argumento del kernel faltante: {0} (forzar deshabilitamiento de SMT)"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:129
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:130
 #, python-brace-format
 msgid "Missing kernel argument (unstable): {0}"
 msgstr "Argumento del kernel faltante (inestable): {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:132
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:133
 msgid "To set hardened kernel arguments, run:"
 msgstr "Para establecer argumentos del kernel endurecido, ejecute:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:134
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:135
 msgid "Checking for hardened kernel arguments"
 msgstr "Verificando argumentos del kernel endurecido faltantes"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:150
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:208
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:272
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:714
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:723
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:151
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:209
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:273
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:732
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:741
 #, python-brace-format
 msgid "The file {0} has been modified."
 msgstr "El archivo {0} ha sido modificado."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:162
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:163
 #, python-brace-format
 msgid "{0} should be {1}, but is actually {2}."
 msgstr "{0} debería ser {1}, pero en realidad es {2}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:165
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:166
 msgid "Ensuring no sysctl overrides"
 msgstr "Asegurando que no hayan sobreescrituras de sysctl"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:179
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:180
 #, python-brace-format
 msgid ""
 "The current image is not signed.\n"
@@ -84,103 +84,103 @@ msgstr ""
 "a ejecutar {0}\n"
 "            desde el repositorio de GitHub de secureblue."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:182
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:183
 msgid "Ensuring a signed image is in use"
 msgstr "Asegurando que una imagen firmada está en uso"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:212
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:213
 #, python-brace-format
 msgid "The module {0} is in {1}, but it is loaded."
 msgstr "El módulo {0} está en {1}, pero ya está cargado."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:215
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:216
 msgid "Ensuring no modprobe overrides"
 msgstr "Asegurando que no hayan sobreescrituras de modprobe"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:230
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:231
 #, python-brace-format
 msgid "ptrace is allowed and **unrestricted** ({0})!"
 msgstr "ptrace está permitido y **no está restringido** ({0})!"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:231
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:244
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:232
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:245
 msgid "For more info on what this means, see:"
 msgstr "Para más información sobre lo que esto significa, vea:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:233
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:246
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:234
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:247
 msgid "To forbid ptrace, run:"
 msgstr "Para prohibir ptrace, ejecute:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:235
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:236
 msgid "To allow restricted ptrace, run the above command twice."
 msgstr ""
 "Para permitir ptrace restringido, ejecute el comando de arriba doble vez."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:241
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:242
 #, python-brace-format
 msgid "ptrace is allowed, but restricted ({0})."
 msgstr "ptrace está permitido, pero de forma restringida ({0})."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:251
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:252
 msgid "Ensuring ptrace is forbidden"
 msgstr "Asegurando que ptrace está prohibido"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:261
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:262
 msgid "Ensuring no authselect overrides"
 msgstr "Asegurando que no hayan sobreescrituras de authselect"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:276
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:277
 #, python-brace-format
 msgid "{0} exists."
 msgstr "{0} existe."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:277
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:278
 msgid "Ensuring no container policy overrides"
 msgstr "Asegurando que no hayan sobreescrituras de políticas de contenedores"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:289
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:290
 msgid "Unconfined domain user namespace creation is permitted."
 msgstr ""
 "Creación del dominio de espacios de nombres de usuarios no confinados está "
 "permitido."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:290
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:307
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:291
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:308
 msgid "To disallow it, run:"
 msgstr "Para prohibirlo, ejecute:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:294
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:295
 msgid "Ensuring unconfined user namespace creation disallowed"
 msgstr ""
 "Asegurando que la creación de espacios de nombres de usuarios no confinados "
 "está prohibida"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:306
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:307
 msgid "Container domain user namespace creation is permitted."
 msgstr ""
 "Creación del dominio de espacios de nombres de usuarios para el uso de "
 "contenedores está permitida."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:311
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:312
 msgid "Ensuring container user namespace creation disallowed"
 msgstr ""
 "Asegurando que la creación del dominio de espacios de nombres de usuarios "
 "para el uso de contenedores está prohibida"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:323
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:324
 msgid "USBGuard is enabled but has failed to run."
 msgstr "USBGuard está habilitado pero ha fallado la ejecución."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:326
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:327
 msgid "USBGuard is not enabled."
 msgstr "USBGuard no está habilitado."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:329
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:330
 msgid "To set up USBGuard, run:"
 msgstr "Para configurar USBGuard, ejecute:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:332
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:333
 msgid ""
 "Caution: if you have already set up USBGuard, this will overwrite the "
 "existing policy."
@@ -188,271 +188,284 @@ msgstr ""
 "Precaución: si ya tiene activado USBGuard, esto sobreescribirá la política "
 "existente."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:336
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:337
 msgid "Ensuring USBGuard is active"
 msgstr "Asegurando que USBGuard está activo"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:348
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:472
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:503
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:592
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:349
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:490
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:521
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:610
 #, python-brace-format
 msgid "{0} is enabled but has failed to run."
 msgstr "{0} está habilitado pero ha fallado la ejecución."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:351
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:597
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:352
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:615
 #, python-brace-format
 msgid "{0} is not enabled."
 msgstr "{0} no está habilitado."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:352
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:353
 msgid "To start and enable it, run:"
 msgstr "Para iniciar y habilitarlo, ejecute:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:354
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:355
 msgid "Ensuring chronyd is active"
 msgstr "Asegurando que chronyd está activo"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:382
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:385
 msgid "DNS over HTTPS in Trivalent is disabled."
 msgstr "DNS mediante HTTPS en Trivalent está deshabilitado."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:386
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:389
 msgid "Consider using DNS over HTTPS in Trivalent to hide queries."
 msgstr ""
 "Considere usar DNS mediante HTTPS en Trivalent para esconder consultas de "
 "búsqueda web."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:387
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:402
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:390
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:405
 msgid "However, if you use a VPN, this may cause DNS leaks."
 msgstr "Sin embargo, si usa un VPN, esto puede causar fugas de DNS."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:388
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:403
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:417
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:454
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:480
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:509
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:540
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:575
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:600
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:391
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:406
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:420
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:472
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:498
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:527
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:558
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:593
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:618
 msgid "To enable it, run:"
 msgstr "Para habilitarlo, ejecute:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:397
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:400
 msgid "Secure global DNS is not configured."
 msgstr "La conexión DNS global segura no está configurada."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:401
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:404
 msgid "Consider using secure global DNS."
 msgstr "Considere usar la conexión global DNS segura."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:412
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:415
 msgid "Local DNSSEC validation is disabled."
 msgstr "La validación de DNSSEC local está deshabilitada."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:416
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:419
 msgid "You should enable local DNSSEC validation to prevent DNS hijacking."
 msgstr ""
 "De preferencia habilite la validación de DNSSEC local para prevenir "
 "envenenamiento de DNS."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:428
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:427
+msgid "The secure DNS resolver is not in use, possibly for a VPN."
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:432
+msgid ""
+"If you use a VPN, consider using it with secure DNS. For instructions, see:"
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:435
+msgid "Otherwise, to view or reset your current DNS configuration, run:"
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:446
 msgid "Ensuring system DNS resolution is secure"
 msgstr "Asegurando que la resolución de conexión DNS sea segura"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:445
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:934
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:463
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:952
 #, python-brace-format
 msgid "Unable to read file {0}."
 msgstr "No es posible leer el archivo {0}."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:453
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:471
 msgid "MAC randomization is not enabled."
 msgstr "La aleatorización de MAC no está habilitada."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:460
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:478
 msgid "Ensuring MAC randomization is enabled"
 msgstr "Asegurando que la aleatorización de MAC está habilitada"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:477
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:506
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:495
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:524
 #, python-brace-format
 msgid "{0} is disabled."
 msgstr "{0} está deshabilitado."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:485
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:514
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:605
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:503
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:532
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:623
 #, python-brace-format
 msgid "Ensuring {0} is enabled"
 msgstr "Asegurando que {0} está habilitado"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:532
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:567
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:550
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:585
 #, python-brace-format
 msgid "{0} is enabled globally but has failed to run."
 msgstr "{0} está habilitado globalmente pero ha fallado la ejecución."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:537
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:572
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:555
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:590
 #, python-brace-format
 msgid "{0} is not enabled globally."
 msgstr "{0} no está habilitado globalmente."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:545
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:580
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:563
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:598
 #, python-brace-format
 msgid "Ensuring {0} is enabled globally"
 msgstr "Asegurando que {0} está habilitado globalmente"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:617
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:635
 msgid "The current user is in the wheel group."
 msgstr "El usuario actual está en el grupo wheel."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:618
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:636
 msgid "To set up a separate wheel account, follow the instructions here:"
 msgstr "Para crear una cuenta wheel separada, siga las instrucciones aquí:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:626
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:644
 msgid "Ensuring user is not a member of the wheel group"
 msgstr "Asegurando que el usuario no sea miembro del grupo wheel"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:635
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:653
 msgid "GNOME"
 msgstr "GNOME"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:638
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:656
 msgid "KDE Plasma"
 msgstr "KDE Plasma"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:641
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:659
 msgid "Sway"
 msgstr "Sway"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:651
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:669
 #, python-brace-format
 msgid "Xwayland is enabled for {0}."
 msgstr "Xwayland está habilitado para {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:652
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:751
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:928
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:670
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:769
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:946
 msgid "To disable it, run:"
 msgstr "Para deshabilitarlo, ejecute:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:656
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:674
 #, python-brace-format
 msgid "Ensuring {0} is disabled for {1}"
 msgstr "Asegurando que {0} está deshabilitado para {1}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:679
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:697
 msgid "GNOME user extensions are enabled."
 msgstr "Las extensiones de usuarios de GNOME están habilitadas."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:680
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:698
 msgid "To disable this, run:"
 msgstr "Para deshabilitar esto, ejecute:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:684
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:702
 msgid "Ensuring GNOME user extensions are disabled"
 msgstr ""
 "Asegurando que las extensiones de usuarios de GNOME están deshabilitadas"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:696
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:714
 msgid "SELinux is in Permissive mode."
 msgstr "SELinux está en Modo Permisivo."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:697
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:715
 msgid "To set it to Enforcing mode, run:"
 msgstr "Para configurarlo en Modo Reforzado, ejecute:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:701
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:719
 msgid "Ensuring SELinux is in Enforcing mode"
 msgstr "Asegurando que SELinux está en Modo Reforzado"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:717
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:735
 #, python-brace-format
 msgid "The file {0} has been deleted."
 msgstr "El archivo {0} ha sido eliminado."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:720
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:738
 #, python-brace-format
 msgid "The file {0} cannot be read."
 msgstr "El archivo {0} no puede ser leído."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:724
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:742
 msgid "To reset it, run:"
 msgstr "Para restablecerlo, ejecute:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:728
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:746
 msgid "Ensuring no environment file overrides"
 msgstr ""
 "Asegurando que no hayan sobreescrituras de variables de entorno de archivos"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:744
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:762
 #, python-brace-format
 msgid "The file {0} was not found or inaccessible."
 msgstr "No se encontró el archivo {0} o es inaccesible."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:750
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:768
 msgid "KDE GNHS is enabled."
 msgstr "KDE GNHS está habilitado."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:757
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:775
 msgid "Ensuring KDE GHNS is disabled"
 msgstr "Asegurando que KDE GHNS está deshabilitado"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:771
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:789
 #, python-brace-format
 msgid "The file {0} was not found."
 msgstr "No se encontró el archivo {0}."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:778
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:796
 #, python-brace-format
 msgid "{0} has mode {1:o} (expected {2:o})"
 msgstr "{0} tiene modo {1:o} ({2:o} esperado)"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:782
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:800
 #, python-brace-format
 msgid "{0} is owned by a non-root user!"
 msgstr "{0} le pertenece a un usuario no root!"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:785
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:803
 #, python-brace-format
 msgid "The file {0} has been modified or deleted."
 msgstr "El archivo {0} ha sido modificado o eliminado."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:786
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:804
 msgid "To reset it and enable hardened_malloc for system processes, run:"
 msgstr ""
 "Para restablecer y habilitar hardened_malloc para procesos del sistema, "
 "ejecute:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:791
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:809
 #, python-brace-format
 msgid "Ensuring {0} has expected permissions"
 msgstr "Asegurando que {0} tenga los permisos esperados"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:809
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:827
 #, python-brace-format
 msgid "{0} is set, but {1} has been modified."
 msgstr "{0} está configurado, pero {1} ha sido modificado."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:814
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:817
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:832
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:835
 #, python-brace-format
 msgid "The '{0}' variant of {1} has been set."
 msgstr "La variante '{0}' de {1} ha sido establecida."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:820
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:838
 #, python-brace-format
 msgid "{0} has not been set."
 msgstr "{0} no se ha establecido."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:823
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:841
 #, python-brace-format
 msgid ""
 "The environment variable {0} has been modified or is unset.\n"
@@ -463,107 +476,107 @@ msgstr ""
 "                Verifique que el método {1} no haya sido sobreescrito en\n"
 "                {2} o en archivos de configuración relacionados."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:829
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:847
 msgid "Ensuring hardened_malloc is set to be preloaded"
 msgstr "Asegurando que hardened_malloc está listo para ser precargado"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:856
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:874
 msgid "Your hardware does not support secure boot."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:861
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:879
 msgid ""
 "The system will be unable to verify that kernel modules are signed or the "
 "boot process."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:867
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:885
 msgid "Ensuring secure boot is enabled"
 msgstr "Asegurando que el arranque seguro está habilitado"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:900
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:918
 msgid "Bash environment is not locked down."
 msgstr "Las variables de entorno de Bash no están confinadas."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:901
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:919
 msgid "The following files do not appear to be immutable or do not exist:"
 msgstr "Los siguientes archivos no parecen ser inmutables o no existen:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:903
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:921
 msgid "To fix this, run:"
 msgstr "Para solucionar esto, ejecute:"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:910
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:928
 msgid "Ensuring current user's bash environment is locked down"
 msgstr ""
 "Asegurando que las variables de entorno de Bash del usuario están confinadas"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:927
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:932
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:945
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:950
 msgid "Webcam module is enabled."
 msgstr "El módulo de la cámara web está habilitado."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:937
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:955
 msgid "Checking whether webcam module is disabled"
 msgstr "Verificando si el módulo de la cámara web está habilitado."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:959
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:977
 #, python-brace-format
 msgid "{0} is configured with an unknown URL."
 msgstr "{0} está configurado con una URL desconocida."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:962
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:980
 #, python-brace-format
 msgid "{0} is not a verified flatpak repository."
 msgstr "{0} no es un repositorio de flatpaks verificados."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:965
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:983
 #, python-brace-format
 msgid "Auditing flatpak remote {0}"
 msgstr "Verificando repositorio remoto de flatpaks {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:998
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1016
 #, python-brace-format
 msgid "Auditing {0}"
 msgstr "Verificando {0}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1014
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1032
 msgid "[Audit process interrupted. Exiting.]"
 msgstr "[Proceso de verificación interrumpido. Saliendo.]"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1027
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1045
 msgid "Audit secureblue configuration for security"
 msgstr "Verificando la configuración de secureblue para seguridad"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1031
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1049
 msgid "skip categories"
 msgstr "saltarse categorías"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1032
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1050
 msgid "display output as JSON"
 msgstr "mostrar salida de datos como JSON"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1036
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1054
 #, python-brace-format
 msgid "Valid arguments to {0} are: {1}"
 msgstr "Argumentos válidos de {0} son: {1}"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1044
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1062
 #, python-brace-format
 msgid "*** Error in check '{0}' ***"
 msgstr "*** Error en la verificación '{0}' ***"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1046
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1064
 msgid "*** Continuing... ***"
 msgstr "*** Continuando... ***"
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1049
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1067
 #, python-brace-format
 msgid "Use option '{0}' to skip flatpak recommendations."
 msgstr ""
 "Use la opción '{0}' para saltarse las recomendaciones para los flatpaks."
 
-#: files/system/usr/libexec/secureblue/audit_secureblue.py:1052
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1070
 msgid "*** WARNING: Unexpected error occurred. ***"
 msgstr "*** ADVERTENCIA: Ha ocurrido un error inesperado. ***"
 

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -368,10 +368,12 @@ def audit_dns():
         if ":" not in line:
             continue
         key, value = line.split(":", 1)
-        flags[key.strip()] = value.strip() == "enabled"
-    global_dns = flags.get("Global DNS", False)
-    dnssec = flags.get("DNSSEC", False)
-    trivalent_doh = flags.get("Trivalent DoH", False)
+        flags[key.strip()] = value.strip()
+
+    global_dns = flags.get("Global DNS") == "enabled"
+    dnssec = flags.get("DNSSEC") == "enabled"
+    trivalent_doh = flags.get("Trivalent DoH") == "enabled"
+    unbound = flags.get("DNS Resolver") == "Unbound"
 
     recs = []
     warnings = []
@@ -393,7 +395,7 @@ def audit_dns():
         )
 
     # WARN
-    if not global_dns:
+    if unbound and not global_dns:
         status = WARN
         warnings.append(_("Secure global DNS is not configured."))
         recs.append(
@@ -408,7 +410,7 @@ def audit_dns():
         )
 
     # FAIL
-    if not dnssec:
+    if unbound and not dnssec:
         status = FAIL
         warnings.append(_("Local DNSSEC validation is disabled."))
         recs.append(
@@ -420,8 +422,23 @@ def audit_dns():
                 ]
             )
         )
+    if not unbound:
+        status = FAIL
+        warnings.append(_("The secure DNS resolver is not in use, possibly for a VPN."))
+        recs.append(
+            "\n".join(
+                [
+                    _(
+                        "If you use a VPN, consider using it with secure DNS. For instructions, see:"
+                    ),
+                    bold("https://secureblue.dev/faq#dns-vpn"),
+                    _("Otherwise, to view or reset your current DNS configuration, run:"),
+                    "$ ujust dns-selector",
+                ]
+            )
+        )
 
-    # Since we evaluate INFO -> WARN -> FAIL, put the most important ones first
+    # Since we evaluate INFO -> WARN -> FAIL, put the most important ones first.
     warnings.reverse()
     recs.reverse()
 


### PR DESCRIPTION
Closes #1417.

If Unbound is disabled:
- Remove Global DNS and DNSSEC warnings.
- Add warning: "The secure DNS resolver is not in use, possibly for a VPN."
- Add recommendation:
  ```
  If you use a VPN, consider using it with secure DNS. For instructions, see:
  https://secureblue.dev/faq#dns-vpn
  Otherwise, to view or reset your current DNS configuration, run:
  $ ujust dns-selector
  ```
  