### PR TITLE
fix(ci): pass registry_token to PR builds

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -125,6 +125,7 @@ jobs:
           cli_version: v0.9.27
           recipe: ${{ inputs.recipe }}
           push: false
+          registry_token: ${{ github.token }}
           pr_event_number: ${{ github.event.number }}
           maximize_build_space: true
           squash: true


### PR DESCRIPTION
This seems to be necessary for PR builds with a secureblue base image, i.e. the Nvidia and ZFS PR builds.