### PR TITLE
fix: generate correct provenance on non-default branches

### DIFF
--- a/.github/workflows/build-one-recipe.yml
+++ b/.github/workflows/build-one-recipe.yml
@@ -64,23 +64,22 @@ jobs:
           RECIPE: ${{ inputs.recipe }}
         run: |
           echo "REGISTRY=ghcr.io/secureblue" >> "${GITHUB_ENV}"
-          echo "IMAGE_NAME=$(grep '^name:' "./recipes/${RECIPE}" | sed 's/^name: //')" >> "${GITHUB_ENV}"
-          echo "IMAGE_MAJOR_VERSION=$(grep '^image-version:' "./recipes/${RECIPE}" | sed 's/^image-version: //')" >> "${GITHUB_ENV}"
-          BASE_IMAGE=$(grep '^base-image:' "./recipes/${RECIPE}" | sed 's/^base-image: //')
-          echo "BASE_IMAGE_NAME=$(echo "${BASE_IMAGE}" | sed 's/.*\/.*\///')" >> "${GITHUB_ENV}"
+          echo "IMAGE_NAME=$(sed -n 's/^name: //p' "./recipes/${RECIPE}")" >> "${GITHUB_ENV}"
+          echo "BASE_IMAGE=$(sed -n 's/^base-image: //p' "./recipes/${RECIPE}")" >> "${GITHUB_ENV}"
+          echo "BASE_IMAGE_VERSION=$(sed -n 's/^image-version: //p' "./recipes/${RECIPE}")" >> "${GITHUB_ENV}"
 
       - name: Verify base image provenance
         shell: bash
         run: |
-          if [[ "$BASE_IMAGE_NAME" != *hardened* ]]; then
+          if [[ "$BASE_IMAGE" != ghcr.io/secureblue/* ]]; then
             echo "Base image isn't secureblue. Skipping."
             exit 0
           fi
 
           go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.7.1
           go install github.com/google/go-containerregistry/cmd/crane@v0.20.6
-          DIGEST=$(~/go/bin/crane digest "ghcr.io/secureblue/${BASE_IMAGE_NAME}:latest")
-          ~/go/bin/slsa-verifier verify-image --source-uri github.com/secureblue/secureblue ghcr.io/secureblue/${BASE_IMAGE_NAME}:latest@"${DIGEST}"
+          DIGEST=$(~/go/bin/crane digest "${BASE_IMAGE}:${BASE_IMAGE_VERSION}")
+          ~/go/bin/slsa-verifier verify-image --source-uri 'github.com/secureblue/secureblue' "${BASE_IMAGE}:${BASE_IMAGE_VERSION}@${DIGEST}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
@@ -98,15 +97,13 @@ jobs:
             exit 0
           fi
 
-          UPSTREAM_CONTAINER="${BASE_IMAGE_NAME}:${IMAGE_MAJOR_VERSION}"
-          if [[ "$IMAGE_NAME" != *nvidia* && "$IMAGE_NAME" != *zfs* ]]; then
-            UPSTREAM_REGISTRY='quay.io/fedora-ostree-desktops'
-            UPSTREAM_PUBKEY='https://gitlab.com/fedora/ostree/ci-test/-/raw/main/quay.io-fedora-ostree-desktops.pub'
-          else
-            UPSTREAM_REGISTRY='ghcr.io/secureblue'
+          UPSTREAM_CONTAINER="${BASE_IMAGE}:${BASE_IMAGE_VERSION}"
+          if [[ "$BASE_IMAGE" == ghcr.io/secureblue/* ]]; then
             UPSTREAM_PUBKEY='https://raw.githubusercontent.com/secureblue/secureblue/refs/heads/live/cosign.pub'
+          else
+            UPSTREAM_PUBKEY='https://gitlab.com/fedora/ostree/ci-test/-/raw/main/quay.io-fedora-ostree-desktops.pub'
           fi
-          if ! cosign verify --key "${UPSTREAM_PUBKEY}" "${UPSTREAM_REGISTRY}/${UPSTREAM_CONTAINER}" | jq; then
+          if ! cosign verify --key "${UPSTREAM_PUBKEY}" "${UPSTREAM_CONTAINER}" | jq; then
             echo "NOTICE: Verification failed. Please ensure your public key is correct."
             exit 1
           fi
@@ -133,11 +130,20 @@ jobs:
 
       - name: Parse image manifest
         id: image_manifest_metadata
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          PR_EVENT_NUMBER: ${{ github.event.number }}
         run: |
-          FULL_IMAGE_REF="${REGISTRY}/${IMAGE_NAME}:latest"
+          case "$GITHUB_REF" in
+            refs/heads/"$DEFAULT_BRANCH") image_tag='latest' ;;
+            refs/pull/*) image_tag="pr-${PR_EVENT_NUMBER}-43" ;;
+            *) image_tag="br-${GITHUB_REF_NAME}-43" ;;
+          esac
+          FULL_IMAGE_REF="${REGISTRY}/${IMAGE_NAME}:${image_tag}"
           IMAGE_DIGEST="$(regctl image digest "${FULL_IMAGE_REF}")"
-          echo "FULL_IMAGE_REF=${FULL_IMAGE_REF}" >> $GITHUB_OUTPUT
-          echo "IMAGE_DIGEST=${IMAGE_DIGEST}" >> $GITHUB_OUTPUT
+          echo "FULL_IMAGE_REF=${FULL_IMAGE_REF}" >> "${GITHUB_OUTPUT}"
+          echo "IMAGE_DIGEST=${IMAGE_DIGEST}" >> "${GITHUB_OUTPUT}"
 
   provenance:
     needs: [bluebuild]

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -56,23 +56,22 @@ jobs:
         env:
           RECIPE: ${{ inputs.recipe }}
         run: |
-          echo "IMAGE_NAME=$(grep '^name:' "./recipes/${RECIPE}" | sed 's/^name: //')" >> "${GITHUB_ENV}"
-          echo "IMAGE_MAJOR_VERSION=$(grep '^image-version:' "./recipes/${RECIPE}" | sed 's/^image-version: //')" >> "${GITHUB_ENV}"
-          BASE_IMAGE=$(grep '^base-image:' "./recipes/${RECIPE}" | sed 's/^base-image: //')
-          echo "BASE_IMAGE_NAME=$(echo "${BASE_IMAGE}" | sed 's/.*\/.*\///')" >> "${GITHUB_ENV}"
+          echo "IMAGE_NAME=$(sed -n 's/^name: //p' "./recipes/${RECIPE}")" >> "${GITHUB_ENV}"
+          echo "BASE_IMAGE=$(sed -n 's/^base-image: //p' "./recipes/${RECIPE}")" >> "${GITHUB_ENV}"
+          echo "BASE_IMAGE_VERSION=$(sed -n 's/^image-version: //p' "./recipes/${RECIPE}")" >> "${GITHUB_ENV}"
 
       - name: Verify base image provenance
         shell: bash
         run: |
-          if [[ "$BASE_IMAGE_NAME" != *hardened* ]]; then
+          if [[ "$BASE_IMAGE" != ghcr.io/secureblue/* ]]; then
             echo "Base image isn't secureblue. Skipping."
             exit 0
           fi
 
           go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.7.1
           go install github.com/google/go-containerregistry/cmd/crane@v0.20.6
-          DIGEST=$(~/go/bin/crane digest "ghcr.io/secureblue/${BASE_IMAGE_NAME}:latest")
-          ~/go/bin/slsa-verifier verify-image --source-uri github.com/secureblue/secureblue ghcr.io/secureblue/${BASE_IMAGE_NAME}:latest@"${DIGEST}"
+          DIGEST=$(~/go/bin/crane digest "${BASE_IMAGE}:${BASE_IMAGE_VERSION}")
+          ~/go/bin/slsa-verifier verify-image --source-uri 'github.com/secureblue/secureblue' "${BASE_IMAGE}:${BASE_IMAGE_VERSION}@${DIGEST}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
@@ -90,15 +89,13 @@ jobs:
             exit 0
           fi
 
-          UPSTREAM_CONTAINER="${BASE_IMAGE_NAME}:${IMAGE_MAJOR_VERSION}"
-          if [[ "$IMAGE_NAME" != *nvidia* && "$IMAGE_NAME" != *zfs* ]]; then
-            UPSTREAM_REGISTRY='quay.io/fedora-ostree-desktops'
-            UPSTREAM_PUBKEY='https://gitlab.com/fedora/ostree/ci-test/-/raw/main/quay.io-fedora-ostree-desktops.pub'
-          else
-            UPSTREAM_REGISTRY='ghcr.io/secureblue'
+          UPSTREAM_CONTAINER="${BASE_IMAGE}:${BASE_IMAGE_VERSION}"
+          if [[ "$BASE_IMAGE" == ghcr.io/secureblue/* ]]; then
             UPSTREAM_PUBKEY='https://raw.githubusercontent.com/secureblue/secureblue/refs/heads/live/cosign.pub'
+          else
+            UPSTREAM_PUBKEY='https://gitlab.com/fedora/ostree/ci-test/-/raw/main/quay.io-fedora-ostree-desktops.pub'
           fi
-          if ! cosign verify --key "${UPSTREAM_PUBKEY}" "${UPSTREAM_REGISTRY}/${UPSTREAM_CONTAINER}" | jq; then
+          if ! cosign verify --key "${UPSTREAM_PUBKEY}" "${UPSTREAM_CONTAINER}" | jq; then
             echo "NOTICE: Verification failed. Please ensure your public key is correct."
             exit 1
           fi


### PR DESCRIPTION
The generated provenance should only be for the `latest` tag on the default branch; otherwise, the tag has a form generated from the branch name or PR number and the OS major version number.

Also simplified the base image verification steps in the build workflows so they don't rely on assumptions about secureblue image naming conventions.