### PR TITLE
feat: pkexec wrapper

### DIFF
--- a/files/system/usr/bin/pkexec
+++ b/files/system/usr/bin/pkexec
@@ -1,0 +1,119 @@
+#!/usr/bin/bash
+
+# Copyright 2025 The Secureblue Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+show_help() {
+    /usr/bin/cat <<EOF
+pkexec --version |
+       --help |
+       --disable-internal-agent |
+       [--keep-cwd] [--user username] [PROGRAM] [ARGUMENTS...]
+
+WARNING: This run0 convenience wrapper for pkexec is part of secureblue. \
+Unlike pkexec, the --disable-internal-agent switch is discarded. run0 also \
+inherits the environment, rather than running in a minimal one.
+EOF
+}
+
+keep_cwd=0
+target_user="root"
+
+# Parse arguments.
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help)
+            show_help
+            exit 0
+            ;;
+
+        --version)
+            # Just in case --version output is used to detect pkexec presence.
+            echo "pkexec version 126"
+            echo "wrapper: spoofed pkexec version for compatibility" >&2
+            exit 0
+            ;;
+
+        --disable-internal-agent)
+            # Ignored intentionally.
+            echo "wrapper: ignored option '--disable-internal-agent'" >&2
+            shift
+            ;;
+
+        --keep-cwd)
+            keep_cwd=1
+            shift
+            ;;
+
+        --user)
+            if [[ $# -lt 2 ]]; then
+                echo "option '--user' requires an argument" >&2
+                exit 1
+            fi
+            target_user="$2"
+            shift 2
+            ;;
+
+        --user=*)
+            target_user="${1#--user=}"
+            shift
+            ;;
+
+        --)
+            shift
+            break
+            ;;
+
+        --*)
+            echo "wrapper: unrecognized option '$1'"
+            show_help
+            exit 1
+            ;;
+
+        *)
+            # The first non-option is the program to run.
+            break
+            ;;
+    esac
+done
+
+program=""
+if [[ $# -gt 0 ]]; then
+    program="$1"
+    shift
+fi
+
+# Start building run0 arguments.
+cmd=("/usr/bin/run0" "--background=" "--user=${target_user}")
+
+# pkexec behaviour is to run in target username's homedir unless --keep-cwd is
+# passed, so we find ~target_user and pass it to run0 as --chdir.
+target_user_home=""
+if [[ $keep_cwd -eq 0 ]]; then
+    target_user_home=$(/usr/bin/getent passwd "$target_user" | cut -d: -f6)
+    if [[ -z "$target_user_home" ]]; then
+        echo "wrapper: The home directory of $target_user could not be found. Try --keep-cwd." >&2
+        exit 1
+    fi
+    cmd+=("--chdir=${target_user_home}")
+fi
+
+# If $program is not specified, the default shell will be run.
+[[ -n "$program" ]] && cmd+=("--" "$program")
+cmd+=("$@")
+
+echo "wrapper: running '${cmd[@]}'" >&2
+exec "${cmd[@]}"

--- a/files/system/usr/bin/pkexec
+++ b/files/system/usr/bin/pkexec
@@ -78,7 +78,8 @@ while [[ $# -gt 0 ]]; do
             ;;
 
         --*)
-            echo "wrapper: unrecognized option '$1'"
+            echo "wrapper: unrecognized option '$1'" >&2
+            echo
             show_help
             exit 1
             ;;


### PR DESCRIPTION
I'm not sure whether this kind of thing should be included in secureblue, especially in /usr/bin/.

pkexec is quite simple to emulate, and when it's missing it can be hard to substitute, as it's often baked into GUI apps and takes different CLI arguments to run0.

I can't foresee any weirdness from including it -- at worst, it probably does no harm -- but perhaps it should be behind a `ujust`, or in a separate COPR.

I think there have been 3 or 4 occasions on Discord where this would have been useful; Wavyebuilder proposed making a wrapper, and I've needed one myself twice. This seems to work.