### PR TITLE
feat: add unauthenticated NIST time server as a fallback

### DIFF
--- a/files/system/etc/chrony.conf
+++ b/files/system/etc/chrony.conf
@@ -18,7 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-server 129.6.15.27 iburst # https://tf.nist.gov/tf-cgi/servers.cgi
+ # https://tf.nist.gov/tf-cgi/servers.cgi
+server 129.6.15.27 iburst
 server time.cloudflare.com iburst nts
 server ntppool1.time.nl iburst nts
 server nts.netnod.se iburst nts

--- a/files/system/etc/chrony.conf
+++ b/files/system/etc/chrony.conf
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+server 129.6.15.27 iburst # https://tf.nist.gov/tf-cgi/servers.cgi
 server time.cloudflare.com iburst nts
 server ntppool1.time.nl iburst nts
 server nts.netnod.se iburst nts
@@ -26,7 +27,8 @@ server time.dfm.dk iburst nts
 server time.cifelli.xyz iburst nts
 
 minsources 3
-authselectmode require
+
+authselectmode prefer
 
 # EF
 dscp 46

--- a/files/system/etc/chrony.conf
+++ b/files/system/etc/chrony.conf
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
- # https://tf.nist.gov/tf-cgi/servers.cgi
+# https://tf.nist.gov/tf-cgi/servers.cgi
 server 129.6.15.27 iburst
 server time.cloudflare.com iburst nts
 server ntppool1.time.nl iburst nts


### PR DESCRIPTION
This is needed in cases where:

- The hardware has no system clock
- CMOS resets/system clock reset for any reason