### PR TITLE
fix: integration tests

### DIFF
--- a/.github/workflows/integration_tests/check_flatpak_setup.sh
+++ b/.github/workflows/integration_tests/check_flatpak_setup.sh
@@ -45,7 +45,7 @@ if ! systemctl --user is-enabled --quiet "${timer_name}"; then
 fi
 
 # Wait a few seconds to give the service time to start
-sleep 5
+sleep 20
 
 state=$(systemctl --user show "${service_name}" --property=ActiveState | sed 's/^ActiveState=//')
 
@@ -56,7 +56,7 @@ if [ -e "$HOME/.config/secureblue/secureblue-flatpak-setup.stamp" ]; then
 elif [ "${state}" = 'activating' ] || [ "${state}" = 'active' ]; then
     echo "${service_name} is currently running."
     # flathub-verified remote should be added first, so wait a few more seconds then test for it.
-    sleep 5
+    sleep 20
     check-flatpak-remotes
 elif [ "${state}" = 'failed' ]; then
     test-fail "${service_name} is in a failed state."

--- a/.github/workflows/integration_tests/expected-audit-silverblue-main-hardened.txt
+++ b/.github/workflows/integration_tests/expected-audit-silverblue-main-hardened.txt
@@ -1,5 +1,5 @@
 {"name":"audit_kargs","description":"Checking for hardened kernel arguments","status":"warn","warnings":["Missing kernel argument: ia32_emulation=0 (32-bit support)","Missing kernel argument: nosmt=force (force-disable SMT)","Missing kernel argument (unstable): amd_iommu=force_isolation","Missing kernel argument (unstable): debugfs=off","Missing kernel argument (unstable): efi=disable_early_pci_dma","Missing kernel argument (unstable): gather_data_sampling=force","Missing kernel argument (unstable): oops=panic"]}
-{"name":"audit_sysctl","description":"Ensuring no sysctl overrides","status":"fail","warnings":["kernel.printk should be 3 3 3 3, but is actually 0\t3\t3\t3."]}
+{"name":"audit_sysctl","description":"Ensuring no sysctl overrides","status":"pass","warnings":[]}
 {"name":"audit_signed_image","description":"Ensuring a signed image is in use","status":"fail","warnings":[]}
 {"name":"audit_modprobe","description":"Ensuring no modprobe overrides","status":"pass","warnings":[]}
 {"name":"audit_ptrace","description":"Ensuring ptrace is forbidden","status":"pass","warnings":[]}


### PR DESCRIPTION
* Sleep for longer in `check_flatpak_setup.sh` to reduce chance of test running before service has a chance to run.
* Update expected audit results: the mysterious issue with `kernel.printk` seems to have resolved itself for some reason.