### PR TITLE
fix(securedns): restrict dns-selector menu for unknown DNS

### DIFF
--- a/files/system/usr/libexec/secureblue/dns_selector.py
+++ b/files/system/usr/libexec/secureblue/dns_selector.py
@@ -272,7 +272,7 @@ def run_interactive() -> int:
             """
         ).strip()
     )
-    if DNSResolver.detect() == DNSResolver.RESOLVED:
+    if DNSResolver.detect() != DNSResolver.UNBOUND:
         mode = ask_option(2)
     else:
         print(


### PR DESCRIPTION
Currently, the shortened interactive dns-selector menu (i.e. without DNSSEC etc.) is shown when systemd-resolved is in use.  Since detection for VPN DNS was added (DNSResolver.UNKNOWN), this caused a bug where the extended list is mistakenly shown for VPN DNS as well. This commit shows the short menu whenever Unbound is not in use.