### PR TITLE
chore: Include pipewire-libs-extra now that pipewire-1.4.9-1 is shipping.

### DIFF
--- a/recipes/common/proprietary-modules.yml
+++ b/recipes/common/proprietary-modules.yml
@@ -22,7 +22,7 @@ modules:
           - heif-pixbuf-loader
           - ffmpegthumbnailer
           - rar
-          # - pipewire-libs-extra uncomment once this ships https://bodhi.fedoraproject.org/updates/FEDORA-2025-1299cfef2f
+          - pipewire-libs-extra
       replace:  
         - from-repo: fedora-multimedia
           packages:


### PR DESCRIPTION
As outlined in the original comment, pipewire 1.4.9-1 is now shipping and the negativo17 pipewire-libs-extra should be included to support additional proprietary audio formats.