### PR TITLE
feat: harden bluetooth.service

### DIFF
--- a/files/system/usr/lib/systemd/system/bluetooth.service.d/40-secureblue.conf
+++ b/files/system/usr/lib/systemd/system/bluetooth.service.d/40-secureblue.conf
@@ -1,0 +1,41 @@
+[Service]
+# We could also create an unprivileged user, but permissions must be manually
+# managed (i.e. not StateDirectory): init_t cannot setattr on file
+# bluetooth_var_lib_t.
+
+# This works for PAN-NAP too.
+RestrictAddressFamilies=AF_UNIX AF_BLUETOOTH AF_NETLINK
+IPAddressDeny=any
+
+SystemCallFilter=@system-service
+SystemCallArchitectures=native
+
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+RestrictNamespaces=yes
+LockPersonality=yes
+
+ProtectProc=invisible
+ProtectClock=yes
+PrivateMounts=yes
+RestrictSUIDSGID=yes
+
+# Devices - see dev_* in bluetooth.te.
+DevicePolicy=closed
+
+# Using /proc/devices lets us handle hotplugging.
+# dev_rw_input_dev
+DeviceAllow=char-input rw
+# dev_rw_usbfs
+DeviceAllow=char-usb rw
+# dev_rw_generic_usb_dev
+DeviceAllow=char-usb_device rw
+# dev_read_sound, dev_write_sound
+DeviceAllow=char-alsa rw
+
+# We could use char-misc here, but it's quite broad.
+# dev_rw_uhid_dev
+DeviceAllow=/dev/uhid rw
+# dev_rw_wireless
+DeviceAllow=/dev/rfkill rw
+DeviceAllow=/dev/hci* rw


### PR DESCRIPTION
- I might need additional testing with Bluetooth tethering here. It was kinda broken before (only works with a newly paired device), and has the same trouble now.
- The upstream Fedora service includes some limited hardening in this case, such as `NoNewPrivileges=true` and `ProtectSystem=strict`.
  - If I don't include these in the override, they seem like undocumented omissions, and any upstream changes could cause issues.
  - We could bake their .service hardening into this override instead, but we might have a licensing issue there? (`GPL-2.0-or-later`)
  - We could replace the whole service, but that may be more likely to cause breakage.
 - Any thoughts would be helpful to guide further contributors/service overrides. I know this service wasn't an especially high priority, but another user was interested.