### PR TITLE
feat: prompt to enable systemctl services for post-vpn installation

### DIFF
--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -271,6 +271,46 @@ install-vpn:
         ["proton"]=""
     )
 
+	# Prompts the user to enable a service
+	function systemctl_prompt_enable_only() {
+		local SERVICE="$1.service"
+		if ! systemctl list-unit-files --full --all | grep -Fq "${SERVICE}"; then
+			echo "Service '${SERVICE}' does not exist, try rebooting"
+			return
+		fi
+		if ! systemctl is-enabled --quiet "${SERVICE}"; then
+			local proceedService
+            read -rp "$SERVICE is not enabled, enable and start now? [Y/n]" proceedService
+            if ! [[ "$proceedService" == [nN]* ]]; then
+				systemctl enable "${SERVICE}"
+            fi
+		fi
+		echo "${SERVICE} is enabled"
+	}
+
+	function systemctl_prompt_enable_start() {
+		local SERVICE="$1.service"
+		if ! systemctl list-unit-files --full --all | grep -Fq "${SERVICE}"; then
+			echo "Service '${SERVICE}' does not exist, try rebooting"
+			return
+		fi
+		if ! systemctl is-enabled --quiet "${SERVICE}"; then
+			local proceedService
+            read -rp "$SERVICE is not enabled, enable and start now? [Y/n]" proceedService
+            if ! [[ "$proceedService" == [nN]* ]]; then
+				systemctl enable --now "${SERVICE}"
+            fi
+		fi
+		if ! systemctl is-active --quiet "${SERVICE}"; then
+			local proceedService
+            read -rp "$SERVICE is enabled but not running, start it now? [Y/n]" proceedService
+            if ! [[ "$proceedService" == [nN]* ]]; then
+				systemctl start "${SERVICE}"
+            fi
+		fi
+		echo "${SERVICE} is enabled and running"
+	}
+
     # VPN install logic
     # ref: https://www.ivpn.net/knowledgebase/linux/fedora-silverblue/
     # ref: https://mullvad.net/de/download/vpn/linux
@@ -286,7 +326,8 @@ install-vpn:
 
                 if util_checkpackage "$PACKAGE_NAMES" || util_checkpackage "$PACKAGE_NAMES-ui"; then
                     echo 'Error: IVPN is already installed.'
-                    echo 'Aborting...'
+                    echo 'Checking if systemctl services are enabled and running...'
+					systemctl_prompt_enable_start ivpn-service
                     exit 1
                 fi
 
@@ -296,21 +337,22 @@ install-vpn:
                 if ! [[ "$proceed2" == [nN]* ]]; then
                     PACKAGE_NAMES="$PACKAGE_NAMES $PACKAGE_NAMES-ui"
                 fi
-                INSTRUCTIONS='Successfully installed IVPN. Please execute the command "systemctl enable --now ivpn-service" after rebooting.'
+                INSTRUCTIONS='Successfully installed IVPN. After rebooting, please execute the command "systemctl enable --now ivpn-service", or rerun this script'
                 ;;
 
             "mullvad")
                 PACKAGE_NAMES="mullvad-vpn"
                 REPO_NAME="mullvad"
-
                 if util_checkpackage "$PACKAGE_NAMES"; then
                     echo 'Error: Mullvad VPN is already installed.'
-                    echo 'Aborting...'
+                    echo 'Checking if systemctl services are enabled and running...'
+					systemctl_prompt_enable_only mullvad-daemon
+					systemctl_prompt_enable_start mullvad-early-boot-blocking
                     exit 1
                 fi
 
                 echo 'Installing Mullvad VPN...'
-                INSTRUCTIONS='Successfully installed Mullvad VPN. Please execute the command "systemctl enable --now mullvad-daemon && systemctl enable mullvad-early-boot-blocking" after rebooting.'
+                INSTRUCTIONS='Successfully installed Mullvad VPN. After rebooting, please execute the command "systemctl enable --now mullvad-daemon && systemctl enable mullvad-early-boot-blocking" or rerun this script'
                 ;;
 
             "proton")


### PR DESCRIPTION
# Description

I was having issues with installing Mullvad VPN. With this, when I re-ran the installer, I found that the post-installation instructions were not provided. This meant that the only way to know about post-installation instructions were to grep the installer script, which is not as user friendly.

To surface this information if users attempt to re-install a VPN, which may likely occur if they are debugging, this will reprompt the user to enable / start the relative services if they weren't enabled before.

# Testing

 - [ ] Re-run the installer locally using Podman