### PR TITLE
fix: unbreak toggle-anticheat-support

### DIFF
--- a/files/justfiles/common/toggles.just
+++ b/files/justfiles/common/toggles.just
@@ -116,14 +116,21 @@ toggle-anticheat-support:
     set -euo pipefail
     sysctl_ptrace_file='/etc/sysctl.d/61-ptrace-scope.conf'
     umask 022
+    # Remove ptrace_scope = 3 from any lexicographically earlier sysctl conf files.
+    # This is because ptrace_scope = 3 cannot be overridden.
+    for conf_file in /etc/sysctl.d/*.conf; do
+        if [[ "$conf_file" < "$sysctl_ptrace_file" ]]; then
+            sed -i -e '/^kernel.yama.ptrace_scope[[:blank:]]*=[[:blank:]]3/d' "$conf_file"
+        fi
+    done
+    # Set the ptrace_scope value we want in 61-ptrace-scope.conf
     if grep -q '^kernel.yama.ptrace_scope[[:blank:]]*=[[:blank:]]*1$' "$sysctl_ptrace_file" 2>/dev/null; then
         echo 'kernel.yama.ptrace_scope = 3' > "$sysctl_ptrace_file"
-        echo 'Anticheat support disabled. ptrace_scope set back to 3.'
+        echo 'Anticheat support disabled. ptrace_scope set back to 3. Reboot to take effect.'
     else
         echo 'kernel.yama.ptrace_scope = 1' > "$sysctl_ptrace_file"
         echo 'Anticheat support enabled. ptrace_scope set to 1. Reboot to take effect.'
     fi
-    sysctl -p "$sysctl_ptrace_file"
 
 # Toggle bash environment lockdown (mitigates LD_PRELOAD attacks). Use skip_approval to bypass initial prompt, and apply_for_all_users to bypass secondary prompt.
 toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prompt":

--- a/files/justfiles/common/toggles.just
+++ b/files/justfiles/common/toggles.just
@@ -120,7 +120,7 @@ toggle-anticheat-support:
     # This is because ptrace_scope = 3 cannot be overridden.
     for conf_file in /etc/sysctl.d/*.conf; do
         if [[ "$conf_file" < "$sysctl_ptrace_file" ]]; then
-            sed -i -e '/^kernel.yama.ptrace_scope[[:blank:]]*=[[:blank:]]3/d' "$conf_file"
+            sed -i -e '/^kernel.yama.ptrace_scope[[:blank:]]*=[[:blank:]]*3/d' "$conf_file"
         fi
     done
     # Set the ptrace_scope value we want in 61-ptrace-scope.conf

--- a/files/system/etc/sysctl.d/61-ptrace-scope.conf
+++ b/files/system/etc/sysctl.d/61-ptrace-scope.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope = 3

--- a/files/system/usr/lib/sysctl.d/55-hardening.conf
+++ b/files/system/usr/lib/sysctl.d/55-hardening.conf
@@ -72,9 +72,6 @@ net.ipv4.conf.default.log_martians = 1
 # https://docs.kernel.org/admin-guide/sysctl/net.html#bpf-jit-harden
 net.core.bpf_jit_harden = 2
 
-# https://www.kernel.org/doc/html/latest/admin-guide/LSM/Yama.html
-kernel.yama.ptrace_scope = 3
-
 # https://docs.kernel.org/admin-guide/sysctl/kernel.html#unprivileged-bpf-disabled
 kernel.unprivileged_bpf_disabled = 1
 


### PR DESCRIPTION
Unfortunately it seems that `ptrace_scope = 3` not only requires a reboot to change, it also can't be overridden by later sysctl conf files. This means we *cannot* set it in `55-hardening.conf`. Instead:

* Remove `ptrace_scope` from `55-hardening.conf`.
* Set `ptrace_scope = 3` in the `/etc/sysctl.d/61-ptrace-scope.conf` file that's edited by `ujust toggle-anticheat-support`.
* Have `ujust toggle-anticheat-support` remove any instances of `ptrace_scope = 3` from lexicographically earlier conf files in `/etc/sysctl.d`. This will avoid the same issue for people who have a leftover `/etc/sysctl.d/60-hardening.conf` file due to local changes.
* Don't run `sysctl -p` to apply the new setting immediately: it doesn't work if the current setting is 3, and it's immediately irreversible until reboot if the new setting is 3, which is annoying if done accidentally (e.g. if a user mistakenly thought they were enabling rather than disabling ptrace support).

Note: this does mean that the sysctl check in the audit script will no longer check for ptrace_scope. However, this is fine because there's a separate, dedicated check for the value of ptrace_scope, so that was redundant anyway.