### PR TITLE
fix: make `ujust harden-flatpak` work on aarch64

### DIFF
--- a/files/system/desktop/usr/libexec/secureblue/harden_flatpak.py
+++ b/files/system/desktop/usr/libexec/secureblue/harden_flatpak.py
@@ -36,7 +36,7 @@ def best_microarch() -> str | None:
     """Get best microarchitecture for system."""
     try:
         ld_info = command_stdout("/usr/lib64/ld-linux-x86-64.so.2", "--help")
-    except subprocess.CalledProcessError:
+    except (FileNotFoundError, subprocess.CalledProcessError):
         return None
     m = re.search(
         r"^\s*(x86-64-v\d+).*\(supported, searched\)", ld_info, flags=re.ASCII | re.MULTILINE


### PR DESCRIPTION
The microarchitecture detection logic should default to "none" on aarch64 since there are no microarch-specific builds for that.

Fixes #1628.