### PR TITLE
fix: improve recipe parsing in build workflows

### DIFF
--- a/.github/workflows/build-one-recipe.yml
+++ b/.github/workflows/build-one-recipe.yml
@@ -57,6 +57,11 @@ jobs:
           sudo rm -f /var/lib/man-db/auto-update
           sudo sed -i 's/^update_initramfs=.*/update_initramfs=no/' /etc/initramfs-tools/update-initramfs.conf
 
+      - name: Install dependencies
+        shell: bash
+        run: |
+          sudo apt install yq
+
       - name: Checkout repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -68,9 +73,9 @@ jobs:
           RECIPE: ${{ inputs.recipe }}
         run: |
           echo "REGISTRY=ghcr.io/secureblue" >> "${GITHUB_ENV}"
-          echo "IMAGE_NAME=$(sed -n 's/^name: //p' "./recipes/${RECIPE}")" >> "${GITHUB_ENV}"
-          echo "BASE_IMAGE=$(sed -n 's/^base-image: //p' "./recipes/${RECIPE}")" >> "${GITHUB_ENV}"
-          echo "BASE_IMAGE_VERSION=$(sed -n 's/^image-version: //p' "./recipes/${RECIPE}")" >> "${GITHUB_ENV}"
+          echo "IMAGE_NAME=$(yq -r '."name"' "./recipes/${RECIPE}")" >> "${GITHUB_ENV}"
+          echo "BASE_IMAGE=$(yq -r '."base-image"' "./recipes/${RECIPE}")" >> "${GITHUB_ENV}"
+          echo "BASE_IMAGE_VERSION=$(yq -r '."image-version"' "./recipes/${RECIPE}")" >> "${GITHUB_ENV}"
 
       - name: Verify base image provenance
         shell: bash

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -47,6 +47,11 @@ jobs:
           sudo rm -f /var/lib/man-db/auto-update
           sudo sed -i 's/^update_initramfs=.*/update_initramfs=no/' /etc/initramfs-tools/update-initramfs.conf
 
+      - name: Install dependencies
+        shell: bash
+        run: |
+          sudo apt install yq
+
       - name: Checkout repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -57,9 +62,9 @@ jobs:
         env:
           RECIPE: ${{ inputs.recipe }}
         run: |
-          echo "IMAGE_NAME=$(sed -n 's/^name: //p' "./recipes/${RECIPE}")" >> "${GITHUB_ENV}"
-          echo "BASE_IMAGE=$(sed -n 's/^base-image: //p' "./recipes/${RECIPE}")" >> "${GITHUB_ENV}"
-          echo "BASE_IMAGE_VERSION=$(sed -n 's/^image-version: //p' "./recipes/${RECIPE}")" >> "${GITHUB_ENV}"
+          echo "IMAGE_NAME=$(yq -r '."name"' "./recipes/${RECIPE}")" >> "${GITHUB_ENV}"
+          echo "BASE_IMAGE=$(yq -r '."base-image"' "./recipes/${RECIPE}")" >> "${GITHUB_ENV}"
+          echo "BASE_IMAGE_VERSION=$(yq -r '."image-version"' "./recipes/${RECIPE}")" >> "${GITHUB_ENV}"
 
       - name: Verify base image provenance
         shell: bash

--- a/recipes/common/common-packages.yml
+++ b/recipes/common/common-packages.yml
@@ -41,7 +41,7 @@ install:
 
     # For use in unprivileged ujust scripts
     - python3-inquirer
-    
+
     # provenance deps
     - crane
     - slsa-verifier

--- a/recipes/common/proprietary-modules.yml
+++ b/recipes/common/proprietary-modules.yml
@@ -23,7 +23,7 @@ modules:
 
     - type: dnf
       source: ghcr.io/blue-build/modules@sha256:50747361c625c0a5afac314f174243ca7d14373dbbdd20e2261c1f9384a632de
-      replace:  
+      replace:
         - from-repo: fedora-multimedia
           skip-unavailable: true
           packages:
@@ -43,7 +43,7 @@ modules:
 
     - type: dnf
       source: ghcr.io/blue-build/modules@sha256:50747361c625c0a5afac314f174243ca7d14373dbbdd20e2261c1f9384a632de
-      replace:  
+      replace:
         - from-repo: fedora-multimedia
           skip-unavailable: true
           packages:

--- a/recipes/common/sericea-modules.yml
+++ b/recipes/common/sericea-modules.yml
@@ -13,7 +13,7 @@
 modules:
   - type: files
     source: ghcr.io/blue-build/modules@sha256:50747361c625c0a5afac314f174243ca7d14373dbbdd20e2261c1f9384a632de
-    files:  
+    files:
       - source: system/sericea
         destination: /
   - type: script

--- a/recipes/general/recipe-cosmic-nvidia.yml
+++ b/recipes/general/recipe-cosmic-nvidia.yml
@@ -16,7 +16,7 @@ description: "Cosmic with nvidia, hardened"
 
 base-image: ghcr.io/secureblue/cosmic-main-hardened
 
-image-version: latest 
+image-version: latest
 
 cosign-version: none
 nushell-version: none


### PR DESCRIPTION
Use `yq` instead of `sed` to extract the image name and base image data from recipe files. This ensures correct parsing of the YAML so the parsed values match what BlueBuild reads from the recipe file, even in the presence of trailing whitespace, quotation marks around the string, or other similar syntax elements allowed by YAML but not handled by the previous parsing method.

Also cleaned up trailing whitespace in recipe files.