### PR TITLE
fix: mask irrelevant coreos service

### DIFF
--- a/files/scripts/disable-coreos-migration-motd.sh
+++ b/files/scripts/disable-coreos-migration-motd.sh
@@ -17,3 +17,4 @@
 set -euo pipefail
 
 systemctl disable coreos-container-signing-migration-motd.service
+systemctl mask coreos-container-signing-migration-motd.service


### PR DESCRIPTION
Otherwise, it is reenabled by the preset:

```
[00:02:55 g.i/s/securecore-main-hardened:latest] => Created symlink '/etc/systemd/system/multi-user.target.wants/coreos-container-signing-migration-motd.service' → '/usr/lib/systemd/system/coreos-container-signing-migration-motd.service'.
```