### PR TITLE
fix: make curl usage more robust

### DIFF
--- a/.github/workflows/iso.yml
+++ b/.github/workflows/iso.yml
@@ -27,18 +27,18 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.triggering_actor == 'royaloughtness'
     strategy:
-      fail-fast: false      
+      fail-fast: false
       matrix:
         image:
           - silverblue-main-hardened
-          - silverblue-nvidia-hardened 
-          - silverblue-nvidia-open-hardened 
-          - kinoite-main-hardened 
-          - kinoite-nvidia-hardened 
-          - kinoite-nvidia-open-hardened 
-          - sericea-main-hardened 
-          - sericea-nvidia-hardened 
-          - sericea-nvidia-open-hardened 
+          - silverblue-nvidia-hardened
+          - silverblue-nvidia-open-hardened
+          - kinoite-main-hardened
+          - kinoite-nvidia-hardened
+          - kinoite-nvidia-open-hardened
+          - sericea-main-hardened
+          - sericea-nvidia-hardened
+          - sericea-nvidia-open-hardened
     permissions:
       contents: read # read repo contents
       packages: read # pull images for iso generation
@@ -65,7 +65,7 @@ jobs:
         env:
           WORKSPACE: ${{ github.workspace }}
         run: |
-          curl -Lo "${WORKSPACE}/secureblue.repo" "https://copr.fedorainfracloud.org/coprs/secureblue/branding/repo/fedora-43/secureblue-branding-fedora-43.repo"
+          curl -fLsS --retry 5 -o "${WORKSPACE}/secureblue.repo" "https://copr.fedorainfracloud.org/coprs/secureblue/branding/repo/fedora-43/secureblue-branding-fedora-43.repo"
 
       - name: Build ISO
         uses: jasonn3/build-container-installer@c9ef3de33236e66781ec37bd0485e8009eaefe24 # v1.4.0
@@ -129,7 +129,7 @@ jobs:
           echo
 
           # validate signature
-          curl -O "https://repo.secureblue.dev/secureblue.gpg"
+          curl -fLsS --retry 5 -O "https://repo.secureblue.dev/secureblue.gpg"
           gpg --no-default-keyring --keyring ./secureblue-keyring.gpg --import secureblue.gpg
 
           if ! gpgv --keyring ./secureblue-keyring.gpg "${CHECKSUM_NAME}"; then
@@ -169,5 +169,4 @@ jobs:
           OUTPUT_DIRECTORY: ${{ steps.rename.outputs.output-directory }}
           SOURCE_DIR: .
         run: |
-          rclone copy "${OUTPUT_DIRECTORY}" R2:isos 
-      
+          rclone copy "${OUTPUT_DIRECTORY}" R2:isos

--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -184,13 +184,17 @@ check-unconfined-userns-state:
 # Install the official docker packages
 install-docker:
     #! /bin/run0 /bin/bash
-    curl -Lo /etc/yum.repos.d/docker-ce.repo https://download.docker.com/linux/fedora/docker-ce.repo
+    set -euo pipefail
+    tempfile=$(mktemp)
+    curl -fLo "$tempfile" https://download.docker.com/linux/fedora/docker-ce.repo
+    mv "$tempfile" /etc/yum.repos.d/docker-ce.repo
     rpm-ostree refresh-md
     rpm-ostree install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 # Uninstall the official docker packages
 uninstall-docker:
     #! /bin/run0 /bin/bash
+    set -euo pipefail
     rm /etc/yum.repos.d/docker-ce.repo
     rpm-ostree refresh-md
     rpm-ostree uninstall docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin

--- a/files/scripts/addrepos.sh
+++ b/files/scripts/addrepos.sh
@@ -17,7 +17,7 @@ set -oue pipefail
 
 install_repo() {
   versioned_repo="${1//%OS_VERSION%/43}"
-  curl -L -o "/etc/yum.repos.d/$(basename "$versioned_repo")" "$versioned_repo"
+  curl -fLsS --retry 5 -o "/etc/yum.repos.d/${versioned_repo##*/}" "$versioned_repo"
 }
 
 common_repos=(

--- a/files/scripts/install-trivalent.sh
+++ b/files/scripts/install-trivalent.sh
@@ -18,7 +18,7 @@ ARCH="$(uname -m)"
 
 dnf5 install python3-dnf -y
 
-curl -Lo /etc/yum.repos.d/repo.secureblue.dev.secureblue.repo https://repo.secureblue.dev/secureblue.repo
+curl -fLsS --retry 5 -o /etc/yum.repos.d/repo.secureblue.dev.secureblue.repo https://repo.secureblue.dev/secureblue.repo
 
 # dnf4 must be used here due to https://github.com/rpm-software-management/dnf5/issues/1985
 dnf4 install --repoid=secureblue --downloadonly --best --downloaddir=. -y trivalent

--- a/files/scripts/installandroidudev.sh
+++ b/files/scripts/installandroidudev.sh
@@ -15,7 +15,7 @@
 set -oue pipefail
 
 LATEST_ANDROID_UDEV_RULES_COMMIT="e62577fade0e79a965edfff732b88f228266cb0b" # 20250525
-curl -OL "https://github.com/M0Rf30/android-udev-rules/archive/${LATEST_ANDROID_UDEV_RULES_COMMIT}.tar.gz"
+curl -fLsS --retry 5 -O "https://github.com/M0Rf30/android-udev-rules/archive/${LATEST_ANDROID_UDEV_RULES_COMMIT}.tar.gz"
 tar xvf "${LATEST_ANDROID_UDEV_RULES_COMMIT}.tar.gz" --strip-components=1
 
 install -m 644 51-android.rules /etc/udev/rules.d/

--- a/files/scripts/installnvidiakmod.sh
+++ b/files/scripts/installnvidiakmod.sh
@@ -25,7 +25,7 @@ if [[ "$IMAGE_NAME" == *"open"* ]]; then
     KERNEL_MODULE_TYPE+="-open"
 fi
 
-curl -Lo /etc/yum.repos.d/negativo17-fedora-nvidia.repo https://negativo17.org/repos/fedora-nvidia.repo
+curl -fLsS --retry 5 -o /etc/yum.repos.d/negativo17-fedora-nvidia.repo https://negativo17.org/repos/fedora-nvidia.repo
 sed -i '/^enabled=1/a\priority=90' /etc/yum.repos.d/negativo17-fedora-nvidia.repo
 
 dnf install -y --setopt=install_weak_deps=False "kernel-devel-matched-$(rpm -q 'kernel' --queryformat '%{VERSION}')"

--- a/files/scripts/installnvidiapackages.sh
+++ b/files/scripts/installnvidiapackages.sh
@@ -20,7 +20,7 @@ if [[ "$IMAGE_NAME" != *"securecore"* && "$IMAGE_NAME" != *"iot"* ]]; then
     nvidia_packages_list+=('libnvidia-fbc' 'libva-nvidia-driver' 'nvidia-driver' 'nvidia-modprobe' 'nvidia-persistenced' 'nvidia-settings')
 fi
 
-curl -L https://negativo17.org/repos/fedora-nvidia.repo -o /etc/yum.repos.d/negativo17-fedora-nvidia.repo
+curl -fLsS --retry 5 https://negativo17.org/repos/fedora-nvidia.repo -o /etc/yum.repos.d/negativo17-fedora-nvidia.repo
 
 
 sed -i 's/^enabled=0.*/enabled=1\npriority=90/' /etc/yum.repos.d/negativo17-fedora-nvidia.repo
@@ -38,7 +38,7 @@ if [[ "$kmod_version" != "$negativo_version" ]]; then
     exit 1
 fi
 
-curl -L https://raw.githubusercontent.com/NVIDIA/dgx-selinux/master/bin/RHEL9/nvidia-container.pp \
+curl -fLsS --retry 5 https://raw.githubusercontent.com/NVIDIA/dgx-selinux/master/bin/RHEL9/nvidia-container.pp \
     -o nvidia-container.pp
 semodule -i nvidia-container.pp
 

--- a/files/scripts/installzfskmod.sh
+++ b/files/scripts/installzfskmod.sh
@@ -18,8 +18,8 @@ set -oue pipefail
 KERNEL_VERSION="$(rpm -q "kernel" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 ZFS_MINOR_VERSION="2.4"
 
-curl "https://api.github.com/repos/openzfs/zfs/releases" -o data.json
-# TODO add back .prerelease==false when 2.4 is out 
+curl -fLsS --retry 5 -o data.json "https://api.github.com/repos/openzfs/zfs/releases"
+# TODO add back .prerelease==false when 2.4 is out
 ZFS_VERSION=$(jq -r --arg ZMV "zfs-${ZFS_MINOR_VERSION}" '[ .[] | select(.draft==false) | select(.tag_name | startswith($ZMV))][0].tag_name' data.json|cut -f2- -d-)
 echo "ZFS_VERSION==$ZFS_VERSION"
 
@@ -29,9 +29,10 @@ dnf install -y --setopt=install_weak_deps=False autoconf automake gcc pv akmods 
 
 ### BUILD zfs
 echo "getting zfs-${ZFS_VERSION}.tar.gz"
-curl -L -O "https://github.com/openzfs/zfs/releases/download/zfs-${ZFS_VERSION}/zfs-${ZFS_VERSION}.tar.gz"
-curl -L -O "https://github.com/openzfs/zfs/releases/download/zfs-${ZFS_VERSION}/zfs-${ZFS_VERSION}.tar.gz.asc"
-curl -L -O "https://github.com/openzfs/zfs/releases/download/zfs-${ZFS_VERSION}/zfs-${ZFS_VERSION}.sha256.asc"
+curl -fLsS --retry 5 \
+    -O "https://github.com/openzfs/zfs/releases/download/zfs-${ZFS_VERSION}/zfs-${ZFS_VERSION}.tar.gz" \
+    -O "https://github.com/openzfs/zfs/releases/download/zfs-${ZFS_VERSION}/zfs-${ZFS_VERSION}.tar.gz.asc" \
+    -O "https://github.com/openzfs/zfs/releases/download/zfs-${ZFS_VERSION}/zfs-${ZFS_VERSION}.sha256.asc"
 
 echo "Import key"
 # https://openzfs.github.io/openzfs-docs/Project%20and%20Community/Signing%20Keys.html
@@ -90,7 +91,7 @@ depmod -a -v "${KERNEL_VERSION}"
 
 rm -f /etc/dnf/protected.d/sudo.conf
 
-dnf remove -y sudo autoconf automake mock 
+dnf remove -y sudo autoconf automake mock
 
 systemctl disable akmods-keygen@akmods-keygen.service
 systemctl mask akmods-keygen@akmods-keygen.service


### PR DESCRIPTION
Consistently use `curl -fLsS --retry 5` in build scripts and workflows that use curl, ensuring that curl handles HTTP errors, follows redirects, retries on encountering errors that are typically temporary, and does not suppress error output in case of failure. This should make curl more robust in the presence of transient network issues and make such issues more apparent in build logs when they do occur.

In the one place where curl is used in a ujust script, use a temporary file to ensure we don't end up writing partial output if curl fails.