### PR TITLE
ci: update BlueBuild, use BlueBuild action for PR builds

### DIFF
--- a/.github/workflows/build-one-recipe.yml
+++ b/.github/workflows/build-one-recipe.yml
@@ -53,16 +53,6 @@ jobs:
           sudo rm -f /var/lib/man-db/auto-update
           sudo sed -i 's/^update_initramfs=.*/update_initramfs=no/' /etc/initramfs-tools/update-initramfs.conf
 
-      - name: Free disk space
-        shell: bash
-        run: |
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /opt/ghc || true
-          sudo rm -rf /usr/local/.ghcup || true
-          sudo docker image prune --all --force || true
-          sudo swapoff -a || true
-          sudo rm -f /mnt/swapfile || true
-
       - name: Checkout repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -122,20 +112,21 @@ jobs:
           fi
 
       - name: Build secureblue
-        uses: blue-build/github-action@785ecb253aee6ead01454ed5bd070c2921010602 # v1.9.1
+        uses: blue-build/github-action@5c6916e55b22914100bedc50fbbd001ed95c971a # v1.10.1
         env:
           KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
         with:
-          cli_version: v0.9.26
+          cli_version: v0.9.27
           recipe: ${{ inputs.recipe }}
           cosign_private_key: ${{ secrets.SIGNING_SECRET }}
           registry_token: ${{ github.token }}
           pr_event_number: ${{ github.event.number }}
-          maximize_build_space: false
+          maximize_build_space: true
           squash: true
           skip_checkout: true
           use_cache: false
           retry_push_count: 3
+          verify_install: true
 
       - name: Install regctl
         uses: regclient/actions/regctl-installer@495560f7c3b510b71ff9f22d6c667c2c429b8e45 # main # zizmor: ignore[stale-action-refs] regctl does not publish tags

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -30,7 +30,7 @@ jobs:
     name: PR build
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      contents: read # Needed to pull the repo for the build
 
     steps:
       - name: Enable egress auditing
@@ -46,16 +46,6 @@ jobs:
           sudo rm -f /var/lib/man-db/auto-update
           sudo sed -i 's/^update_initramfs=.*/update_initramfs=no/' /etc/initramfs-tools/update-initramfs.conf
 
-      - name: Free disk space
-        shell: bash
-        run: |
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /opt/ghc || true
-          sudo rm -rf /usr/local/.ghcup || true
-          sudo docker image prune --all --force || true
-          sudo swapoff -a || true
-          sudo rm -f /mnt/swapfile || true
-
       - name: Checkout repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -66,10 +56,10 @@ jobs:
         env:
           RECIPE: ${{ inputs.recipe }}
         run: |
-          echo "IMAGE_NAME=$(grep '^name:' "./recipes/${RECIPE}" | sed 's/^name: //')" >> "$GITHUB_ENV"
-          echo "IMAGE_MAJOR_VERSION=$(grep '^image-version:' "./recipes/${RECIPE}" | sed 's/^image-version: //')" >> "$GITHUB_ENV"
+          echo "IMAGE_NAME=$(grep '^name:' "./recipes/${RECIPE}" | sed 's/^name: //')" >> "${GITHUB_ENV}"
+          echo "IMAGE_MAJOR_VERSION=$(grep '^image-version:' "./recipes/${RECIPE}" | sed 's/^image-version: //')" >> "${GITHUB_ENV}"
           BASE_IMAGE=$(grep '^base-image:' "./recipes/${RECIPE}" | sed 's/^base-image: //')
-          echo "BASE_IMAGE_NAME=$(echo "$BASE_IMAGE" | sed 's/.*\/.*\///')" >> "$GITHUB_ENV"
+          echo "BASE_IMAGE_NAME=$(echo "${BASE_IMAGE}" | sed 's/.*\/.*\///')" >> "${GITHUB_ENV}"
 
       - name: Verify base image provenance
         shell: bash
@@ -113,41 +103,27 @@ jobs:
             exit 1
           fi
 
-      - name: Determine Vars
-        id: build_vars
+      - name: Set up test keys
+        id: test_keys
         shell: bash
-        env:
-          RECIPE: ${{ inputs.recipe }}
-        run: |
-          RECIPE_PATH=""
-          if [ -f "./config/${RECIPE}" ]; then
-            RECIPE_PATH="./config/${RECIPE}"
-          else
-            RECIPE_PATH="./recipes/${RECIPE}"
-          fi
-          echo "recipe_path=${RECIPE_PATH}" >> "${GITHUB_OUTPUT}"
-
-      - name: Install BlueBuild
-        shell: bash
-        run: |
-          docker create \
-            --name blue-build-installer \
-            ghcr.io/blue-build/cli:v0.9.26-installer
-          docker cp blue-build-installer:/out/bluebuild /usr/local/bin/bluebuild
-          docker rm blue-build-installer
-          bluebuild --version
-
-      - name: Build Image
-        shell: bash
-        env:
-          RECIPE_PATH: ${{ steps.build_vars.outputs.recipe_path }}
-          RUST_LOG_STYLE: always
-          CLICOLOR_FORCE: '1'
-          GH_PR_EVENT_NUMBER: ${{ github.event.number }}
         run: |
           cp ./.github/workflows/public_key.der.test ./files/system/etc/pki/akmods/certs/akmods-secureblue.der
-          KERNEL_PRIVKEY=$(< ./.github/workflows/private_key.priv.test)
-          export KERNEL_PRIVKEY
+          {
+            echo 'kernel_privkey<<EOF'
+            cat ./.github/workflows/private_key.priv.test
+            echo 'EOF'
+          } >> "${GITHUB_OUTPUT}"
 
-          BUILD_OPTS="--build-driver podman --squash"
-          bluebuild build -v ${BUILD_OPTS} "${RECIPE_PATH}"
+      - name: Build secureblue
+        uses: blue-build/github-action@5c6916e55b22914100bedc50fbbd001ed95c971a # v1.10.1
+        env:
+          KERNEL_PRIVKEY: ${{ steps.test_keys.outputs.kernel_privkey }}
+        with:
+          cli_version: v0.9.27
+          recipe: ${{ inputs.recipe }}
+          push: false
+          pr_event_number: ${{ github.event.number }}
+          maximize_build_space: true
+          squash: true
+          skip_checkout: true
+          verify_install: true


### PR DESCRIPTION
* Update BlueBuild CLI to v0.9.27 (which fixes the bug that recently led to the BlueBuild CLI not being installed into the built images).
* Update BlueBuild action to v1.10.1.
* Use `maximize_build_space` and `verify_install` options for BlueBuild action now that these are added/improved in the latest version.
* Use BlueBuild action (rather than manually installing the CLI) for PR builds. This is made possible by the new version of the BlueBuild action having the option to opt out of pushing the image, and helps ensure that PR builds more closely match the real builds.