### PR TITLE
chore: add IOT image support to audit script

### DIFF
--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -379,7 +379,7 @@ def audit_dns(state):
     status = PASS
 
     # INFO
-    if not trivalent_doh and state["image"] != Image.COREOS:
+    if not trivalent_doh and state["image"] not in (Image.COREOS, Image.IOT):
         status = INFO
         warnings.append(_("DNS over HTTPS in Trivalent is disabled."))
         recs.append(

--- a/files/system/usr/libexec/secureblue/dns_selector.py
+++ b/files/system/usr/libexec/secureblue/dns_selector.py
@@ -25,7 +25,7 @@ import textwrap
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
-from typing import Final, Optional
+from typing import Final
 from urllib.parse import urlparse
 
 import sandbox
@@ -109,8 +109,8 @@ def ask_should_validate_dnssec() -> bool:
 class DNSServers:
     """A DNS server to be set as a global upstream by NetworkManager."""
 
-    servers_csv: Optional[str]
-    https_endpoint: Optional[str]
+    servers_csv: str | None
+    https_endpoint: str | None
 
 
 def _ask_custom_ips() -> str:
@@ -468,7 +468,7 @@ def ask_valid_ipv6(prompt: str) -> str:
             print("Invalid IPv6 address, try again.")
 
 
-def ask_valid_https(prompt: str) -> Optional[str]:
+def ask_valid_https(prompt: str) -> str | None:
     """Returns a valid HTTPS URL."""
     while True:
         raw_url = interruptible_ask(prompt)

--- a/files/system/usr/libexec/secureblue/inner/dns.py
+++ b/files/system/usr/libexec/secureblue/inner/dns.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass
 from enum import Enum
 from functools import partialmethod
 from pathlib import Path
-from typing import Final, Optional
+from typing import Final
 
 DNSCONFD_CONF_PATH: Final[Path] = Path("/etc/dnsconfd.conf")
 DNSCONFD_MANAGER_PATH: Final[Path] = Path("/etc/NetworkManager/conf.d/dnsconfd.conf")
@@ -185,7 +185,7 @@ def set_resolver(resolver: DNSResolver) -> None:
             DNSResolver.RESOLVED.service.enable()
 
 
-def set_global_nm_servers(servers: Optional[str] = None) -> None:
+def set_global_nm_servers(servers: str | None = None) -> None:
     """
     Set NetworkManager global DNS servers.
 
@@ -210,7 +210,7 @@ def set_global_nm_servers(servers: Optional[str] = None) -> None:
     NM_GLOBALDNS_CONF_PATH.chmod(0o644)
 
 
-def set_trivalent_doh_endpoint(https_endpoint: Optional[str] = None) -> None:
+def set_trivalent_doh_endpoint(https_endpoint: str | None = None) -> None:
     """
     Sets Trivalent DNS over HTTPS policy.
 

--- a/files/system/usr/libexec/secureblue/utils/__init__.py
+++ b/files/system/usr/libexec/secureblue/utils/__init__.py
@@ -185,21 +185,22 @@ class Image(enum.Enum):
     SERICEA = enum.auto()
     COSMIC = enum.auto()
     COREOS = enum.auto()
+    IOT = enum.auto()
 
     @classmethod
     def from_image_ref(cls, image_ref: str) -> "Image | None":
         """Convert an image reference to the corresponding Image enum instance."""
-        if "silverblue" in image_ref:
-            return cls.SILVERBLUE
-        if "kinoite" in image_ref:
-            return cls.KINOITE
-        if "sericea" in image_ref:
-            return cls.SERICEA
-        if "cosmic" in image_ref:
-            return cls.COSMIC
-        if "securecore" in image_ref:
-            return cls.COREOS
-        return None
+        image_dict = {
+            "silverblue": cls.SILVERBLUE,
+            "kinoite": cls.KINOITE,
+            "sericea": cls.SERICEA,
+            "cosmic": cls.COSMIC,
+            "securecore": cls.COREOS,
+            "iot": cls.IOT,
+        }
+        image_name = image_ref.rsplit("/", maxsplit=1)[-1]
+        image_prefix = image_name.split("-", maxsplit=1)[0]
+        return image_dict.get(image_prefix)
 
 
 async def get_flatpak_permissions(name: str, version: str) -> str:


### PR DESCRIPTION
Add `Image.IOT` variant for `iot-*` images, and exempt IOT images from Trivalent DNS check (same as CoreOS images). Also improve parsing in `Image.from_image_ref` and fix some style issues flagged by Ruff.