### PR TITLE
Run Brave Browser under the trivalent domain

### DIFF
--- a/files/scripts/selinux/trivalent/trivalent.fc
+++ b/files/scripts/selinux/trivalent/trivalent.fc
@@ -2,11 +2,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
+# ---------------------------------------
+# Trivalent
+# ---------------------------------------
 /usr/lib/trivalent/trivalent				--	gen_context(system_u:object_r:trivalent_exec_t,s0)
-
 # TODO: move crashpad handler to its own dom
 /usr/lib/trivalent/chrome_crashpad_handler			--	gen_context(system_u:object_r:trivalent_exec_t,s0)
 /usr/lib/trivalent/trivalent.sh				--	gen_context(system_u:object_r:trivalent_script_exec_t,s0)
 /usr/lib/trivalent/install_filter.sh				--	gen_context(system_u:object_r:trivalent_script_exec_t,s0)
 HOME_DIR/\.cache/trivalent(/.*)?		gen_context(system_u:object_r:trivalent_home_t,s0)
 HOME_DIR/\.config/trivalent(/.*)?	gen_context(system_u:object_r:trivalent_home_t,s0)
+
+# ---------------------------------------
+# Brave
+# ---------------------------------------
+/opt/brave.com/brave/brave				--	gen_context(system_u:object_r:trivalent_exec_t,s0)
+# TODO: move crashpad handler to its own dom
+/opt/brave.com/brave/chrome_crashpad_handler			--	gen_context(system_u:object_r:trivalent_exec_t,s0)
+/opt/brave.com/brave/brave-browser				--	gen_context(system_u:object_r:trivalent_script_exec_t,s0)
+HOME_DIR/\.cache/BraveSoftware(/.*)?		gen_context(system_u:object_r:trivalent_home_t,s0)
+HOME_DIR/\.config/BraveSoftware(/.*)?	gen_context(system_u:object_r:trivalent_home_t,s0)


### PR DESCRIPTION
Adds contexts for Brave Browser to trivalent.fc. This lets Brave run confined under the trivalent domain. It also circumvents the need to allow unprivileged user namespaces for unconfined domains for Brave to run on Secureblue, leading to better overall security and less user friction.