### PR TITLE
fix(securedns): make sure DNS is cleared when switching to systemd-resolved

### DIFF
--- a/files/system/usr/libexec/secureblue/inner/dns.py
+++ b/files/system/usr/libexec/secureblue/inner/dns.py
@@ -175,6 +175,9 @@ def set_resolver(resolver: DNSResolver) -> None:
             SystemdService("unbound.socket").disable_now()
             SystemdService("unbound-control.socket").disable_now()
 
+            # If switching to systemd-resolved for a VPN, we don't want to carry
+            # over global DNS configuration.
+            NM_GLOBALDNS_CONF_PATH.unlink(missing_ok=True)
             DNSCONFD_MANAGER_PATH.unlink(missing_ok=True)
             # systemd-resolved is implicitly detected by NetworkManager based on
             # a resolv.conf symlink.


### PR DESCRIPTION
**Edit:** I've just realised this is already the case. `set-resolver` does `set_global_nm_servers(None)`. I was thinking of this because of a problem someone had rebasing from secureblue w/ Unbound to another Atomic-based image, which understandably broke their DNS.
___

Deletes Global DNS setting when switching to systemd-resolved.

I haven't had any bug reports for this, but I just realised it was missing. I suspect not many people have used the "Unbound + Global DNS -> systemd-resolved" path yet, and `ujust dns-selector status` wouldn't report Global DNS in this situation, so we need to clear it.