### PR TITLE
feat: add service to update SELinux contexts in /var

### DIFF
--- a/files/system/usr/lib/systemd/system-preset/40-secureblue.preset
+++ b/files/system/usr/lib/systemd/system-preset/40-secureblue.preset
@@ -2,6 +2,7 @@ enable dnsconfd.service
 enable podman-auto-update.timer
 enable rpm-ostreed-automatic.timer
 enable secureblue-migrate-dns.service
+enable secureblue-selinux-update.service
 enable secureblue-unbound-key.service
 
 disable geoclue.service

--- a/files/system/usr/lib/systemd/system/secureblue-selinux-update.service
+++ b/files/system/usr/lib/systemd/system/secureblue-selinux-update.service
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText 2025 The Secureblue Authors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+[Unit]
+Description=Secureblue SELinux context update
+After=multi-user.target
+Wants=multi-user.target
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/sh -c 'version=$(cat /var/lib/secureblue-selinux-update.stamp 2>/dev/null); [ "$(( version ))" -lt 1 ]'
+ExecStart=/usr/libexec/secureblue/selinux-context-update
+ExecStartPost=/usr/bin/sh -c 'echo 1 > /var/lib/secureblue-selinux-update.stamp'
+
+ProtectSystem=full
+CapabilityBoundingSet=CAP_DAC_OVERRIDE
+DevicePolicy=closed
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateIPC=yes
+PrivateNetwork=yes
+ProcSubset=pid
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+PrivateTmp=yes
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+
+[Install]
+WantedBy=multi-user.target

--- a/files/system/usr/libexec/secureblue/selinux-context-update
+++ b/files/system/usr/libexec/secureblue/selinux-context-update
@@ -1,0 +1,10 @@
+#!/usr/bin/bash
+
+# SPDX-FileCopyrightText 2025 The Secureblue Authors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+set -euo pipefail
+
+# Restore SELinux contexts in /var that are affected by secureblue's changes to SELinux policy.
+/usr/bin/restorecon -R -i /var/lib/flatpak
+/usr/bin/restorecon -R -i /var/{home/*,roothome}/{.local/share/flatpak,.cache/flatpak,.var}


### PR DESCRIPTION
Changes to secureblue's fork of SELinux policy will require changes to file contexts in `/var`, which won't be applied automatically on update. This is especially an issue for the flatpak policy being developed. To handle this, we set up a service to run `restorecon` on the affected files, with a version number to allow for re-running as needed with future updates.

Marking as draft for now; this shouldn't be merged until the SELinux policy fork is in use.