### PR TITLE
fix: preload libno_rlimit_as.so

### DIFF
--- a/files/scripts/hardened_malloc-pam.sh
+++ b/files/scripts/hardened_malloc-pam.sh
@@ -14,4 +14,4 @@
 
 set -euo pipefail
 
-sed -i -e '$a\LD_PRELOAD DEFAULT=libhardened_malloc.so' -e '/^LD_PRELOAD[[:space:]]/d' /etc/security/pam_env.conf
+sed -i -e '$a\LD_PRELOAD DEFAULT="libhardened_malloc.so libno_rlimit_as.so"' -e '/^LD_PRELOAD[[:space:]]/d' /etc/security/pam_env.conf

--- a/files/system/etc/profile.d/hardened_malloc.sh
+++ b/files/system/etc/profile.d/hardened_malloc.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/sh
-export LD_PRELOAD=libhardened_malloc.so
+export LD_PRELOAD='libhardened_malloc.so libno_rlimit_as.so'

--- a/files/system/usr/lib/environment.d/40-hardened_malloc.conf
+++ b/files/system/usr/lib/environment.d/40-hardened_malloc.conf
@@ -1,1 +1,1 @@
-LD_PRELOAD=libhardened_malloc.so
+LD_PRELOAD=libhardened_malloc.so libno_rlimit_as.so

--- a/files/system/usr/lib/systemd/system.conf.d/40-hardened_malloc.conf
+++ b/files/system/usr/lib/systemd/system.conf.d/40-hardened_malloc.conf
@@ -1,2 +1,2 @@
 [Manager]
-DefaultEnvironment=LD_PRELOAD=libhardened_malloc.so
+DefaultEnvironment="LD_PRELOAD=libhardened_malloc.so libno_rlimit_as.so"

--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -16,6 +16,7 @@ repos:
     - https://copr.fedorainfracloud.org/coprs/secureblue/bubblejail/repo/fedora-%OS_VERSION%/secureblue-bubblejail-fedora-%OS_VERSION%.repo
     - https://repo.secureblue.dev/secureblue.repo
     - https://copr.fedorainfracloud.org/coprs/secureblue/branding/repo/fedora-%OS_VERSION%/secureblue-branding-fedora-%OS_VERSION%.repo
+    - https://copr.fedorainfracloud.org/coprs/secureblue/no_rlimit_as/repo/fedora-%OS_VERSION%/secureblue-no_rlimit_as-fedora-%OS_VERSION%.repo
 install:
   packages:
     - headsetcontrol
@@ -39,6 +40,9 @@ install:
 
     # ensure universal font coverage
     - google-noto-fonts-all
+
+    # address hardened_malloc incompatibilities
+    - no_rlimit_as
 remove:
   packages:
     - firefox


### PR DESCRIPTION
This hooks into `setrlimit` and makes it a no-op when called with `RLIMIT_AS`, preventing processes from reducing their own address space, which breaks hardened_malloc. See [no_rlimit_as](https://github.com/HastD/no_rlimit_as) for details.

`/etc/ld.so.preload` is *not* modified in the same way, which means `setrlimit` calls by PID 1 won't be affected.