### PR TITLE
fix: use "all" instead of "*" for drop_gratuitous_arp sysctl

### DIFF
--- a/files/system/etc/sysctl.d/60-hardening.conf
+++ b/files/system/etc/sysctl.d/60-hardening.conf
@@ -31,12 +31,12 @@ net.ipv6.icmp.echo_ignore_all = 1
 net.ipv4.tcp_timestamps = 0
 
 # Enable IP spoofing protection, turn on source route verification
-# https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt
+# https://docs.kernel.org/networking/ip-sysctl.html
 net.ipv4.conf.all.rp_filter = 1
 net.ipv4.conf.default.rp_filter = 1
 
 # Disable ICMP Redirect Acceptance
-# https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt
+# https://docs.kernel.org/networking/ip-sysctl.html
 net.ipv4.conf.*.send_redirects = 0
 net.ipv4.conf.*.accept_redirects = 0
 net.ipv6.conf.*.accept_redirects = 0
@@ -51,7 +51,7 @@ net.ipv4.conf.*.arp_filter = 1
 net.ipv4.conf.*.arp_ignore = 2
 
 # https://docs.kernel.org/networking/ip-sysctl.html
-net.ipv4.conf.*.drop_gratuitous_arp = 1
+net.ipv4.conf.all.drop_gratuitous_arp = 1
 
 # https://docs.kernel.org/networking/ip-sysctl.html
 net.ipv4.conf.*.accept_source_route = 0
@@ -60,19 +60,19 @@ net.ipv4.tcp_sack=0
 net.ipv4.tcp_dsack=0
 
 # Enable ipv6 privacy extension
-# https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt
+# https://docs.kernel.org/networking/ip-sysctl.html
 net.ipv6.conf.all.use_tempaddr = 2
 net.ipv6.conf.default.use_tempaddr = 2
 
 # Enable Log Spoofed Packets, Source Routed Packets, Redirect Packets
-# https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt
+# https://docs.kernel.org/networking/ip-sysctl.html
 net.ipv4.conf.all.log_martians = 1
 net.ipv4.conf.default.log_martians = 1
 
 # https://docs.kernel.org/admin-guide/sysctl/net.html#bpf-jit-harden
 net.core.bpf_jit_harden = 2
 
-# https://www.kernel.org/doc/Documentation/security/Yama.txt
+# https://www.kernel.org/doc/html/latest/admin-guide/LSM/Yama.html
 kernel.yama.ptrace_scope = 3
 
 # https://docs.kernel.org/admin-guide/sysctl/kernel.html#unprivileged-bpf-disabled


### PR DESCRIPTION
This should fix #1416 while still dropping gratuitous ARP frames.

Also edit links in comments to consistently link to HTML rather than plain-text documentation.