### PR TITLE
removed sysctls already set in fedora

### DIFF
--- a/files/system/usr/lib/sysctl.d/55-hardening.conf
+++ b/files/system/usr/lib/sysctl.d/55-hardening.conf
@@ -11,17 +11,8 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 # https://docs.kernel.org/networking/ip-sysctl.html
-net.ipv4.tcp_syncookies = 1
-
-# https://docs.kernel.org/networking/ip-sysctl.html
 # https://datatracker.ietf.org/doc/html/rfc1337
 net.ipv4.tcp_rfc1337 = 1
-
-# https://docs.kernel.org/networking/ip-sysctl.html
-net.ipv4.icmp_echo_ignore_broadcasts = 1
-
-# https://docs.kernel.org/networking/ip-sysctl.html
-net.ipv4.icmp_ignore_bogus_error_responses = 1
 
 # https://docs.kernel.org/networking/ip-sysctl.html
 net.ipv4.icmp_echo_ignore_all = 1
@@ -54,7 +45,6 @@ net.ipv4.conf.*.arp_ignore = 2
 net.ipv4.conf.all.drop_gratuitous_arp = 1
 
 # https://docs.kernel.org/networking/ip-sysctl.html
-net.ipv4.conf.*.accept_source_route = 0
 net.ipv6.conf.*.accept_source_route = 0
 net.ipv4.tcp_sack=0
 net.ipv4.tcp_dsack=0
@@ -84,9 +74,6 @@ kernel.perf_event_paranoid = 3
 # https://docs.kernel.org/admin-guide/sysctl/kernel.html#kptr-restrict
 kernel.kptr_restrict = 2
 
-# https://docs.kernel.org/admin-guide/sysctl/kernel.html#dmesg-restrict
-kernel.dmesg_restrict = 1
-
 # https://docs.kernel.org/admin-guide/sysctl/kernel.html#oops-limit
 kernel.oops_limit=100
 
@@ -108,20 +95,8 @@ fs.protected_regular = 2
 # https://docs.kernel.org/admin-guide/sysctl/fs.html#protected-fifos
 fs.protected_fifos = 2
 
-# https://docs.kernel.org/admin-guide/sysctl/fs.html#protected-hardlinks
-# Default in Fedora, including for runtime audit
-fs.protected_hardlinks = 1
-
-# https://docs.kernel.org/admin-guide/sysctl/fs.html#protected-symlinks
-# Default in Fedora, including for runtime audit
-fs.protected_symlinks = 1
-
 # https://lkml.org/lkml/2019/4/15/890
 dev.tty.ldisc_autoload = 0
-
-# Restrict userfaultfd to CAP_SYS_PTRACE
-# https://docs.kernel.org/admin-guide/sysctl/vm.html#unprivileged-userfaultfd
-vm.unprivileged_userfaultfd = 0
 
 # Prevent kernel info leaks in console during boot.
 # https://docs.kernel.org/admin-guide/sysctl/kernel.html#printk
@@ -145,13 +120,3 @@ kernel.io_uring_disabled = 2
 # https://docs.kernel.org/admin-guide/sysctl/vm.html#mmap-rnd-bits
 vm.mmap_rnd_bits = 32
 vm.mmap_rnd_compat_bits = 16
-
-# https://docs.kernel.org/admin-guide/sysctl/kernel.html#randomize-va-space
-# Default in Fedora, including for runtime audit
-kernel.randomize_va_space = 2
-
-# https://docs.kernel.org/admin-guide/sysctl/vm.html#mmap-min-addr
-# https://docs.kernel.org/admin-guide/sysctl/vm.html#max-map-count
-# Default in Fedora, including for runtime audit
-vm.mmap_min_addr = 65536
-vm.max_map_count = 1048576


### PR DESCRIPTION
Fresh install on a thinkpad from the latest silverblue image shows these are all set by default, so no need to set them in secureblue