### PR TITLE
fix: prevent dbus access by unbound.service (closes #1697)

### DIFF
--- a/files/system/usr/lib/systemd/system/unbound.service.d/secureblue.conf
+++ b/files/system/usr/lib/systemd/system/unbound.service.d/secureblue.conf
@@ -58,6 +58,7 @@ Group=unbound
 CapabilityBoundingSet=
 ProtectSystem=strict
 ReadWritePaths=/run/unbound /etc/unbound /var/lib/unbound
+InaccessiblePaths=/run/dbus/ /run/user/
 RuntimeDirectory=unbound
 RuntimeDirectoryMode=0775
 RuntimeDirectoryPreserve=yes


### PR DESCRIPTION
This commit makes D-Bus inaccessible to Unbound to prevent sandbox escapes (see #1697). Of the services we have sandboxed so far, I think only `unbound.service` can have its D-Bus access removed, so I think we can close the issue.