### PR TITLE
feat: add steam-devices udev rules

### DIFF
--- a/recipes/common/common-packages.yml
+++ b/recipes/common/common-packages.yml
@@ -35,6 +35,7 @@ install:
     - wireguard-tools
     - gettext
     - rsync
+    - steam-devices
 
     # signing deps
     - sbsigntools


### PR DESCRIPTION
steam-devices is a tiny (10KB) package that adds 2 udev rules files for various input devices