### PR TITLE
fix: issues with systemd unit conf files

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -46,5 +46,6 @@ jobs:
             ./.github/workflows/integration_tests/check_cleanup.sh
             ./.github/workflows/integration_tests/check_flatpak_setup.sh
             ./.github/workflows/integration_tests/check_unbound_migration.sh
+            ./.github/workflows/integration_tests/validate_systemd_unit_files.sh
           data-files: |
             ./.github/workflows/integration_tests/expected-audit-silverblue-main-hardened.txt

--- a/.github/workflows/integration_tests/validate_systemd_unit_files.sh
+++ b/.github/workflows/integration_tests/validate_systemd_unit_files.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euxo pipefail
+
+# Check systemd unit files for correctness.
+systemd-analyze verify --recursive-errors=yes multi-user.target
+systemd-analyze verify --user --recursive-errors=yes default.target

--- a/files/system/desktop/usr/lib/systemd/system/flatpak-system-update.service
+++ b/files/system/desktop/usr/lib/systemd/system/flatpak-system-update.service
@@ -3,6 +3,8 @@ Description=Flatpak Automatic Update
 Documentation=man:flatpak(1)
 Wants=network-online.target
 After=network-online.target
+StartLimitIntervalSec=24h
+StartLimitBurst=3
 
 [Service]
 Type=oneshot
@@ -10,5 +12,3 @@ ExecCondition=/bin/bash -c '[[ "$(busctl get-property org.freedesktop.NetworkMan
 ExecStart=/usr/bin/flatpak --system uninstall --unused -y --noninteractive ; /usr/bin/flatpak --system update -y --noninteractive ; /usr/bin/flatpak --system repair
 RestartSec=1h
 Restart=on-failure
-StartLimitIntervalSec=24h
-StartLimitBurst=3

--- a/files/system/desktop/usr/lib/systemd/user/flatpak-user-update.service
+++ b/files/system/desktop/usr/lib/systemd/user/flatpak-user-update.service
@@ -4,6 +4,8 @@ Documentation=man:flatpak(1)
 Wants=network-online.target
 After=network-online.target
 ConditionUser=!@system
+StartLimitIntervalSec=24h
+StartLimitBurst=3
 
 [Service]
 Type=oneshot
@@ -11,5 +13,3 @@ ExecCondition=/bin/bash -c '[[ "$(busctl get-property org.freedesktop.NetworkMan
 ExecStart=/usr/bin/flatpak --user uninstall --unused -y --noninteractive ; /usr/bin/flatpak --user update -y --noninteractive ; /usr/bin/flatpak --user repair
 RestartSec=1h
 Restart=on-failure
-StartLimitIntervalSec=24h
-StartLimitBurst=3

--- a/files/system/desktop/usr/lib/systemd/user/security-update-notification.path
+++ b/files/system/desktop/usr/lib/systemd/user/security-update-notification.path
@@ -1,7 +1,6 @@
 [Unit]
 Description=Monitor for rpm-ostreed-automatic completion
 Wants=paths.target
-After=paths.target
 ConditionUser=!@system
 
 [Path]

--- a/files/system/etc/systemd/system/rpm-ostreed-automatic.service.d/override.conf
+++ b/files/system/etc/systemd/system/rpm-ostreed-automatic.service.d/override.conf
@@ -1,10 +1,10 @@
 [Unit]
 Wants=network-online.target
 After=network-online.target
+StartLimitIntervalSec=24h
+StartLimitBurst=3
 
 [Service]
 ExecCondition=/bin/bash -c '[[ "$(busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Metered | cut -c 3-)" == @(2|4) ]]'
 RestartSec=1h
 Restart=on-failure
-StartLimitIntervalSec=24h
-StartLimitBurst=3


### PR DESCRIPTION
* Fix dependency cycle in `security-update-notification.path`.
* `StartLimitIntervalSec` and `StartLimitBurst` go in the `[Unit]` section, not the `[Service]` section.
* Add integration test that runs `systemd-analyze verify` so this sort of error won't go unnoticed in the future.