### PR TITLE
fix(ci): update peter-evans/create-pull-request

### DIFF
--- a/.github/workflows/update-modules.yml
+++ b/.github/workflows/update-modules.yml
@@ -63,7 +63,7 @@ jobs:
               -e "/\<source: ghcr.io\/blue-build\/modules@/s/@sha256:.*/@${digest}/" \
               '{}' +
 
-      - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e  # v7.0.8
+      - uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412  # v7.0.9
         with:
           add-paths: |
             recipes/*.yml


### PR DESCRIPTION
This fixes an incompatibility with `actions/checkout@v6` and updates the version used in `update-modules.yml` to match the version used in `update-po.yml`. For release details, see: https://github.com/peter-evans/create-pull-request/releases/tag/v7.0.9