### PR TITLE
fix: suppress spammy AVC denials from Trivalent reading /proc

### DIFF
--- a/files/scripts/selinux/trivalent/trivalent.te
+++ b/files/scripts/selinux/trivalent/trivalent.te
@@ -315,6 +315,13 @@ allow trivalent_script_t dosfs_t:filesystem remount;
 allow trivalent_script_t null_device_t:chr_file mounton;
 allow trivalent_script_t trivalent_t:process2 { nosuid_transition nnp_transition };
 
+# Do not audit attempts to read /proc/PID for other processes.
+optional_policy(`
+	gen_require(`
+		attribute domain;
+	')
+	dontaudit trivalent_script_t domain:dir getattr;
+')
 
 # xwayland/nvidia
 xserver_exec(trivalent_script_t)


### PR DESCRIPTION
The Trivalent launch script reads `/proc` to determine whether an instance of Trivalent is already running, and this results in a bunch of irrelevant SELinux denials from attempting to read other processes' info. This `dontaudit` rule suppresses those messages.