### PR TITLE
feat(selinux): make Trivalent policy role-agnostic

### DIFF
--- a/files/scripts/selinux/flatpakfull/flatpakfull.te
+++ b/files/scripts/selinux/flatpakfull/flatpakfull.te
@@ -31,16 +31,16 @@ optional_policy(`
 optional_policy(`
 	gen_require(`
 		type unconfined_t;
-		type trivalent_t;
+		attribute trivalent_domain;
 		role unconfined_r;
 	')
 
 	flatpak_run(unconfined_t, unconfined_r)
-	flatpak_run(trivalent_t, unconfined_r)
-	
+	flatpak_run(trivalent_domain, unconfined_r)
+
 	# required for trivalent/flatpak clipboard sharing
-	allow trivalent_t flatpak_t:fifo_file write;
+	allow trivalent_domain flatpak_t:fifo_file write;
 
 	# required for trivalent/flatpak integration
-	allow trivalent_t flatpak_t:process2 { nnp_transition nosuid_transition };
+	allow trivalent_domain flatpak_t:process2 { nnp_transition nosuid_transition };
 ')

--- a/files/scripts/selinux/nautilus/nautilus.te
+++ b/files/scripts/selinux/nautilus/nautilus.te
@@ -24,10 +24,10 @@ unconfined_domain_noaudit(nautilus_t)
 optional_policy(`
 	gen_require(`
 		type unconfined_t;
-		type trivalent_t;
+		attribute trivalent_domain;
 		role unconfined_r;
 	')
 
 	nautilus_run(unconfined_t, unconfined_r)
-	nautilus_run(trivalent_t, unconfined_r)
+	nautilus_run(trivalent_domain, unconfined_r)
 ')

--- a/files/scripts/selinux/systemsettings/systemsettings.te
+++ b/files/scripts/selinux/systemsettings/systemsettings.te
@@ -25,12 +25,12 @@ unconfined_domain_noaudit(systemsettings_t)
 optional_policy(`
 	gen_require(`
 		type unconfined_t;
-		type trivalent_t;
+		attribute trivalent_domain;
 		role unconfined_r;
 	')
 
 	systemsettings_run(unconfined_t, unconfined_r)
-	systemsettings_run(trivalent_t, unconfined_r)
+	systemsettings_run(trivalent_domain, unconfined_r)
 ')
 
 # Required for accountsd to access systemsettings's tmp file.

--- a/files/scripts/selinux/thunar/thunar.te
+++ b/files/scripts/selinux/thunar/thunar.te
@@ -24,10 +24,10 @@ unconfined_domain_noaudit(thunar_t)
 optional_policy(`
 	gen_require(`
 		type unconfined_t;
-		type trivalent_t;
+		attribute trivalent_domain;
 		role unconfined_r;
 	')
 
 	thunar_run(unconfined_t, unconfined_r)
-	thunar_run(trivalent_t, unconfined_r)
+	thunar_run(trivalent_domain, unconfined_r)
 ')

--- a/files/scripts/selinux/trivalent/trivalent.if
+++ b/files/scripts/selinux/trivalent/trivalent.if
@@ -6,103 +6,91 @@
 
 ########################################
 ## <summary>
-##	Execute trivalent in the trivalent domain.
+##	Allow role to run Trivalent from the given domain.
 ## </summary>
-## <param name="domain">
-## <summary>
-##	Domain allowed to transition.
-## </summary>
-## </param>
-#
-interface(`trivalent_domtrans',`
-	gen_require(`
-		type trivalent_t, trivalent_exec_t;
-	')
-
-	domtrans_pattern($1, trivalent_exec_t, trivalent_t)
-')
-
-
-########################################
-## <summary>
-##	Execute trivalent in the trivalent domain.
-## </summary>
-## <param name="domain">
-## <summary>
-##	Domain allowed to transition.
-## </summary>
+## <param name="domain_prefix">
+##	<summary>
+##	The prefix of the domain (e.g., user is the prefix for user_t).
+##	</summary>
 ## </param>
 ## <param name="role">
 ##	<summary>
-##	Role allowed access.
+##	Role (or role attribute) allowed access.
+##	</summary>
+## </param>
+## <param name="domain">
+##	<summary>
+##	User domain for the role.
 ##	</summary>
 ## </param>
 #
-interface(`trivalent_run',`
+template(`trivalent_role_template',`
 	gen_require(`
-		type trivalent_t;
 		attribute_role trivalent_roles;
+		attribute trivalent_domain;
+		attribute trivalent_script_domain;
 	')
 
-	trivalent_domtrans($1)
+	##############################
+	#
+	# Declarations
+	#
+
 	roleattribute $2 trivalent_roles;
-')
 
+	type $1_trivalent_t, trivalent_domain;
+	application_domain($1_trivalent_t, trivalent_exec_t)
+	ubac_constrained($1_trivalent_t)
 
+	type $1_trivalent_script_t, trivalent_script_domain;
+	application_domain($1_trivalent_script_t, trivalent_script_exec_t)
+	ubac_constrained($1_trivalent_script_t)
 
-########################################
-## <summary>
-##	Execute trivalent script in the trivalent script domain.
-## </summary>
-## <param name="domain">
-## <summary>
-##	Domain allowed to transition.
-## </summary>
-## </param>
-#
-interface(`trivalent_script_domtrans',`
-	gen_require(`
-		type trivalent_script_t, trivalent_script_exec_t;
+	role $2 types { $1_trivalent_t $1_trivalent_script_t };
+
+	##############################
+	#
+	# Local policy
+	#
+
+	domtrans_pattern($3, trivalent_script_exec_t, $1_trivalent_script_t)
+	domtrans_pattern($1_trivalent_script_t, trivalent_exec_t, $1_trivalent_t)
+	allow $1_trivalent_script_t $1_trivalent_t:process2 { nosuid_transition nnp_transition };
+	trivalent_filetrans_home_content($3)
+
+	# screenshare access
+	allow $1_trivalent_t $3:unix_stream_socket { connectto rw_socket_perms };
+
+	kernel_read_system_state($1_trivalent_t)
+	pulseaudio_tmpfs_content($1_trivalent_t)
+
+	optional_policy(`
+		gen_require(`
+			type user_tmpfs_t;
+		')
+		xserver_user_x_domain_template($1_trivalent, $1_trivalent_t, user_tmpfs_t)
 	')
 
-	domtrans_pattern($1, trivalent_script_exec_t, trivalent_script_t)
+	# Trivalent-Flatpak integration
+	# uncomment this once new flatpak policy is in use
+	# optional_policy(`
+	# 	flatpak_role_template($1_trivalent, $2, $1_trivalent_t, $1_t)
+	# 	allow $1_trivalent_t $1_trivalent_flatpak_t:process2 { nnp_transition nosuid_transition };
+	# 	write_fifo_files_pattern($1_trivalent_flatpak_t, $1_trivalent_script_t, $1_trivalent_script_t)
+	# 	# write_fifo_files_pattern($3, $1_trivalent_script_t, $1_trivalent_script_t)
+	# ')
 ')
 
 
 ########################################
 ## <summary>
-##	Execute trivalent script in the trivalent script domain.
+##	Create trivalent directory in the user home directory
+##	with an correct label.
 ## </summary>
 ## <param name="domain">
-## <summary>
-##	Domain allowed to transition.
-## </summary>
-## </param>
-## <param name="role">
 ##	<summary>
-##	Role allowed access.
+##	Domain allowed access.
 ##	</summary>
-## </param>
-#
-interface(`trivalent_script_run',`
-	gen_require(`
-		type trivalent_script_t;
-		attribute_role trivalent_script_roles;
-	')
-
-	trivalent_script_domtrans($1)
-	roleattribute $2 trivalent_script_roles;
-')
-
-########################################
-## <summary>
-##      Create trivalent directory in the user home directory
-##      with an correct label.
-## </summary>
-## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
 ## </param>
 #
 interface(`trivalent_filetrans_home_content',`

--- a/files/scripts/selinux/trivalent/trivalent.te
+++ b/files/scripts/selinux/trivalent/trivalent.te
@@ -19,33 +19,28 @@ policy_module(trivalent, 1.0.0)
 ## </desc>
 gen_tunable(trivalent_rwmap_video_dev, true)
 
-
-# trivalent executable
 attribute_role trivalent_roles;
-roleattribute object_r trivalent_roles;
 
-type trivalent_t;
-type trivalent_home_t;
+attribute trivalent_domain;
+attribute trivalent_script_domain;
+
 type trivalent_exec_t;
-domain_type(trivalent_t, trivalent_exec_t)
-application_domain(trivalent_t, trivalent_exec_t)
+application_executable_file(trivalent_exec_t)
 
-role trivalent_roles types { trivalent_t trivalent_home_t };
-
+type trivalent_home_t;
 userdom_user_home_content(trivalent_home_t)
 
-# trivalent script
-attribute_role trivalent_script_roles;
-roleattribute object_r trivalent_script_roles;
-
-type trivalent_script_t;
 type trivalent_script_exec_t;
-domain_type(trivalent_script_t, trivalent_script_exec_t)
-application_domain(trivalent_script_t, trivalent_script_exec_t)
+application_executable_file(trivalent_script_exec_t)
 
-role trivalent_script_roles types trivalent_script_t;
+
+##############################
+#
+# Local policy
+#
 
 gen_require(`
+	attribute userdomain;
 	class dbus acquire_svc;
 	type audio_home_t;
 	type chrome_sandbox_home_t;
@@ -62,222 +57,277 @@ gen_require(`
 	type nsfs_t;
 	type tmp_t;
 	type tmpfs_t;
-	type unconfined_t;
-	type unconfined_dbusd_t;
 	type user_home_t;
 	type xserver_misc_device_t;
 ')
 
+trivalent_filetrans_home_content(userdomain)
+trivalent_filetrans_home_content(trivalent_domain)
+trivalent_filetrans_home_content(trivalent_script_domain)
+
 # internal
-allow trivalent_t self:process { dyntransition transition execmem getcap getsched ptrace setcap setrlimit setsched sigkill signal signull };
-allow trivalent_t self:dir { manage_dir_perms };
-allow trivalent_t self:file { manage_file_perms execute map };
-allow trivalent_t self:lnk_file { manage_lnk_file_perms };
-allow trivalent_t self:fifo_file rw_fifo_file_perms;
-allow trivalent_t self:sem create_sem_perms;
-allow trivalent_t self:netlink_kobject_uevent_socket client_stream_socket_perms;
-allow trivalent_t self:user_namespace create;
-allow trivalent_t self:unix_stream_socket { connectto rw_socket_perms };
-allow trivalent_t self:cap_userns { sys_admin sys_chroot sys_ptrace net_admin setpcap };
-allow trivalent_t self:capability { dac_read_search sys_admin sys_chroot sys_ptrace };
-allow trivalent_t self:fifo_file { manage_fifo_file_perms relabelfrom relabelto };
-allow trivalent_t self:dir rw_dir_perms;
-allow trivalent_t self:socket_class_set create_socket_perms;
-allow trivalent_t self:tcp_socket { accept listen };
-allow trivalent_t trivalent_exec_t:file execute_no_trans;
-allow trivalent_t chrome_sandbox_home_t:dir { manage_dir_perms };
-allow trivalent_t chrome_sandbox_home_t:file { manage_file_perms execute map };
-allow trivalent_t chrome_sandbox_home_t:lnk_file { manage_lnk_file_perms };
-allow trivalent_t trivalent_home_t:dir { manage_dir_perms };
-allow trivalent_t trivalent_home_t:file { manage_file_perms execute map };
-allow trivalent_t trivalent_home_t:lnk_file { manage_lnk_file_perms };
-allow trivalent_t self:netlink_route_socket { nlmsg_read nlmsg_write };
+allow trivalent_domain self:process { dyntransition transition execmem getcap getsched ptrace setcap setrlimit setsched sigkill signal signull };
+allow trivalent_domain self:dir { manage_dir_perms };
+allow trivalent_domain self:file { manage_file_perms execute map };
+allow trivalent_domain self:lnk_file { manage_lnk_file_perms };
+allow trivalent_domain self:fifo_file rw_fifo_file_perms;
+allow trivalent_domain self:sem create_sem_perms;
+allow trivalent_domain self:netlink_kobject_uevent_socket client_stream_socket_perms;
+allow trivalent_domain self:user_namespace create;
+allow trivalent_domain self:unix_stream_socket { connectto rw_socket_perms };
+allow trivalent_domain self:cap_userns { sys_admin sys_chroot sys_ptrace net_admin setpcap };
+allow trivalent_domain self:capability { dac_read_search sys_admin sys_chroot sys_ptrace };
+allow trivalent_domain self:fifo_file { manage_fifo_file_perms relabelfrom relabelto };
+allow trivalent_domain self:dir rw_dir_perms;
+allow trivalent_domain self:socket_class_set create_socket_perms;
+allow trivalent_domain self:tcp_socket { accept listen };
+allow trivalent_domain trivalent_exec_t:file execute_no_trans;
+allow trivalent_domain chrome_sandbox_home_t:dir { manage_dir_perms };
+allow trivalent_domain chrome_sandbox_home_t:file { manage_file_perms execute map };
+allow trivalent_domain chrome_sandbox_home_t:lnk_file { manage_lnk_file_perms };
+allow trivalent_domain trivalent_home_t:dir { manage_dir_perms };
+allow trivalent_domain trivalent_home_t:file { manage_file_perms execute map };
+allow trivalent_domain trivalent_home_t:lnk_file { manage_lnk_file_perms };
+allow trivalent_domain self:netlink_route_socket { nlmsg_read nlmsg_write };
 
 # not covered by interfaces
-allow trivalent_t fonts_cache_t:dir mounton;
-allow trivalent_t howl_port_t:udp_socket name_bind;
-allow trivalent_t http_port_t:tcp_socket { name_connect };
-allow trivalent_t http_cache_port_t:tcp_socket { name_connect };
-allow trivalent_t pki_ca_port_t:tcp_socket name_connect;
-allow trivalent_t root_t:dir mounton;
-allow trivalent_t tmp_t:lnk_file { create unlink };
-allow trivalent_t tmp_t:sock_file { create unlink };
-allow trivalent_t tmp_t:dir mounton;
-allow trivalent_t tmpfs_t:file mounton;
-allow trivalent_t tmpfs_t:dir { create };
+allow trivalent_domain fonts_cache_t:dir mounton;
+allow trivalent_domain howl_port_t:udp_socket name_bind;
+allow trivalent_domain http_port_t:tcp_socket { name_connect };
+allow trivalent_domain http_cache_port_t:tcp_socket { name_connect };
+allow trivalent_domain pki_ca_port_t:tcp_socket name_connect;
+allow trivalent_domain root_t:dir mounton;
+allow trivalent_domain tmp_t:lnk_file { create unlink };
+allow trivalent_domain tmp_t:sock_file { create unlink };
+allow trivalent_domain tmp_t:dir mounton;
+allow trivalent_domain tmpfs_t:file mounton;
+allow trivalent_domain tmpfs_t:dir { create };
 
 # required for trivalent to be able to detect whether it's the default browser
-allow trivalent_t trivalent_script_exec_t:file { execute getattr read execute_no_trans ioctl open };
+allow trivalent_domain trivalent_script_exec_t:file { execute getattr read execute_no_trans ioctl open };
 
 # homedir access
-allow trivalent_t user_home_t:dir { manage_dir_perms };
-allow trivalent_t user_home_t:file { manage_file_perms };
-allow trivalent_t user_home_t:lnk_file { manage_lnk_file_perms };
-allow trivalent_t audio_home_t:dir { manage_dir_perms };
-allow trivalent_t audio_home_t:file { manage_file_perms };
-allow trivalent_t audio_home_t:lnk_file { manage_lnk_file_perms };
+allow trivalent_domain user_home_t:dir { manage_dir_perms };
+allow trivalent_domain user_home_t:file { manage_file_perms };
+allow trivalent_domain user_home_t:lnk_file { manage_lnk_file_perms };
+allow trivalent_domain audio_home_t:dir { manage_dir_perms };
+allow trivalent_domain audio_home_t:file { manage_file_perms };
+allow trivalent_domain audio_home_t:lnk_file { manage_lnk_file_perms };
 
 optional_policy(`
 	gen_require(`
 		attribute file_manager_type;
 	')
 
-  # required for trivalent/FM clipboard sharing
-  allow trivalent_t file_manager_type:fifo_file write;
+	# required for trivalent/FM clipboard sharing
+	allow trivalent_domain file_manager_type:fifo_file write;
 ')
-# screenshare access
-allow trivalent_t unconfined_t:unix_stream_socket { connectto rw_socket_perms };
 
 # allow trivalent to interface with flatpaks (necessary for keepassxc extension, for example)
-allow trivalent_t data_home_t:file { execute execute_no_trans };
+# uncomment this once new flatpak policy is in use
+# optional_policy(`
+# 	flatpak_read_apps(trivalent_domain)
+# 	flatpak_exec_apps(trivalent_domain)
+# ')
+allow trivalent_domain data_home_t:file { execute execute_no_trans };
 
 # allow trivalent to own its mpris daemon
-allow trivalent_t unconfined_dbusd_t:dbus acquire_svc;
+dbus_connect_session_bus(trivalent_domain)
 
 # xwayland/nvidia
-xserver_exec(trivalent_t)
-dev_rw_xserver_misc(trivalent_t)
-dev_map_xserver_misc(trivalent_t)
-allow trivalent_t xserver_misc_device_t:chr_file { getattr ioctl map open read write };
-xserver_stream_connect_xdm(trivalent_t)
-xserver_stream_connect(trivalent_t)
-xserver_user_x_domain_template(trivalent, trivalent_t, user_tmpfs_t)
+xserver_exec(trivalent_domain)
+dev_rw_xserver_misc(trivalent_domain)
+dev_map_xserver_misc(trivalent_domain)
+allow trivalent_domain xserver_misc_device_t:chr_file { getattr ioctl map open read write };
+xserver_stream_connect_xdm(trivalent_domain)
+xserver_stream_connect(trivalent_domain)
 
-files_list_home(trivalent_t)
-files_search_home(trivalent_t)
-files_read_usr_files(trivalent_t)
-files_read_etc_files(trivalent_t)
-files_read_etc_runtime_files(trivalent_t)
-files_watch_etc_dirs(trivalent_t)
-files_getattr_all_dirs(trivalent_t)
-files_watch_root_dirs(trivalent_t)
-files_read_var_lib_files(trivalent_t)
-files_rw_generic_tmp_dir(trivalent_t)
-files_manage_generic_tmp_files(trivalent_t)
-files_manage_generic_tmp_dirs(trivalent_t)
-files_rw_generic_tmp_sockets(trivalent_t)
-files_rw_tmp_file_leaks(trivalent_t)
-files_map_generic_tmp_files(trivalent_t)
+files_list_home(trivalent_domain)
+files_search_home(trivalent_domain)
+files_read_usr_files(trivalent_domain)
+files_read_etc_files(trivalent_domain)
+files_read_etc_runtime_files(trivalent_domain)
+files_watch_etc_dirs(trivalent_domain)
+files_getattr_all_dirs(trivalent_domain)
+files_watch_root_dirs(trivalent_domain)
+files_read_var_lib_files(trivalent_domain)
+files_rw_generic_tmp_dir(trivalent_domain)
+files_manage_generic_tmp_files(trivalent_domain)
+files_manage_generic_tmp_dirs(trivalent_domain)
+files_rw_generic_tmp_sockets(trivalent_domain)
+files_rw_tmp_file_leaks(trivalent_domain)
+files_map_generic_tmp_files(trivalent_domain)
 
 # memory pressure
-kernel_read_psi(trivalent_t)
-kernel_read_system_state(trivalent_t)
-kernel_read_kernel_sysctls(trivalent_t)
-kernel_read_fs_sysctls(trivalent_t)
+kernel_read_psi(trivalent_domain)
+kernel_read_kernel_sysctls(trivalent_domain)
+kernel_read_fs_sysctls(trivalent_domain)
 
 # required to connect to wayland
-unconfined_stream_connect(trivalent_t)
-dbus_system_bus_client(trivalent_t)
-dbus_session_bus_client(trivalent_t)
+dbus_system_bus_client(trivalent_domain)
+dbus_session_bus_client(trivalent_domain)
 
-dbus_write_session_tmp_sock_files(trivalent_t)
-devicekit_dbus_chat_disk(trivalent_t)
-devicekit_dbus_chat_power(trivalent_t)
-systemd_dbus_chat_hostnamed(trivalent_t)
+dbus_write_session_tmp_sock_files(trivalent_domain)
+devicekit_dbus_chat_disk(trivalent_domain)
+devicekit_dbus_chat_power(trivalent_domain)
+systemd_dbus_chat_hostnamed(trivalent_domain)
 
-fs_rw_inherited_tmpfs_files(trivalent_t)
-fs_getattr_xattr_fs(trivalent_t)
-fs_getattr_tmpfs(trivalent_t)
-fs_manage_tmpfs_files(trivalent_t)
-fs_map_tmpfs_files(trivalent_t)
-fs_search_cgroup_dirs(trivalent_t)
-fs_associate_proc(trivalent_t)
-fs_unmount_tmpfs(trivalent_t)
-fs_mount_tmpfs(trivalent_t)
-fs_manage_tmpfs_symlinks(trivalent_t)
-fs_all_mount_fs_perms_xattr_fs(trivalent_t)
-fs_mounton_tmpfs(trivalent_t)
+fs_rw_inherited_tmpfs_files(trivalent_domain)
+fs_getattr_xattr_fs(trivalent_domain)
+fs_getattr_tmpfs(trivalent_domain)
+fs_manage_tmpfs_files(trivalent_domain)
+fs_map_tmpfs_files(trivalent_domain)
+fs_search_cgroup_dirs(trivalent_domain)
+fs_associate_proc(trivalent_domain)
+fs_unmount_tmpfs(trivalent_domain)
+fs_mount_tmpfs(trivalent_domain)
+fs_manage_tmpfs_symlinks(trivalent_domain)
+fs_all_mount_fs_perms_xattr_fs(trivalent_domain)
+fs_mounton_tmpfs(trivalent_domain)
 
-miscfiles_read_all_certs(trivalent_t)
-miscfiles_map_generic_certs(trivalent_t)
-miscfiles_read_localization(trivalent_t)
-miscfiles_watch_localization_dirs(trivalent_t)
-miscfiles_read_hwdata(trivalent_t)
+miscfiles_read_all_certs(trivalent_domain)
+miscfiles_map_generic_certs(trivalent_domain)
+miscfiles_read_localization(trivalent_domain)
+miscfiles_watch_localization_dirs(trivalent_domain)
+miscfiles_read_hwdata(trivalent_domain)
 
-alsa_read_rw_config(trivalent_t)
-pulseaudio_tmpfs_content(trivalent_t)
-pulseaudio_stream_connect(trivalent_t)
-pulseaudio_read_home_files(trivalent_t)
-cups_read_config(trivalent_t)
-cups_stream_connect(trivalent_t)
+alsa_read_rw_config(trivalent_domain)
+pulseaudio_stream_connect(trivalent_domain)
+pulseaudio_read_home_files(trivalent_domain)
+cups_read_config(trivalent_domain)
+cups_stream_connect(trivalent_domain)
 
-dev_read_sysfs(trivalent_t)
-dev_rw_dma_dev(trivalent_t)
-dev_rw_dri(trivalent_t)
-dev_rw_generic_usb_dev(trivalent_t)
-dev_read_sound(trivalent_t)
-dev_write_sound(trivalent_t)
-dev_read_urand(trivalent_t)
-dev_read_rand(trivalent_t)
+dev_read_sysfs(trivalent_domain)
+dev_rw_dma_dev(trivalent_domain)
+dev_rw_dri(trivalent_domain)
+dev_rw_generic_usb_dev(trivalent_domain)
+dev_read_sound(trivalent_domain)
+dev_write_sound(trivalent_domain)
+dev_read_urand(trivalent_domain)
+dev_read_rand(trivalent_domain)
 
 tunable_policy(`trivalent_rwmap_video_dev', `
-	dev_read_video_dev(trivalent_t)
-	dev_write_video_dev(trivalent_t)
-	dev_map_video_dev(trivalent_t)
+	dev_read_video_dev(trivalent_domain)
+	dev_write_video_dev(trivalent_domain)
+	dev_map_video_dev(trivalent_domain)
 ')
 
-udev_read_pid_files(trivalent_t)
-term_mount_pty_fs(trivalent_t)
+udev_read_pid_files(trivalent_domain)
+term_mount_pty_fs(trivalent_domain)
 
-gnome_search_gconf_data_dir(trivalent_t)
-gnome_manage_cache_home_dir(trivalent_t)
-gnome_manage_generic_cache_files(trivalent_t)
-gnome_manage_generic_cache_sockets(trivalent_t)
-gnome_map_generic_cache_files(trivalent_t)
-gnome_manage_home_config(trivalent_t)
-gnome_exec_config_home_files(trivalent_t)
-gnome_manage_home_config_dirs(trivalent_t)
-gnome_manage_data(trivalent_t)
-gnome_manage_generic_home_files(trivalent_t)
-gnome_manage_generic_home_dirs(trivalent_t)
-gnome_map_generic_data_home_files(trivalent_t)
-gnome_manage_gstreamer_home_files(trivalent_t)
-gnome_dbus_chat_gconfdefault(trivalent_t)
-gnome_dbus_chat_gkeyringd(trivalent_t)
+gnome_search_gconf_data_dir(trivalent_domain)
+gnome_manage_cache_home_dir(trivalent_domain)
+gnome_manage_generic_cache_files(trivalent_domain)
+gnome_manage_generic_cache_sockets(trivalent_domain)
+gnome_map_generic_cache_files(trivalent_domain)
+gnome_manage_home_config(trivalent_domain)
+gnome_exec_config_home_files(trivalent_domain)
+gnome_manage_home_config_dirs(trivalent_domain)
+gnome_manage_data(trivalent_domain)
+gnome_manage_generic_home_files(trivalent_domain)
+gnome_manage_generic_home_dirs(trivalent_domain)
+gnome_map_generic_data_home_files(trivalent_domain)
+gnome_manage_gstreamer_home_files(trivalent_domain)
+gnome_dbus_chat_gconfdefault(trivalent_domain)
+gnome_dbus_chat_gkeyringd(trivalent_domain)
 
-userdom_manage_user_tmp_sockets(trivalent_t)
-userdom_manage_user_tmp_files(trivalent_t)
-userdom_map_tmp_files(trivalent_t)
-userdom_manage_tmpfs_files(trivalent_t)
-userdom_read_inherited_user_tmp_files(trivalent_t)
-userdom_manage_home_certs(trivalent_t)
-userdom_use_user_terminals(trivalent_t)
-userdom_list_user_home_dirs(trivalent_t)
+userdom_manage_user_tmp_sockets(trivalent_domain)
+userdom_manage_user_tmp_files(trivalent_domain)
+userdom_map_tmp_files(trivalent_domain)
+userdom_manage_tmpfs_files(trivalent_domain)
+userdom_read_inherited_user_tmp_files(trivalent_domain)
+userdom_manage_home_certs(trivalent_domain)
+userdom_use_user_terminals(trivalent_domain)
+userdom_list_user_home_dirs(trivalent_domain)
 
-logging_write_journal_files(trivalent_t)
-logging_write_syslog_pid_socket(trivalent_t)
+logging_write_journal_files(trivalent_domain)
+logging_write_syslog_pid_socket(trivalent_domain)
 
-auth_read_passwd_file(trivalent_t)
+auth_read_passwd_file(trivalent_domain)
 
 # needed to be able to xdg-open, which is bin_t
-corecmd_exec_bin(trivalent_t)
+corecmd_exec_bin(trivalent_domain)
 
-pcscd_stream_connect(trivalent_t)
-xserver_use_user_fonts(trivalent_t)
-xserver_map_user_fonts(trivalent_t)
+pcscd_stream_connect(trivalent_domain)
+xserver_use_user_fonts(trivalent_domain)
+xserver_map_user_fonts(trivalent_domain)
 
-systemd_dbus_chat_hostnamed(trivalent_t)
-systemd_resolved_watch_pid_dirs(trivalent_t)
-init_search_pid_dirs(trivalent_t)
-init_read_state(trivalent_t)
+systemd_dbus_chat_hostnamed(trivalent_domain)
+systemd_resolved_watch_pid_dirs(trivalent_domain)
+init_search_pid_dirs(trivalent_domain)
+init_read_state(trivalent_domain)
 
-corenet_tcp_connect_all_unreserved_ports(trivalent_t)
-corenet_tcp_connect_generic_port(trivalent_t)
-corenet_tcp_connect_ftp_port(trivalent_t)
-corenet_tcp_connect_http_port(trivalent_t)
-corenet_tcp_connect_ipp_port(trivalent_t)
-corenet_tcp_bind_generic_node(trivalent_t)
-corenet_udp_bind_generic_node(trivalent_t)
-corenet_udp_bind_all_unreserved_ports(trivalent_t)
-sysnet_read_config(trivalent_t)
-sysnet_dns_name_resolve(trivalent_t)
-networkmanager_dbus_chat(trivalent_t)
+corenet_tcp_connect_all_unreserved_ports(trivalent_domain)
+corenet_tcp_connect_generic_port(trivalent_domain)
+corenet_tcp_connect_ftp_port(trivalent_domain)
+corenet_tcp_connect_http_port(trivalent_domain)
+corenet_tcp_connect_ipp_port(trivalent_domain)
+corenet_tcp_bind_generic_node(trivalent_domain)
+corenet_udp_bind_generic_node(trivalent_domain)
+corenet_udp_bind_all_unreserved_ports(trivalent_domain)
+sysnet_read_config(trivalent_domain)
+sysnet_dns_name_resolve(trivalent_domain)
+networkmanager_dbus_chat(trivalent_domain)
 
-storage_getattr_fixed_disk_dev(trivalent_t)
+storage_getattr_fixed_disk_dev(trivalent_domain)
 
 optional_policy(`
-	bluetooth_dbus_chat(trivalent_t)
+	bluetooth_dbus_chat(trivalent_domain)
 ')
+
+allow trivalent_script_domain trivalent_domain:dir { getattr search };
+allow trivalent_script_domain trivalent_domain:file { open read };
+allow trivalent_script_domain self:dir { add_entry_dir_perms };
+allow trivalent_script_domain self:file { create };
+allow trivalent_script_domain self:user_namespace create;
+allow trivalent_script_domain self:cap_userns { sys_ptrace sys_admin setpcap };
+allow trivalent_script_domain self:process { ptrace setcap setsched };
+allow trivalent_script_domain user_home_t:dir { search };
+allow trivalent_script_domain chrome_sandbox_home_t:dir { manage_dir_perms };
+allow trivalent_script_domain chrome_sandbox_home_t:file { manage_file_perms };
+allow trivalent_script_domain chrome_sandbox_home_t:lnk_file read;
+allow trivalent_script_domain trivalent_home_t:dir { manage_dir_perms };
+allow trivalent_script_domain trivalent_home_t:file { manage_file_perms map };
+allow trivalent_script_domain trivalent_home_t:lnk_file { manage_lnk_file_perms };
+allow trivalent_script_domain nsfs_t:file getattr;
+allow trivalent_script_domain ld_so_cache_t:file mounton;
+allow trivalent_script_domain root_t:dir mounton;
+allow trivalent_script_domain tmp_t:dir mounton;
+allow trivalent_script_domain tmp_t:sock_file getattr;
+allow trivalent_script_domain tmpfs_t:dir { create };
+allow trivalent_script_domain device_t:filesystem remount;
+allow trivalent_script_domain dosfs_t:filesystem remount;
+allow trivalent_script_domain null_device_t:chr_file mounton;
+
+# xwayland/nvidia
+xserver_exec(trivalent_script_domain)
+dev_rw_xserver_misc(trivalent_script_domain)
+dev_map_xserver_misc(trivalent_script_domain)
+allow trivalent_script_domain xserver_misc_device_t:chr_file { getattr ioctl map open read write };
+
+domain_dontaudit_search_all_domains_state(trivalent_script_domain)
+fs_mounton_tmpfs(trivalent_script_domain)
+fs_unmount_tmpfs(trivalent_script_domain)
+fs_mount_tmpfs(trivalent_script_domain)
+gnome_manage_data(trivalent_script_domain)
+gnome_manage_home_config(trivalent_script_domain)
+gnome_manage_home_config_dirs(trivalent_script_domain)
+gnome_manage_cache_home_dir(trivalent_script_domain)
+gnome_manage_generic_cache_files(trivalent_script_domain)
+gnome_manage_generic_cache_sockets(trivalent_script_domain)
+gnome_map_generic_cache_files(trivalent_script_domain)
+corecmd_exec_shell(trivalent_script_domain)
+corecmd_exec_bin(trivalent_script_domain)
+files_getattr_all_dirs(trivalent_script_domain)
+userdom_list_user_home_dirs(trivalent_script_domain)
+kernel_list_proc(trivalent_script_domain)
+kernel_read_proc_files(trivalent_script_domain)
+kernel_getattr_proc_files(trivalent_script_domain)
+kernel_getattr_proc(trivalent_script_domain)
+seutil_exec_setfiles(trivalent_script_domain)
+seutil_manage_file_contexts(trivalent_script_domain)
+userdom_use_inherited_user_terminals(trivalent_script_domain)
+fs_all_mount_fs_perms_xattr_fs(trivalent_script_domain)
 
 optional_policy(`
 	gen_require(`
@@ -285,62 +335,32 @@ optional_policy(`
 		role unconfined_r;
 	')
 
-	trivalent_run(trivalent_script_t, unconfined_r)
-	trivalent_script_run(unconfined_t, unconfined_r)
-	trivalent_filetrans_home_content(unconfined_t)
+	trivalent_role_template(unconfined, unconfined_r, unconfined_t)
 ')
 
-allow trivalent_script_t trivalent_t:dir { getattr search };
-allow trivalent_script_t trivalent_t:file { open read };
-allow trivalent_script_t self:dir { add_entry_dir_perms };
-allow trivalent_script_t self:file { create };
-allow trivalent_script_t self:user_namespace create;
-allow trivalent_script_t self:cap_userns { sys_ptrace sys_admin setpcap };
-allow trivalent_script_t self:process { ptrace setcap setsched };
-allow trivalent_script_t user_home_t:dir { search };
-allow trivalent_script_t chrome_sandbox_home_t:dir { manage_dir_perms };
-allow trivalent_script_t chrome_sandbox_home_t:file { manage_file_perms };
-allow trivalent_script_t chrome_sandbox_home_t:lnk_file read;
-allow trivalent_script_t trivalent_home_t:dir { manage_dir_perms };
-allow trivalent_script_t trivalent_home_t:file { manage_file_perms map };
-allow trivalent_script_t trivalent_home_t:lnk_file { manage_lnk_file_perms };
-allow trivalent_script_t nsfs_t:file getattr;
-allow trivalent_script_t ld_so_cache_t:file mounton;
-allow trivalent_script_t root_t:dir mounton;
-allow trivalent_script_t tmp_t:dir mounton;
-allow trivalent_script_t tmp_t:sock_file getattr;
-allow trivalent_script_t tmpfs_t:dir { create };
-allow trivalent_script_t device_t:filesystem remount;
-allow trivalent_script_t dosfs_t:filesystem remount;
-allow trivalent_script_t null_device_t:chr_file mounton;
-allow trivalent_script_t trivalent_t:process2 { nosuid_transition nnp_transition };
+optional_policy(`
+	gen_require(`
+		type sysadm_t;
+		role sysadm_r;
+	')
 
-# xwayland/nvidia
-xserver_exec(trivalent_script_t)
-dev_rw_xserver_misc(trivalent_script_t)
-dev_map_xserver_misc(trivalent_script_t)
-allow trivalent_script_t xserver_misc_device_t:chr_file { getattr ioctl map open read write };
+	trivalent_role_template(sysadm, sysadm_r, sysadm_t)
+')
 
-domain_dontaudit_search_all_domains_state(trivalent_script_t)
-fs_mounton_tmpfs(trivalent_script_t)
-fs_unmount_tmpfs(trivalent_script_t)
-fs_mount_tmpfs(trivalent_script_t)
-gnome_manage_data(trivalent_script_t)
-gnome_manage_home_config(trivalent_script_t)
-gnome_manage_home_config_dirs(trivalent_script_t)
-gnome_manage_cache_home_dir(trivalent_script_t)
-gnome_manage_generic_cache_files(trivalent_script_t)
-gnome_manage_generic_cache_sockets(trivalent_script_t)
-gnome_map_generic_cache_files(trivalent_script_t)
-corecmd_exec_shell(trivalent_script_t)
-corecmd_exec_bin(trivalent_script_t)
-files_getattr_all_dirs(trivalent_script_t)
-userdom_list_user_home_dirs(trivalent_script_t)
-kernel_list_proc(trivalent_script_t)
-kernel_read_proc_files(trivalent_script_t)
-kernel_getattr_proc_files(trivalent_script_t)
-kernel_getattr_proc(trivalent_script_t)
-seutil_exec_setfiles(trivalent_script_t)
-seutil_manage_file_contexts(trivalent_script_t)
-userdom_use_inherited_user_terminals(trivalent_script_t)
-fs_all_mount_fs_perms_xattr_fs(trivalent_script_t)
+optional_policy(`
+	gen_require(`
+		type staff_t;
+		role staff_r;
+	')
+
+	trivalent_role_template(staff, staff_r, staff_t)
+')
+
+optional_policy(`
+	gen_require(`
+		type user_t;
+		role user_r;
+	')
+
+	trivalent_role_template(user, user_r, user_t)
+')


### PR DESCRIPTION
Currently the Trivalent SELinux policy implicitly assumes that the user is unconfined, and doesn't work for confined users. This modifies the policy to work for confined users as well.

The `trivalent_t` and `trivalent_script_t` domains are replaced by `trivalent_domain` and `trivalent_script_domain` attributes, containing domains `$1_trivalent_t` and `$1_trivalent_script_t`, respectively, for each role `$1_r` permitted to run Trivalent.

The use of domain prefixes allows for role-dependent domain transitions, so for example `staff_trivalent_t` can be authorized to run something as `staff_$2_t`. This will be useful once the new flatpak policy is in use, and I included commented-out lines that will allow for Trivalent-flatpak integration to keep working after we switch to that policy.