### PR TITLE
chore: opt out of installing cosign to images

### DIFF
--- a/.github/workflows/build-one-recipe.yml
+++ b/.github/workflows/build-one-recipe.yml
@@ -104,7 +104,7 @@ jobs:
             echo "Upstream isn't signed. Skipping."
             exit 0
           fi
-          
+
           UPSTREAM_CONTAINER="${BASE_IMAGE_NAME}:${IMAGE_MAJOR_VERSION}"
           if [[ "$IMAGE_NAME" != *nvidia* && "$IMAGE_NAME" != *zfs* ]]; then
             UPSTREAM_REGISTRY='quay.io/fedora-ostree-desktops'
@@ -123,7 +123,7 @@ jobs:
         env:
           KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
         with:
-          cli_version: v0.9.24
+          cli_version: v0.9.26
           recipe: ${{ inputs.recipe }}
           cosign_private_key: ${{ secrets.SIGNING_SECRET }}
           registry_token: ${{ github.token }}

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -37,7 +37,7 @@ jobs:
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
-          
+
       - name: Optimize build times
         shell: bash
         run: |
@@ -96,7 +96,7 @@ jobs:
             echo "Upstream isn't signed. Skipping."
             exit 0
           fi
-          
+
           UPSTREAM_CONTAINER="${BASE_IMAGE_NAME}:${IMAGE_MAJOR_VERSION}"
           if [[ "$IMAGE_NAME" != *nvidia* && "$IMAGE_NAME" != *zfs* ]]; then
             UPSTREAM_REGISTRY='quay.io/fedora-ostree-desktops'
@@ -129,7 +129,7 @@ jobs:
         run: |
           docker create \
             --name blue-build-installer \
-            ghcr.io/blue-build/cli:v0.9.24-installer
+            ghcr.io/blue-build/cli:v0.9.26-installer
           docker cp blue-build-installer:/out/bluebuild /usr/local/bin/bluebuild
           docker rm blue-build-installer
           bluebuild --version

--- a/recipes/general/recipe-cosmic-main.yml
+++ b/recipes/general/recipe-cosmic-main.yml
@@ -18,6 +18,7 @@ base-image: quay.io/fedora-ostree-desktops/cosmic-atomic
 
 image-version: 43
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/general/recipe-cosmic-nvidia-open.yml
+++ b/recipes/general/recipe-cosmic-nvidia-open.yml
@@ -18,6 +18,7 @@ base-image: ghcr.io/secureblue/cosmic-main-hardened
 
 image-version: latest
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/general/recipe-cosmic-nvidia.yml
+++ b/recipes/general/recipe-cosmic-nvidia.yml
@@ -18,6 +18,7 @@ base-image: ghcr.io/secureblue/cosmic-main-hardened
 
 image-version: latest
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/general/recipe-kinoite-main.yml
+++ b/recipes/general/recipe-kinoite-main.yml
@@ -18,6 +18,7 @@ base-image: quay.io/fedora-ostree-desktops/kinoite
 
 image-version: 43
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/general/recipe-kinoite-nvidia-open.yml
+++ b/recipes/general/recipe-kinoite-nvidia-open.yml
@@ -18,6 +18,7 @@ base-image: ghcr.io/secureblue/kinoite-main-hardened
 
 image-version: latest
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/general/recipe-kinoite-nvidia.yml
+++ b/recipes/general/recipe-kinoite-nvidia.yml
@@ -18,6 +18,7 @@ base-image: ghcr.io/secureblue/kinoite-main-hardened
 
 image-version: latest
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/general/recipe-sericea-main.yml
+++ b/recipes/general/recipe-sericea-main.yml
@@ -18,6 +18,7 @@ base-image: quay.io/fedora-ostree-desktops/sway-atomic
 
 image-version: 43
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/general/recipe-sericea-nvidia-open.yml
+++ b/recipes/general/recipe-sericea-nvidia-open.yml
@@ -18,6 +18,7 @@ base-image: ghcr.io/secureblue/sericea-main-hardened
 
 image-version: latest
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/general/recipe-sericea-nvidia.yml
+++ b/recipes/general/recipe-sericea-nvidia.yml
@@ -18,6 +18,7 @@ base-image: ghcr.io/secureblue/sericea-main-hardened
 
 image-version: latest
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/general/recipe-silverblue-main.yml
+++ b/recipes/general/recipe-silverblue-main.yml
@@ -18,6 +18,7 @@ base-image: quay.io/fedora-ostree-desktops/silverblue
 
 image-version: 43
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/general/recipe-silverblue-nvidia-open.yml
+++ b/recipes/general/recipe-silverblue-nvidia-open.yml
@@ -18,6 +18,7 @@ base-image: ghcr.io/secureblue/silverblue-main-hardened
 
 image-version: latest
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/general/recipe-silverblue-nvidia.yml
+++ b/recipes/general/recipe-silverblue-nvidia.yml
@@ -18,6 +18,7 @@ base-image: ghcr.io/secureblue/silverblue-main-hardened
 
 image-version: latest
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/iot/recipe-iot-main.yml
+++ b/recipes/iot/recipe-iot-main.yml
@@ -18,6 +18,7 @@ base-image: quay.io/fedora/fedora-iot
 
 image-version: 43
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/iot/recipe-iot-nvidia-open.yml
+++ b/recipes/iot/recipe-iot-nvidia-open.yml
@@ -18,6 +18,7 @@ base-image: ghcr.io/secureblue/iot-main-hardened
 
 image-version: latest
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/iot/recipe-iot-nvidia.yml
+++ b/recipes/iot/recipe-iot-nvidia.yml
@@ -18,6 +18,7 @@ base-image: ghcr.io/secureblue/iot-main-hardened
 
 image-version: latest
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/iot/recipe-iot-zfs-main.yml
+++ b/recipes/iot/recipe-iot-zfs-main.yml
@@ -18,6 +18,7 @@ base-image: ghcr.io/secureblue/iot-main-hardened
 
 image-version: latest
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/iot/recipe-iot-zfs-nvidia-open.yml
+++ b/recipes/iot/recipe-iot-zfs-nvidia-open.yml
@@ -18,6 +18,7 @@ base-image: ghcr.io/secureblue/iot-zfs-main-hardened
 
 image-version: latest
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/iot/recipe-iot-zfs-nvidia.yml
+++ b/recipes/iot/recipe-iot-zfs-nvidia.yml
@@ -18,6 +18,7 @@ base-image: ghcr.io/secureblue/iot-zfs-main-hardened
 
 image-version: latest
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/securecore/recipe-securecore-main.yml
+++ b/recipes/securecore/recipe-securecore-main.yml
@@ -18,6 +18,7 @@ base-image: quay.io/fedora/fedora-coreos
 
 image-version: testing
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/securecore/recipe-securecore-nvidia-open.yml
+++ b/recipes/securecore/recipe-securecore-nvidia-open.yml
@@ -18,6 +18,7 @@ base-image: ghcr.io/secureblue/securecore-main-hardened
 
 image-version: latest
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/securecore/recipe-securecore-nvidia.yml
+++ b/recipes/securecore/recipe-securecore-nvidia.yml
@@ -18,6 +18,7 @@ base-image: ghcr.io/secureblue/securecore-main-hardened
 
 image-version: latest
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/securecore/recipe-securecore-zfs-main.yml
+++ b/recipes/securecore/recipe-securecore-zfs-main.yml
@@ -18,6 +18,7 @@ base-image: ghcr.io/secureblue/securecore-main-hardened
 
 image-version: latest
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/securecore/recipe-securecore-zfs-nvidia-open.yml
+++ b/recipes/securecore/recipe-securecore-zfs-nvidia-open.yml
@@ -18,6 +18,7 @@ base-image: ghcr.io/secureblue/securecore-zfs-main-hardened
 
 image-version: latest
 
+cosign-version: none
 nushell-version: none
 
 modules:

--- a/recipes/securecore/recipe-securecore-zfs-nvidia.yml
+++ b/recipes/securecore/recipe-securecore-zfs-nvidia.yml
@@ -18,6 +18,7 @@ base-image: ghcr.io/secureblue/securecore-zfs-main-hardened
 
 image-version: latest
 
+cosign-version: none
 nushell-version: none
 
 modules:


### PR DESCRIPTION
Cosign is used in the build process but isn't needed in the built images, and adds about 150 MB to image sizes. Users who want to install cosign can install it via brew.

Also update BlueBuild CLI to v0.9.26, which has the option to omit cosign from the image.