### PR TITLE
feat: rewrite ujust harden-flatpak in Python

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ on:
       - staging
     paths-ignore:
       - "**.md"
-  workflow_dispatch: # allow manually triggering 
+  workflow_dispatch: # allow manually triggering
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -45,10 +45,10 @@ jobs:
            assert-path: "${{ github.workspace }}/.bats/bats-assert"
            detik-path: "${{ github.workspace }}/.bats/bats-detik"
            file-path: "${{ github.workspace }}/.bats/bats-file"
-      
+
       - name: Install just
-        run: |          
-          sudo apt-get install just
+        run: |
+          sudo bash files/scripts/manuallyinstalljust.sh
 
       - name: Run tests
         shell: bash

--- a/files/justfiles/common/wrappers.just
+++ b/files/justfiles/common/wrappers.just
@@ -10,25 +10,27 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-set positional-arguments := true
-
 # Audit secureblue
+[positional-arguments]
 audit-secureblue *args:
     #!/bin/sh
     exec /usr/bin/python3 /usr/libexec/secureblue/audit_secureblue.py "$@"
 
 # Run a non-flatpak application with standard memory allocator
 [no-cd]
+[positional-arguments]
 with-standard-malloc *args:
     #!/bin/sh
     LD_PRELOAD='' exec "$@"
 
 # Sets bluetooth kernel modules on/off (requires reboot)
+[positional-arguments]
 set-bluetooth-modules *args:
     #!/bin/sh
     exec /usr/bin/python3 /usr/libexec/secureblue/bluetooth_main.py "$@"
 
 # Interactively select secure DNS servers
+[positional-arguments]
 dns-selector *args:
     #!/bin/sh
     exec /usr/bin/python3 /usr/libexec/secureblue/dns_selector.py "$@"

--- a/files/justfiles/desktop/flatpak.just
+++ b/files/justfiles/desktop/flatpak.just
@@ -23,76 +23,10 @@ disable-flathub-unfiltered:
     flatpak remote-delete --user flathub
 
 # Harden flatpaks by preloading hardened_malloc (highest supported hwcap). When called with a flatpak application ID as an argument, applies the overrides to that application instead of globally.
-harden-flatpak FLATPAK_APPID="":
-    #!/usr/bin/bash
-    set -euo pipefail
-    flatpak_id="{{ FLATPAK_APPID }}"
-
-    # Determine best microarchitecture to use for hardened_malloc
-    best_uarch="$(/usr/lib64/ld-linux-x86-64.so.2 --help | grep -F '(supported, searched)' \
-        | grep -o 'x86-64-v[[:digit:]]*' | sort -nr | head -n1 || echo '')"
-    readonly best_uarch
-    readonly hmalloc_path="/var/run/host/usr/lib64/${best_uarch:+"glibc-hwcaps/$best_uarch/"}libhardened_malloc.so"
-    readonly hmalloc_description="hardened_malloc${best_uarch:+" (µarch $best_uarch)"}"
-
-    if [[ -z "$flatpak_id" ]]; then
-        flatpak override --user --filesystem=host-os:ro
-        flatpak override --user --env=LD_PRELOAD="$hmalloc_path"
-        echo "$hmalloc_description applied to all flatpaks by default."
-        exit
-    fi
-
-    readonly override_dir="$HOME/.local/share/flatpak/overrides"
-
-    has_host_os_access() {
-        grep -Eqx 'filesystems=(.*;)?host-os(:ro)?(;.*)?' "$override_dir/$1"
-    }
-
-    remove_no_host_os() {
-        sed -Ei '/^filesystems=/s/!host-os(;|$)//' "$override_dir/$1"
-    }
-
-    has_ld_preload() {
-        grep -Fqx "LD_PRELOAD=$hmalloc_path" "$override_dir/$1"
-    }
-
-    remove_ld_preload_override() {
-        sed -i '/^LD_PRELOAD=/d' "$override_dir/$1"
-    }
-
-    harden_flatpak_app() {
-        if has_host_os_access 'global'; then
-            remove_no_host_os "$1"
-        else
-            flatpak override --user --filesystem=host-os:ro "$1"
-        fi
-        if has_ld_preload 'global'; then
-            remove_ld_preload_override "$1"
-        else
-            flatpak override --user --env=LD_PRELOAD="$hmalloc_path" "$1"
-        fi
-    }
-
-    installed_app_ids="$(flatpak list --columns=application --app)"
-    if ! echo "$installed_app_ids" | grep -Fqx "$flatpak_id"; then
-        echo "'$flatpak_id' is not the application ID of an installed flatpak."
-        readarray -t matching_ids < <(echo "$installed_app_ids" | grep -Fi "$flatpak_id")
-        if (( ${#matching_ids[@]} == 0 )); then
-            echo "No matching IDs found; exiting."
-            exit 1
-        fi
-        echo "Did you mean one of the following? (enter number to select, any letter to cancel)"
-        select selected_id in "${matching_ids[@]}"; do
-            if [[ -z "$selected_id" ]]; then
-                exit 1
-            fi
-            flatpak_id="$selected_id"
-            break
-        done
-    fi
-
-    harden_flatpak_app "$flatpak_id"
-    echo "$hmalloc_description applied to flatpak $flatpak_id"
+[positional-arguments]
+harden-flatpak *args:
+    #!/usr/bin/sh
+    exec /usr/bin/python3 /usr/libexec/secureblue/harden_flatpak.py
 
 # Harden Flatpaks further by disabling all permissions by default and rejecting known arbitrary DBus names, applies only to the current user
 flatpak-permissions-lockdown:

--- a/files/scripts/manuallyinstalljust.sh
+++ b/files/scripts/manuallyinstalljust.sh
@@ -14,20 +14,23 @@ set -oue pipefail
 # Unless required by applicable law or agreed to in writing, software distributed under the License is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-LATEST_URL="$(curl -Ls -o /dev/null -w '%{url_effective}' https://github.com/casey/just/releases/latest)"
-VER="$(basename "$LATEST_URL")"
-curl -fLs --create-dirs "https://github.com/casey/just/releases/download/${VER}/just-${VER}-x86_64-unknown-linux-musl.tar.gz" -o "/tmp/just-${VER}-x86_64-unknown-linux-musl.tar.gz"
-curl -fLs --create-dirs "https://github.com/casey/just/releases/download/${VER}/SHA256SUMS" -o /tmp/SHA256SUMS
-cd /tmp
-if ! sha256sum -c SHA256SUMS --ignore-missing
-then
+
+latest_url=$(curl -fLsS --retry 5 -o /dev/null -w '%{url_effective}' https://github.com/casey/just/releases/latest)
+ver=$(basename "$latest_url")
+temp_dir=$(mktemp -d)
+curl -fLsS --retry 5 --create-dirs \
+    "https://github.com/casey/just/releases/download/${ver}/just-${ver}-x86_64-unknown-linux-musl.tar.gz" -o "${temp_dir}/just-${ver}-x86_64-unknown-linux-musl.tar.gz" \
+    "https://github.com/casey/just/releases/download/${ver}/SHA256SUMS" -o "${temp_dir}/SHA256SUMS"
+cd "${temp_dir}"
+if ! sha256sum -c SHA256SUMS --ignore-missing; then
     echo "Just tarball verification FAILED! Exiting..."
     exit 1
 fi
 cd -
-mkdir -p /tmp/just && tar -xzf "/tmp/just-${VER}-x86_64-unknown-linux-musl.tar.gz" -C /tmp/just/
-cp /tmp/just/just /usr/bin/just && chmod 0755 /usr/bin/just
-cp /tmp/just/completions/just.bash /usr/share/bash-completion/completions/just
-cp /tmp/just/just.1 /usr/share/man/man1/just.1
-rm "/tmp/just-${VER}-x86_64-unknown-linux-musl.tar.gz"
-rm -r /tmp/just/
+mkdir "${temp_dir}/just"
+tar -xzf "${temp_dir}/just-${ver}-x86_64-unknown-linux-musl.tar.gz" -C "${temp_dir}/just/"
+cp "${temp_dir}/just/just" /usr/bin/just
+chmod 0755 /usr/bin/just
+cp "${temp_dir}/just/completions/just.bash" /usr/share/bash-completion/completions/just
+cp "${temp_dir}/just/just.1" /usr/share/man/man1/just.1
+rm -r "${temp_dir}"

--- a/files/system/desktop/usr/libexec/secureblue/harden_flatpak.py
+++ b/files/system/desktop/usr/libexec/secureblue/harden_flatpak.py
@@ -23,7 +23,7 @@ import sys
 from typing import Final
 
 import inquirer
-from utils import command_stdout
+from utils import command_stdout, print_wrapped
 
 DESCRIPTION: Final[str] = """
 Harden flatpaks by preloading hardened_malloc, using the highest supported
@@ -75,7 +75,7 @@ def resolve_app_id(provided: str, installed_app_ids: list[str]) -> str | None:
     if len(matches) == 1:
         return matches[0]
 
-    print(f"'{provided}' is not the application ID of an installed flatpak.")
+    print_wrapped(f"'{provided}' is not the application ID of an installed flatpak.")
 
     # If there's no case-insensitive matches, try substring matches.
     if not matches:
@@ -165,10 +165,15 @@ def main() -> int:
     uarch = best_microarch()
     hmalloc_path = libhardened_malloc_path(uarch)
     hmalloc_description = "hardened_malloc" if uarch is None else f"hardened_malloc (µarch {uarch})"
+    host_os_note = """
+    Note: the filesystem=host-os:ro permission has also been granted. This gives read-only
+    access to /usr, which is where the hardened_malloc shared library is installed.
+    """
 
     if not args.app_id:
         flatpak_override("--filesystem=host-os:ro", f"--env=LD_PRELOAD={hmalloc_path}")
-        print(f"{hmalloc_description} applied to all flatpaks by default.")
+        print_wrapped(f"{hmalloc_description} applied to all flatpaks by default.")
+        print_wrapped(host_os_note)
         return 0
 
     installed_app_ids = installed_app_list()
@@ -177,7 +182,8 @@ def main() -> int:
         print("No matching app IDs found; exiting.")
         return 1
     harden_flatpak_app(app_id, hmalloc_path)
-    print(f"{hmalloc_description} applied to flatpak {app_id}")
+    print_wrapped(f"{hmalloc_description} applied to flatpak {app_id}")
+    print_wrapped(host_os_note)
 
     return 0
 

--- a/files/system/desktop/usr/libexec/secureblue/harden_flatpak.py
+++ b/files/system/desktop/usr/libexec/secureblue/harden_flatpak.py
@@ -1,0 +1,186 @@
+#!/usr/bin/python3
+
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import contextlib
+import os
+import re
+import subprocess  # nosec
+import sys
+from typing import Final
+
+import inquirer
+from utils import command_stdout
+
+DESCRIPTION: Final[str] = """
+Harden flatpaks by preloading hardened_malloc, using the highest supported
+hardware capabilities. When called with one or more flatpak application IDs as
+arguments, applies the overrides to those applications instead of globally.
+"""
+
+
+def best_microarch() -> str | None:
+    """Get best microarchitecture for system."""
+    try:
+        ld_info = command_stdout("/usr/lib64/ld-linux-x86-64.so.2", "--help")
+    except subprocess.CalledProcessError:
+        return None
+    m = re.search(
+        r"^\s*(x86-64-v\d+).*\(supported, searched\)", ld_info, flags=re.ASCII | re.MULTILINE
+    )
+    return m and m.group(1)
+
+
+def libhardened_malloc_path(uarch: str | None) -> str:
+    """Get path to libhardened_malloc.so"""
+    directory = "/var/run/host/usr/lib64"
+    if uarch is not None:
+        directory += f"/glibc-hwcaps/{uarch}"
+    return f"{directory}/libhardened_malloc.so"
+
+
+def flatpak_override(*args: str) -> None:
+    """Apply flatpak overrides."""
+    subprocess.run(["/usr/bin/flatpak", "override", "--user", *args], check=True)  # nosec
+
+
+def installed_app_list() -> list[str]:
+    """Get list of installed flatpak app IDs."""
+    return command_stdout("/usr/bin/flatpak", "list", "--columns=application", "--app").splitlines()
+
+
+def resolve_app_id(provided: str, installed_app_ids: list[str]) -> str | None:
+    """Determine app ID intended by user."""
+    # First, return exact match if found.
+    if provided in installed_app_ids:
+        return provided
+
+    # Next, try case-insensitive matches.
+    provided = provided.casefold()
+    matches = [app_id for app_id in installed_app_ids if app_id.casefold() == provided]
+    # If there's exactly one case-insensitive match, just choose it, don't prompt the user.
+    if len(matches) == 1:
+        return matches[0]
+
+    print(f"'{provided}' is not the application ID of an installed flatpak.")
+
+    # If there's no case-insensitive matches, try substring matches.
+    if not matches:
+        matches = [app_id for app_id in installed_app_ids if provided in app_id.casefold()]
+
+    if not matches:
+        return None
+
+    question = inquirer.List(
+        "app_id", message="Did you mean one of the following? (Ctrl+C to cancel)", choices=matches
+    )
+    answer = inquirer.prompt([question])
+    return answer and answer["app_id"]
+
+
+def current_override_status(app_id: str, hmalloc_path: str) -> tuple[bool, bool]:
+    """Get current host-os and LD_PRELOAD override status"""
+    override_dir = os.path.expanduser("~/.local/share/flatpak/overrides")
+    host_os_access = False
+    ld_preload_set = False
+    host_os_pattern = re.compile(r"filesystems=(?:.*;)?host-os(?::ro)?(?:;.*)?\n")
+    ld_preload_pattern = re.compile(rf"LD_PRELOAD=(?:.*\s)?{re.escape(hmalloc_path)}(?:\s.*)?\n")
+    with (
+        contextlib.suppress(FileNotFoundError),
+        open(f"{override_dir}/{app_id}", encoding="utf8") as f,
+    ):
+        for line in f:
+            if re.fullmatch(host_os_pattern, line):
+                host_os_access = True
+            if re.fullmatch(ld_preload_pattern, line):
+                ld_preload_set = True
+    return host_os_access, ld_preload_set
+
+
+def remove_overrides_from_file(override_file: str, *, no_host_os: bool, ld_preload: bool) -> None:
+    """Remove selected overrides from flatpak override file at given path."""
+    if not no_host_os and not ld_preload:
+        return
+
+    file_modified = False
+    modified_contents = ""
+    with open(override_file, encoding="utf8") as f:
+        for line in f:
+            if no_host_os and line.startswith("filesystems="):
+                line, subs = re.subn(r"!host-os(?:;|$)", "", line)  # noqa: PLW2901
+                if subs > 0:
+                    file_modified = True
+            elif ld_preload and line.startswith("LD_PRELOAD="):
+                file_modified = True
+                continue
+            modified_contents += line
+
+    if file_modified:
+        with open(override_file, "w", encoding="utf8") as f:
+            f.write(modified_contents)
+
+
+def harden_flatpak_app(app_id: str, hmalloc_path: str) -> None:
+    """Applied hardened_malloc to flatpak app with given app ID."""
+    override_dir = os.path.expanduser("~/.local/share/flatpak/overrides")
+    overrides_to_apply = []
+    global_host_os_access, global_ld_preload = current_override_status("global", hmalloc_path)
+
+    with contextlib.suppress(FileNotFoundError):
+        remove_overrides_from_file(
+            f"{override_dir}/{app_id}",
+            no_host_os=global_host_os_access,
+            ld_preload=global_ld_preload,
+        )
+
+    if not global_host_os_access:
+        overrides_to_apply.append("--filesystem=host-os:ro")
+
+    if not global_ld_preload:
+        overrides_to_apply.append(f"--env=LD_PRELOAD={hmalloc_path}")
+
+    if overrides_to_apply:
+        flatpak_override(*overrides_to_apply, app_id)
+
+
+def main() -> int:
+    """Main entry point for script."""
+    parser = argparse.ArgumentParser(prog="ujust harden-flatpak", description=DESCRIPTION)
+    parser.add_argument("app_id", nargs="?", metavar="APP_ID", help="app ID of flatpak to harden")
+    args = parser.parse_args()
+
+    uarch = best_microarch()
+    hmalloc_path = libhardened_malloc_path(uarch)
+    hmalloc_description = "hardened_malloc" if uarch is None else f"hardened_malloc (µarch {uarch})"
+
+    if not args.app_id:
+        flatpak_override("--filesystem=host-os:ro", f"--env=LD_PRELOAD={hmalloc_path}")
+        print(f"{hmalloc_description} applied to all flatpaks by default.")
+        return 0
+
+    installed_app_ids = installed_app_list()
+    app_id = resolve_app_id(args.app_id, installed_app_ids)
+    if app_id is None:
+        print("No matching app IDs found; exiting.")
+        return 1
+    harden_flatpak_app(app_id, hmalloc_path)
+    print(f"{hmalloc_description} applied to flatpak {app_id}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -37,6 +37,14 @@ from typing import Final
 
 import kargs_hardening_common
 from audit_flatpak import check_flatpak_permissions, parse_flatpak_permissions
+from audit_utils import (
+    Image,
+    get_flatpak_permissions,
+    get_legend,
+    get_width,
+    validate_sysctl,
+    warn_if_root,
+)
 from auditor import (
     Report,
     Status,
@@ -48,17 +56,11 @@ from auditor import (
     global_audit,
 )
 from utils import (
-    Image,
     command_stdout,
     command_succeeds,
-    get_flatpak_permissions,
-    get_legend,
-    get_width,
     is_using_vpn,
     parse_config,
     print_err,
-    validate_sysctl,
-    warn_if_root,
 )
 
 _: Final = gettext_marker()

--- a/files/system/usr/libexec/secureblue/audit_utils/__init__.py
+++ b/files/system/usr/libexec/secureblue/audit_utils/__init__.py
@@ -1,0 +1,184 @@
+#!/usr/bin/python3
+
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Utils for system auditing.
+"""
+
+import asyncio
+import enum
+import os
+import re
+
+# All subprocess calls we make have trusted inputs and do not use shell=True.
+import subprocess  # nosec
+import textwrap
+from typing import Final
+
+from auditor import AuditError, Status, gettext_marker
+from utils import print_err
+
+PASS: Final = Status.PASS
+INFO: Final = Status.INFO
+WARN: Final = Status.WARN
+FAIL: Final = Status.FAIL
+UNKNOWN: Final = Status.UNKNOWN
+
+
+_: Final = gettext_marker()
+
+
+class Image(enum.Enum):
+    """Fedora atomic base image"""
+
+    SILVERBLUE = enum.auto()
+    KINOITE = enum.auto()
+    SERICEA = enum.auto()
+    COSMIC = enum.auto()
+    COREOS = enum.auto()
+    IOT = enum.auto()
+
+    @classmethod
+    def from_image_ref(cls, image_ref: str) -> "Image | None":
+        """Convert an image reference to the corresponding Image enum instance."""
+        image_dict = {
+            "silverblue": cls.SILVERBLUE,
+            "kinoite": cls.KINOITE,
+            "sericea": cls.SERICEA,
+            "cosmic": cls.COSMIC,
+            "securecore": cls.COREOS,
+            "iot": cls.IOT,
+        }
+        image_name = image_ref.rsplit("/", maxsplit=1)[-1]
+        image_prefix = image_name.split("-", maxsplit=1)[0]
+        return image_dict.get(image_prefix)
+
+    def is_server(self) -> bool:
+        """Is the image a server image?"""
+        return self in (Image.COREOS, Image.IOT)
+
+    def is_desktop(self) -> bool:
+        """Is the image a desktop image?"""
+        return not self.is_server()
+
+
+def warn_if_root() -> None:
+    """If run as root, warn that this is not recommended."""
+    if not os.getuid():
+        print_err("\n" + _("*** WARNING: Running audit script as root is not recommended. ***"))
+        print_err(_("*** Some results may be misleading or incomplete. ***") + "\n")
+
+
+def get_width() -> int:
+    """Get the width in columns to be used for reports."""
+    try:
+        width = min(max(80, os.get_terminal_size().columns), 100)
+    except OSError:
+        width = 80
+    return width
+
+
+def _format_legend_entry(status: Status, description: str, width: int = 80) -> str:
+    """Format legend entry"""
+    key_str = f"[{status.to_str_in_color()}]: "
+    key_str_width = len(status.name) + 4
+    description = re.sub(r"\s+", " ", description.strip())
+    lines = textwrap.wrap(description, width=width - key_str_width)
+    if not lines:
+        return f"{key_str}\n"
+    entry = f"{key_str}{lines[0]}\n"
+    for line in lines[1:]:
+        entry += f"{' ' * key_str_width}{line}\n"
+    return entry
+
+
+def get_legend(width: int = 80) -> str:
+    """Get legend to be printed with --help option."""
+    legend = _("The following status indicators accompany checks run by the audit script:")
+    legend += "\n\n"
+    status_descriptions: dict[Status, str] = {
+        FAIL: _("check failed - the configuration may be less secure."),
+        WARN: _("partial failure, or less significant issue detected."),
+        PASS: _("check passed - no problems detected."),
+        UNKNOWN: _("unable to perform check (usually due to a file permission issue)."),
+    }
+    for status, desc in status_descriptions.items():
+        legend += _format_legend_entry(status, desc, width)
+    legend += "\n"
+    legend += _("For flatpak checks, the status indicators have more specific meanings:")
+    legend += "\n\n"
+    flatpak_status_descriptions: dict[Status, str] = {
+        FAIL: _("""app has permissions that can be used as sandbox escapes, allow it to modify
+            its own permissions, or otherwise grant very broad access to the system (e.g. access
+            to certain directories, direct D-Bus access, X11)."""),
+        WARN: _("""app has permissions that have some sandbox escape potential or otherwise
+            weaken security (e.g. PulseAudio, Bluetooth, not using hardened_malloc)."""),
+        INFO: _("""no potential sandbox escapes detected but some permissions could increase
+            attack surface or have privacy implications (e.g. network access)."""),
+        PASS: _("no app permissions flagged (however, not all permissions are audited)."),
+    }
+    for status, desc in flatpak_status_descriptions.items():
+        legend += _format_legend_entry(status, desc, width)
+    legend += "\n" + textwrap.fill(
+        textwrap.dedent(
+            _("""\
+            Note that some flatpak apps require broad permissions to function. Permissions being
+            flagged by the audit script do not necessarily mean that action should be taken.
+            """)
+        ),
+        width=width,
+    )
+    return legend
+
+
+class AsyncProcessError(AuditError):
+    """An asynchronous subprocess command returned a nonzero exit code."""
+
+
+async def async_command_stdout(cmd: str, *args: str, check: bool = True) -> str:
+    """Asynchronously run a command in the shell and return the contents of stdout."""
+    # nosemgrep: dangerous-subprocess-use-audit, dangerous-asyncio-create-exec-audit
+    sub = await asyncio.create_subprocess_exec(
+        cmd, *args, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
+    )
+    await sub.wait()
+    # pylint: disable=use-implicit-booleaness-not-comparison-to-zero
+    if check and sub.returncode != 0:
+        err = f"async command `{cmd} {' '.join(args)}` returned nonzero exit code {sub.returncode}"
+        raise AsyncProcessError(err)
+    if sub.stdout is None:
+        err = f"Failed to get stdout for async command `{cmd} {' '.join(args)}`"
+        raise AsyncProcessError(err)
+    output = await sub.stdout.read()
+    return output.decode("utf-8", errors="replace").strip()
+
+
+async def get_flatpak_permissions(name: str, version: str) -> str:
+    """Get permissions for an installed flatpak."""
+    return await async_command_stdout("flatpak", "info", "--show-permissions", name, version)
+
+
+def validate_sysctl(sysctl: str, actual: str, expected: str) -> bool:
+    """Validate a sysctl value against an expected value."""
+    actual = re.sub(r"\s+", " ", actual.strip())
+    replace = {"disabled": "0", "enabled": "1"}.get(actual)
+    if replace is not None:
+        actual = replace
+    if sysctl == "kernel.sysrq":
+        # Both 0 and 4 are secure values for this setting. For details, see:
+        # https://www.kernel.org/doc/html/latest/admin-guide/sysrq.html
+        return actual in (expected, "0", "4")
+    return actual == expected

--- a/files/system/usr/libexec/secureblue/utils/__init__.py
+++ b/files/system/usr/libexec/secureblue/utils/__init__.py
@@ -26,6 +26,11 @@ from collections.abc import Iterable
 import rpm
 
 
+def print_wrapped(text: str, *, width: int = 70) -> None:
+    """Print text to stdout, wrapped to the given width."""
+    print(textwrap.fill(" ".join(text.split()), width=width))
+
+
 def print_err(text: str) -> None:
     """Print text to stderr in bold and red."""
     print(f"\x1b[1m\x1b[31m{text}\x1b[0m", file=sys.stderr)

--- a/files/system/usr/libexec/secureblue/utils/__init__.py
+++ b/files/system/usr/libexec/secureblue/utils/__init__.py
@@ -15,106 +15,20 @@
 # limitations under the License.
 
 """
-Utils for system auditing.
+Various utility functions used in secureblue scripts.
 """
 
-import asyncio
-import enum
-import os
-import re
-
-# All subprocess calls we make have trusted inputs and do not use shell=True.
 import subprocess  # nosec
 import sys
 import textwrap
 from collections.abc import Iterable
-from typing import Final
 
 import rpm
-from auditor import AuditError, Status, gettext_marker
-
-PASS: Final = Status.PASS
-INFO: Final = Status.INFO
-WARN: Final = Status.WARN
-FAIL: Final = Status.FAIL
-UNKNOWN: Final = Status.UNKNOWN
-
-
-_: Final = gettext_marker()
 
 
 def print_err(text: str) -> None:
     """Print text to stderr in bold and red."""
     print(f"\x1b[1m\x1b[31m{text}\x1b[0m", file=sys.stderr)
-
-
-def warn_if_root() -> None:
-    """If run as root, warn that this is not recommended."""
-    if not os.getuid():
-        print_err("\n" + _("*** WARNING: Running audit script as root is not recommended. ***"))
-        print_err(_("*** Some results may be misleading or incomplete. ***") + "\n")
-
-
-def get_width() -> int:
-    """Get the width in columns to be used for reports."""
-    try:
-        width = min(max(80, os.get_terminal_size().columns), 100)
-    except OSError:
-        width = 80
-    return width
-
-
-def _format_legend_entry(status: Status, description: str, width: int = 80) -> str:
-    """Format legend entry"""
-    key_str = f"[{status.to_str_in_color()}]: "
-    key_str_width = len(status.name) + 4
-    description = re.sub(r"\s+", " ", description.strip())
-    lines = textwrap.wrap(description, width=width - key_str_width)
-    if not lines:
-        return f"{key_str}\n"
-    entry = f"{key_str}{lines[0]}\n"
-    for line in lines[1:]:
-        entry += f"{' ' * key_str_width}{line}\n"
-    return entry
-
-
-def get_legend(width: int = 80) -> str:
-    """Get legend to be printed with --help option."""
-    legend = _("The following status indicators accompany checks run by the audit script:")
-    legend += "\n\n"
-    status_descriptions: dict[Status, str] = {
-        FAIL: _("check failed - the configuration may be less secure."),
-        WARN: _("partial failure, or less significant issue detected."),
-        PASS: _("check passed - no problems detected."),
-        UNKNOWN: _("unable to perform check (usually due to a file permission issue)."),
-    }
-    for status, desc in status_descriptions.items():
-        legend += _format_legend_entry(status, desc, width)
-    legend += "\n"
-    legend += _("For flatpak checks, the status indicators have more specific meanings:")
-    legend += "\n\n"
-    flatpak_status_descriptions: dict[Status, str] = {
-        FAIL: _("""app has permissions that can be used as sandbox escapes, allow it to modify
-            its own permissions, or otherwise grant very broad access to the system (e.g. access
-            to certain directories, direct D-Bus access, X11)."""),
-        WARN: _("""app has permissions that have some sandbox escape potential or otherwise
-            weaken security (e.g. PulseAudio, Bluetooth, not using hardened_malloc)."""),
-        INFO: _("""no potential sandbox escapes detected but some permissions could increase
-            attack surface or have privacy implications (e.g. network access)."""),
-        PASS: _("no app permissions flagged (however, not all permissions are audited)."),
-    }
-    for status, desc in flatpak_status_descriptions.items():
-        legend += _format_legend_entry(status, desc, width)
-    legend += "\n" + textwrap.fill(
-        textwrap.dedent(
-            _("""\
-            Note that some flatpak apps require broad permissions to function. Permissions being
-            flagged by the audit script do not necessarily mean that action should be taken.
-            """)
-        ),
-        width=width,
-    )
-    return legend
 
 
 def command_stdout(*args: str, check: bool = True) -> str:
@@ -124,30 +38,8 @@ def command_stdout(*args: str, check: bool = True) -> str:
     return subprocess.run(args, capture_output=True, check=check, text=True).stdout.strip()  # nosec
 
 
-class AsyncProcessError(AuditError):
-    """An asynchronous subprocess command returned a nonzero exit code."""
-
-
-async def async_command_stdout(cmd: str, *args: str, check: bool = True) -> str:
-    """Asynchronously run a command in the shell and return the contents of stdout."""
-    # nosemgrep: dangerous-subprocess-use-audit, dangerous-asyncio-create-exec-audit
-    sub = await asyncio.create_subprocess_exec(
-        cmd, *args, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
-    )
-    await sub.wait()
-    # pylint: disable=use-implicit-booleaness-not-comparison-to-zero
-    if check and sub.returncode != 0:
-        err = f"async command `{cmd} {' '.join(args)}` returned nonzero exit code {sub.returncode}"
-        raise AsyncProcessError(err)
-    if sub.stdout is None:
-        err = f"Failed to get stdout for async command `{cmd} {' '.join(args)}`"
-        raise AsyncProcessError(err)
-    output = await sub.stdout.read()
-    return output.decode("utf-8", errors="replace").strip()
-
-
 def command_succeeds(*args: str) -> bool:
-    """Run a command in the shell and return the contents of stdout."""
+    """Run a command in the shell and return whether it completes with return code 0."""
     # We only call this with trusted inputs and do not set shell=True.
     # nosemgrep: dangerous-subprocess-use-audit
     return subprocess.run(args, capture_output=True, check=False).returncode == 0  # nosec
@@ -177,63 +69,13 @@ def is_rpm_package_installed(name: str) -> bool:
     return len(matches) > 0
 
 
-class Image(enum.Enum):
-    """Fedora atomic base image"""
-
-    SILVERBLUE = enum.auto()
-    KINOITE = enum.auto()
-    SERICEA = enum.auto()
-    COSMIC = enum.auto()
-    COREOS = enum.auto()
-    IOT = enum.auto()
-
-    @classmethod
-    def from_image_ref(cls, image_ref: str) -> "Image | None":
-        """Convert an image reference to the corresponding Image enum instance."""
-        image_dict = {
-            "silverblue": cls.SILVERBLUE,
-            "kinoite": cls.KINOITE,
-            "sericea": cls.SERICEA,
-            "cosmic": cls.COSMIC,
-            "securecore": cls.COREOS,
-            "iot": cls.IOT,
-        }
-        image_name = image_ref.rsplit("/", maxsplit=1)[-1]
-        image_prefix = image_name.split("-", maxsplit=1)[0]
-        return image_dict.get(image_prefix)
-
-    def is_server(self) -> bool:
-        """Is the image a server image?"""
-        return self in (Image.COREOS, Image.IOT)
-
-    def is_desktop(self) -> bool:
-        """Is the image a desktop image?"""
-        return not self.is_server()
-
-
-async def get_flatpak_permissions(name: str, version: str) -> str:
-    """Get permissions for an installed flatpak."""
-    return await async_command_stdout("flatpak", "info", "--show-permissions", name, version)
-
-
-def validate_sysctl(sysctl: str, actual: str, expected: str) -> bool:
-    """Validate a sysctl value against an expected value."""
-    actual = re.sub(r"\s+", " ", actual.strip())
-    replace = {"disabled": "0", "enabled": "1"}.get(actual)
-    if replace is not None:
-        actual = replace
-    if sysctl == "kernel.sysrq":
-        # Both 0 and 4 are secure values for this setting. For details, see:
-        # https://www.kernel.org/doc/html/latest/admin-guide/sysrq.html
-        return actual in (expected, "0", "4")
-    return actual == expected
-
-
 def is_using_vpn() -> bool:
     """Returns whether an OpenVPN or Wireguard VPN is currently in use."""
 
     # Check for Wireguard VPN use.
     wg_out = command_stdout("/usr/bin/ip", "link", "show", "type", "wireguard")
+    if wg_out:
+        return True
 
     # For OpenVPN, we need to figure out whether the default route is via a TUN/TAP interface.
     # Otherwise, we'd detect virtual networks, etc.
@@ -247,7 +89,7 @@ def is_using_vpn() -> bool:
             has_openvpn = True
             break
 
-    return wg_out or has_openvpn
+    return has_openvpn
 
 
 def interruptible_ask(prompt: str) -> str:

--- a/recipes/common/common-packages.yml
+++ b/recipes/common/common-packages.yml
@@ -41,3 +41,6 @@ install:
 
     # address hardened_malloc incompatibilities
     - no_rlimit_as
+
+    # For use in unprivileged ujust scripts
+    - python3-inquirer


### PR DESCRIPTION
The Python rewrite has the same basic logic but with some improvements to user-facing messages and the app ID search logic.

The third-party `inquirer` module is used for letting the user select from a list of options, and is installed via RPM. (I put it in `common-packages.yml` rather than `desktop-packages.yml` because it's likely to be useful in other ujust scripts, and is a small package in any case.)

Also move audit-script-specific parts of the `utils` module into a new `audit_utils` module, and fix a minor type error in `is_using_vpn`.