### PR TITLE
feat: add oops, warn, and panic related `sysctl` settings

### DIFF
--- a/files/system/usr/lib/sysctl.d/55-hardening.conf
+++ b/files/system/usr/lib/sysctl.d/55-hardening.conf
@@ -93,6 +93,9 @@ kernel.oops_limit=100
 # https://docs.kernel.org/admin-guide/sysctl/kernel.html#warn-limit
 kernel.warn_limit=100
 
+# https://docs.kernel.org/admin-guide/sysctl/kernel.html#panic
+kernel.panic=-1
+
 # https://docs.kernel.org/admin-guide/binfmt-misc.html
 fs.binfmt_misc.status = 0
 

--- a/files/system/usr/lib/sysctl.d/55-hardening.conf
+++ b/files/system/usr/lib/sysctl.d/55-hardening.conf
@@ -87,6 +87,9 @@ kernel.kptr_restrict = 2
 # https://docs.kernel.org/admin-guide/sysctl/kernel.html#dmesg-restrict
 kernel.dmesg_restrict = 1
 
+# https://docs.kernel.org/admin-guide/sysctl/kernel.html#oops-limit
+kernel.oops_limit=100
+
 # https://docs.kernel.org/admin-guide/binfmt-misc.html
 fs.binfmt_misc.status = 0
 

--- a/files/system/usr/lib/sysctl.d/55-hardening.conf
+++ b/files/system/usr/lib/sysctl.d/55-hardening.conf
@@ -90,6 +90,9 @@ kernel.dmesg_restrict = 1
 # https://docs.kernel.org/admin-guide/sysctl/kernel.html#oops-limit
 kernel.oops_limit=100
 
+# https://docs.kernel.org/admin-guide/sysctl/kernel.html#warn-limit
+kernel.warn_limit=100
+
 # https://docs.kernel.org/admin-guide/binfmt-misc.html
 fs.binfmt_misc.status = 0
 


### PR DESCRIPTION
Partially closes https://github.com/secureblue/secureblue/issues/1398#issuecomment-3393875608.

Note that the limits of 100 are preliminary and should over time be reduced after comprehensive testing.