### PR TITLE
feat: use textarea for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,7 @@ labels: []
 assignees: []
 
 body:
-  - type: input
+  - type: textarea
     id: description
     attributes:      
       label: Description
@@ -14,7 +14,7 @@ body:
     validations:
       required: true
 
-  - type: input
+  - type: textarea
     id: reproduce
     attributes:      
       label: Reproduce
@@ -23,7 +23,7 @@ body:
     validations:
       required: true
 
-  - type: input
+  - type: textarea
     id: expected
     attributes:      
       label: Expected
@@ -32,7 +32,7 @@ body:
     validations:
       required: true
       
-  - type: input
+  - type: textarea
     id: actual
     attributes:      
       label: Actual

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,7 +5,7 @@ labels: []
 assignees: []
 
 body:
-  - type: input
+  - type: textarea
     id: benefit
     attributes:      
       label: Benefit
@@ -14,7 +14,7 @@ body:
     validations:
       required: true
 
-  - type: input
+  - type: textarea
     id: solution
     attributes:      
       label: Solution
@@ -23,7 +23,7 @@ body:
     validations:
       required: true
 
-  - type: input
+  - type: textarea
     id: alternatives
     attributes:      
       label: Alternatives


### PR DESCRIPTION
Changes most of the input fields in the issue templates to full-sized textareas with an adjustable size and formatting tools. 

I have no idea if I did the commit naming scheme right, hopefully that's satisfactory!