### PR TITLE
feat: give steam flatpak basic perms on install

### DIFF
--- a/files/justfiles/desktop/steam.just
+++ b/files/justfiles/desktop/steam.just
@@ -57,16 +57,13 @@ install-steam:
             echo "Disabling hardened_malloc for Steam."
             flatpak override --user --unset-env=LD_PRELOAD --nofilesystem=host-os com.valvesoftware.Steam
 
-            globalperms="$(flatpak override --user --show)"
-            if [[ "$globalperms" =~ (!network)|(!x11)|(!pulseaudio)|(!multiarch)|(!per-app-dev-shm) ]]; then
-                echo "" # spaced out to be more obvious and for ease of reading
-                echo "Granting Steam necessary permissions for basic functionality, including access to X11 and PulseAudio."
-                echo "This will override the flatpak-permissions-lockdown command, or any other global overrides."
-                echo "Note that to use controllers, you must additionally grant device=input."
-                echo "Games with anti-cheats will likely require granting allow=devel alongside running ujust toggle-anticheat-support."
-                flatpak override --user --share=network --socket=x11 --socket=pulseaudio --allow=multiarch --allow=per-app-dev-shm com.valvesoftware.Steam
-                echo ""
-            fi
+            echo "" # spaced out to be more obvious and for ease of reading
+            echo "Granting Steam necessary permissions for basic functionality, including access to X11 and PulseAudio."
+            echo "This will override the flatpak-permissions-lockdown command, or any other global overrides."
+            echo "Note that to use controllers, you must additionally grant device=input if it is globally denied."
+            echo "Games with anti-cheats will likely require granting allow=devel alongside running ujust toggle-anticheat-support."
+            flatpak override --user --share=network --socket=x11 --socket=pulseaudio --allow=multiarch --allow=per-app-dev-shm com.valvesoftware.Steam
+            echo ""
             ;;
         2)
             echo "Distrobox method selected."

--- a/files/justfiles/desktop/steam.just
+++ b/files/justfiles/desktop/steam.just
@@ -56,6 +56,17 @@ install-steam:
             flatpak install -y flathub com.valvesoftware.Steam
             echo "Disabling hardened_malloc for Steam."
             flatpak override --user --unset-env=LD_PRELOAD --nofilesystem=host-os com.valvesoftware.Steam
+
+            globalperms="$(flatpak override --user --show)"
+            if [[ "$globalperms" =~ (!network)|(!x11)|(!pulseaudio)|(!multiarch)|(!per-app-dev-shm) ]]; then
+                echo "" # spaced out to be more obvious and for ease of reading
+                echo "Granting Steam necessary permissions for basic functionality, including access to X11 and PulseAudio."
+                echo "This will override the flatpak-permissions-lockdown command, or any other global overrides."
+                echo "Note that to use controllers, you must additionally grant device=input."
+                echo "Games with anti-cheats will likely require granting allow=devel alongside running ujust toggle-anticheat-support."
+                flatpak override --user --share=network --socket=x11 --socket=pulseaudio --allow=multiarch --allow=per-app-dev-shm com.valvesoftware.Steam
+                echo ""
+            fi
             ;;
         2)
             echo "Distrobox method selected."

--- a/files/justfiles/desktop/steam.just
+++ b/files/justfiles/desktop/steam.just
@@ -62,7 +62,7 @@ install-steam:
             echo "This will override the flatpak-permissions-lockdown command, or any other global overrides."
             echo "Note that to use controllers, you must additionally grant device=input if it is globally denied."
             echo "Games with anti-cheats will likely require granting allow=devel alongside running ujust toggle-anticheat-support."
-            flatpak override --user --share=network --socket=x11 --socket=pulseaudio --allow=multiarch --allow=per-app-dev-shm com.valvesoftware.Steam
+            flatpak override --user --share=network --share=ipc --socket=x11 --socket=pulseaudio --allow=multiarch --allow=per-app-dev-shm com.valvesoftware.Steam
             echo ""
             ;;
         2)


### PR DESCRIPTION
Considering there is a dedicated script to install Steam, I believe it makes sense to have it set up Steam in at least a minimally functional state, regardless of any hardening features. If one is installing Steam, it can be presumed they wish to use it. Even if flatpak permissions are locked down, it is reasonable to expect the script will grant the basic permissions to be able to start Steam, especially since it disables hardened malloc automatically.

At a bare minimum to execute, Steam requires X11, multiarch, and per-application shared memory. To actually be useful, it needs network access. Realistically, most using it will want to hear their games, requiring PulseAudio as well. As such, users installing Steam are going to enable these 5 permissions. Rather than making them figure this out, it makes sense to automate this.

Users may also wish to grant device=input for controller support, or allow=devel for games with anti-cheat. However, this will not be everyone, and Steam can function without them, so it should still be opt-in. Instead, a notice has been added that these may be desired.

I am completely open to changes, this is just what seemed right to me on a whim.