### PR TITLE
feat: add ujust get-image-name to utilities.just

### DIFF
--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -15,6 +15,15 @@
 uid := `id -u`
 shell := `grep :$(id -u): /etc/passwd | cut -d: -f7`
 
+# Get name of currently booted image
+get-image-name:
+    #!/usr/bin/bash
+    set -euo pipefail
+    image_ref=$(rpm-ostree status --json --booted | jq -r '.deployments[0]."container-image-reference"')
+    image_name_with_tag="${image_ref##*/}"
+    image_name="${image_name_with_tag%:*}"
+    echo "${image_name}"
+
 # Boot into this device's BIOS/UEFI screen
 bios:
     #!/usr/bin/bash
@@ -49,13 +58,12 @@ enroll-secureblue-secure-boot-key:
 # Toggle display of the user-motd in terminal
 toggle-user-motd:
     #!/usr/bin/bash
-    if test -e "${HOME}/.config/no-show-user-motd"; then
-      rm -f "${HOME}/.config/no-show-user-motd"
+    set -euo pipefail
+    if [ -e ~/.config/no-show-user-motd ]; then
+      rm -f ~/.config/no-show-user-motd
     else
-      if test ! -d "${HOME}/.config"; then
-        mkdir "${HOME}/.config"
-      fi
-      touch "${HOME}/.config/no-show-user-motd"
+      mkdir -p ~/.config
+      touch ~/.config/no-show-user-motd
     fi
 
 # Update device firmware
@@ -404,30 +412,28 @@ install-vpn:
     if [[ "$vpn_requirements" =~ "always_needs_xwayland" || "$vpn_requirements" =~ "gui_needs_xwayland" && "$needs_gui" == "1" ]]; then
         echo
 
-        DE="unknown"
-        IMAGE="$(rpm-ostree status 2>&- | grep '●')"
-        if echo "$IMAGE" | grep -q 'silverblue'; then
-            DE="gnome"
-        elif echo "$IMAGE" | grep -q 'kinoite'; then
-            DE="plasma"
-        elif echo "$IMAGE" | grep -q 'sericea' || echo "$IMAGE" | grep 'sway'; then
-            DE=sway
-        fi
+        case "$(ujust get-image-name || echo 'unknown')" in
+            silverblue-*) DE='gnome' ;;
+            kinoite-*) DE='plasma' ;;
+            sericea-*) DE='sway' ;;
+            *) DE='unknown' ;;
+        esac
 
-        xwayland_enabled="0"
-        if [[ "$DE" == "gnome" ]]; then
-            if ! test -e "/etc/systemd/user/org.gnome.Shell@wayland.service.d/override.conf"; then
-                xwayland_enabled="1"
-            fi
-        elif [[ "$DE" == "plasma" ]]; then
-            if ! test -e "/etc/systemd/user/plasma-kwin_wayland.service.d/override.conf"; then
-                xwayland_enabled="1"
-            fi
-        elif [[ "$DE" == "sway" ]]; then
-            if ! test -e "/etc/sway/config.d/99-noxwayland.conf"; then
-                xwayland_enabled="1"
-            fi
-        fi
+        xwayland_enabled=0
+        case "$DE" in
+            gnome)
+                if ! [ -e "/etc/systemd/user/org.gnome.Shell@wayland.service.d/override.conf" ]; then
+                    xwayland_enabled="1"
+                fi ;;
+            plasma)
+                if ! [ -e "/etc/systemd/user/plasma-kwin_wayland.service.d/override.conf" ]; then
+                    xwayland_enabled="1"
+                fi ;;
+            sway)
+                if ! [ -e "/etc/sway/config.d/99-noxwayland.conf" ]; then
+                    xwayland_enabled="1"
+                fi ;;
+        esac
 
         if [[ "$DE" == "unknown" ]]; then
             echo 'Warning: Unable to identify your desktop environment. Please manually ensure that XWayland is enabled. Skipping...'

--- a/files/justfiles/desktop/xwayland.just
+++ b/files/justfiles/desktop/xwayland.just
@@ -15,30 +15,29 @@
 # Toggle Xwayland support
 toggle-xwayland ACTION="prompt":
     #! /bin/run0 /bin/bash
+    set -euo pipefail
     source /usr/lib/ujust/ujust.sh
     OPTION="{{ ACTION }}"
-    if [ "$OPTION" = "prompt" ]; then
-      IMAGE="$(rpm-ostree status | grep '●')"
-      if echo "$IMAGE" | grep -q 'silverblue'; then
-          OPTION=gnome
-      elif echo "$IMAGE" | grep -q 'kinoite'; then
-          OPTION=plasma
-      elif echo "$IMAGE" | grep -qE 'sericea|sway'; then
-          OPTION=sway
-      else
-        echo "${bold}Toggling Xwayland (requires logout)${unbold}"
-        echo 'For which DE/WM do you want to toggle Xwayland?'
-        OPTION=$(ugum choose "GNOME" "KDE Plasma" "Sway")
-      fi
-    elif [ "$OPTION" = "help" ]; then
-      echo "Usage: ujust toggle-xwayland <option>"
-      echo "  <option>: Specify the quick option - 'gnome', 'plasma', or 'sway'"
-      echo "  Use 'gnome' to Toggle Xwayland for GNOME."
-      echo "  Use 'plasma' to Toggle Xwayland for KDE Plasma."
-      echo "  Use 'sway' to Toggle Xwayland for Sway."
-      exit 0
+    if [ "$OPTION" = 'prompt' ]; then
+      case "$(ujust get-image-name || echo 'unknown')" in
+        silverblue-*)
+          OPTION=gnome ;;
+        kinoite-*)
+          OPTION=plasma ;;
+        sericea-*)
+          OPTION=sway ;;
+        *)
+          echo "${bold}Toggling Xwayland (requires logout)${unbold}"
+          echo 'For which DE/WM do you want to toggle Xwayland?'
+          OPTION=$(ugum choose "GNOME" "KDE Plasma" "Sway")
+          OPTION="${OPTION#KDE }"
+          OPTION="${OPTION,,}"
+          ;;
+      esac
     fi
-    if [ "${OPTION,,}" = "gnome" ]; then
+    case "$OPTION" in
+    prompt) ;;
+    gnome)
       GNOME_XWAYLAND_FILE='/etc/systemd/user/org.gnome.Shell@wayland.service.d/override.conf'
       if [ -e "$GNOME_XWAYLAND_FILE" ]; then
         rm -f "$GNOME_XWAYLAND_FILE"
@@ -48,7 +47,8 @@ toggle-xwayland ACTION="prompt":
         chmod 644 "$GNOME_XWAYLAND_FILE"
         echo 'Xwayland for GNOME has been disabled.'
       fi
-    elif [ "$OPTION" = "KDE Plasma" ] || [ "${OPTION,,}" = "plasma" ]; then
+      ;;
+    plasma)
       PLASMA_XWAYLAND_FILE='/etc/systemd/user/plasma-kwin_wayland.service.d/override.conf'
       if [ -e "$PLASMA_XWAYLAND_FILE" ]; then
         rm -f "$PLASMA_XWAYLAND_FILE"
@@ -58,7 +58,8 @@ toggle-xwayland ACTION="prompt":
         chmod 644 "$PLASMA_XWAYLAND_FILE"
         echo 'Xwayland for KDE Plasma has been disabled.'
       fi
-    elif [ "${OPTION,,}" = "sway" ]; then
+      ;;
+    sway)
       SWAY_XWAYLAND_FILE='/etc/sway/config.d/99-noxwayland.conf'
       if [ -e "$SWAY_XWAYLAND_FILE" ]; then
         rm -f "$SWAY_XWAYLAND_FILE"
@@ -68,4 +69,17 @@ toggle-xwayland ACTION="prompt":
         chmod 644 "$SWAY_XWAYLAND_FILE"
         echo "Xwayland for Sway has been disabled."
       fi
-    fi
+      ;;
+    help)
+      echo "Usage: ujust toggle-xwayland [option]"
+      echo "  [option]: Specify the quick option - 'gnome', 'plasma', or 'sway'"
+      echo "  Use 'gnome' to toggle Xwayland for GNOME."
+      echo "  Use 'plasma' to toggle Xwayland for KDE Plasma."
+      echo "  Use 'sway' to toggle Xwayland for Sway."
+      exit 0
+      ;;
+    *)
+      echo "Unknown option '${OPTION}'." >&2
+      exit 1
+      ;;
+    esac


### PR DESCRIPTION
This provides a simple way for scripts to get the current image name (e.g. `silverblue-main-hardened`) without having to duplicate logic for parsing `rpm-ostree status`. Also:

* Use this new ujust to simplify `ujust install-vpn` and `ujust toggle-xwayland`.
* Add `set -euo pipefail` to `ujust toggle-xwayland`, and improve error handling so invalid options aren't silently ignored.
* Slightly simplify `ujust toggle-user-motd`.