### PR TITLE
ci: add workflow to create PR to update PO files weekly

### DIFF
--- a/.github/workflows/update-po.yml
+++ b/.github/workflows/update-po.yml
@@ -1,0 +1,52 @@
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: update-po
+permissions: {}
+on:
+  schedule:
+    - cron: 00 0 * * MON  # run weekly
+  workflow_dispatch:
+
+jobs:
+  update-po:
+    name: Update PO files
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write  # needed to create branch
+      pull-requests: write  # needed to create pull request
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+        with:
+          persist-credentials: true  # zizmor: ignore[artipacked]
+
+      - name: Update PO files
+        shell: bash
+        run: |
+          python3 files/po/update_po.py
+
+      - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e  # v7.0.8
+        with:
+          add-paths: |
+            files/po/*.pot
+            files/po/*/*.po
+          commit-message: 'chore(i18n): update PO files'
+          branch: create-pull-request/update-po
+          sign-commits: true
+          title: 'chore(i18n): update PO files'
+          body: |
+            Automatically update POT and PO files by running the script `files/po/update_po.py`.
+
+            Translators may need to add new translations to the PO files.


### PR DESCRIPTION
The workflow checks out the repository, runs `files/po/update_po.py`, and (if this results in changes to the POT or PO files) opens a PR with those changes. This will run on a weekly basis.