### PR TITLE
feat: add two more kernel arguments

### DIFF
--- a/files/system/usr/lib/bootc/kargs.d/10-secureblue.toml
+++ b/files/system/usr/lib/bootc/kargs.d/10-secureblue.toml
@@ -1,5 +1,4 @@
 kargs = [
-  "bdev_allow_write_mounted=0",
   "init_on_alloc=1",
   "init_on_free=1",
   "intel_iommu=on",

--- a/files/system/usr/lib/bootc/kargs.d/10-secureblue.toml
+++ b/files/system/usr/lib/bootc/kargs.d/10-secureblue.toml
@@ -1,4 +1,5 @@
 kargs = [
+  "bdev_allow_write_mounted=0",
   "init_on_alloc=1",
   "init_on_free=1",
   "intel_iommu=on",
@@ -14,6 +15,7 @@ kargs = [
   "mitigations=auto,nosmt",
   "module.sig_enforce=1",
   "page_alloc.shuffle=1",
+  "proc_mem.force_override=ptrace",
   "pti=on",
   "random.trust_bootloader=off",
   "random.trust_cpu=off",

--- a/files/system/usr/libexec/secureblue/kargs_hardening_common/__init__.py
+++ b/files/system/usr/libexec/secureblue/kargs_hardening_common/__init__.py
@@ -36,6 +36,7 @@ FORCE_NOSMT = "nosmt=force"
 
 UNSTABLE_KARGS = [
     "amd_iommu=force_isolation",
+    "bdev_allow_write_mounted=0",
     "debugfs=off",
     "efi=disable_early_pci_dma",
     "gather_data_sampling=force",


### PR DESCRIPTION
* `proc_mem.force_override=ptrace`: Prevent processes from modifying memory mappings via `/proc/<pid>/mem` unless the process is attached via ptrace.
* `bdev_allow_write_mounted=0`: Prevent direct writes to block devices, which in most circumstances is likely to cause filesystem corruption. Added to unstable (not default) kargs.

Thanks to @raja-grewal for suggesting these (in #1393).