### PR TITLE
fix: check for bad selinux file context

### DIFF
--- a/files/scripts/check-selinux-fcontext.sh
+++ b/files/scripts/check-selinux-fcontext.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+if grep -q '^/var/home ' /etc/selinux/targeted/contexts/files/file_contexts.subs_dist; then
+    echo "Bad file context (aliasing /var/home) found in file_contexts.subs_dist."
+    echo "This is a bug that we're still trying to track down."
+    echo "Making build fail to ensure this doesn't silently slip through."
+    exit 1
+fi

--- a/recipes/common/final-modules.yml
+++ b/recipes/common/final-modules.yml
@@ -21,3 +21,4 @@ modules:
         - enable-preset-services.sh
         - removesudo.sh
         - ensuresudoabsent.sh
+        - check-selinux-fcontext.sh


### PR DESCRIPTION
In ostree-based images, the SELinux file context alias `/var/home = /home` needs to be reversed to `/home = /var/home`. This is supposed to be patched in by rpm-ostree at build time, but for unclear reasons this sometimes is failing to take place.

We don't want this bug to silently pass into builds--it messes up file contexts for the whole home directory--so as a stopgap until we debug this further, let's add a script to check for this error and fail the build if it does occur.