### PR TITLE
fix: don't notify about flatpak provisioning more than once

### DIFF
--- a/files/system/desktop/usr/libexec/secureblue/secureblueflatpaksetup
+++ b/files/system/desktop/usr/libexec/secureblue/secureblueflatpaksetup
@@ -14,6 +14,12 @@
 
 set -euo pipefail
 
+in_progress_indicator=~/.cache/secureblue-flatpak-setup-in-progress
+if [ ! -f "$in_progress_indicator ]; then
+    notify-send -a 'secureblue' -i 'dialog-information' -u normal 'Provisioning core flatpaks, please wait...'
+fi
+touch "$in_progress_indicator"
+
 flatpak remote-add --if-not-exists --user --subset=verified --title='Flathub Verified' flathub-verified https://flathub.org/repo/flathub.flatpakrepo
 ujust harden-flatpak
 
@@ -27,3 +33,5 @@ if [[ "$IMAGE_REF_NAME" == *"silverblue"* ]]; then
     flatpak install --user -y --noninteractive flathub-verified io.github.flattool.Warehouse
 fi
 
+notify-send -a 'secureblue' -i 'dialog-information' -u normal 'Flatpak provisioning completed.'
+rm -f "$in_progress_indicator"

--- a/files/system/desktop/usr/libexec/secureblue/secureblueflatpaksetup
+++ b/files/system/desktop/usr/libexec/secureblue/secureblueflatpaksetup
@@ -15,7 +15,7 @@
 set -euo pipefail
 
 in_progress_indicator=~/.cache/secureblue-flatpak-setup-in-progress
-if [ ! -f "$in_progress_indicator ]; then
+if [ ! -f "$in_progress_indicator" ]; then
     notify-send -a 'secureblue' -i 'dialog-information' -u normal 'Provisioning core flatpaks, please wait...'
 fi
 touch "$in_progress_indicator"

--- a/files/system/desktop/usr/libexec/secureblue/secureblueflatpaksetup
+++ b/files/system/desktop/usr/libexec/secureblue/secureblueflatpaksetup
@@ -14,8 +14,6 @@
 
 set -euo pipefail
 
-notify-send -a 'secureblue' -i 'dialog-information' -u normal 'Provisioning core flatpaks, please wait...'
-
 flatpak remote-add --if-not-exists --user --subset=verified --title='Flathub Verified' flathub-verified https://flathub.org/repo/flathub.flatpakrepo
 ujust harden-flatpak
 
@@ -29,4 +27,3 @@ if [[ "$IMAGE_REF_NAME" == *"silverblue"* ]]; then
     flatpak install --user -y --noninteractive flathub-verified io.github.flattool.Warehouse
 fi
 
-notify-send -a 'secureblue' -i 'dialog-information' -u normal 'Flatpak provisioning completed.'


### PR DESCRIPTION
This fixes commit 9eb808a4c62cb4795ad72d4dd0c3110accfbb591.

With the exponential backoff, it's too spammy