### PR TITLE
fix: spelling: XWayland -> Xwayland

### DIFF
--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -430,18 +430,18 @@ install-vpn:
         fi
 
         if [[ "$DE" == "unknown" ]]; then
-            echo 'Warning: Unable to identify your desktop environment. Please manually ensure that XWayland is enabled. Skipping...'
+            echo 'Warning: Unable to identify your desktop environment. Please manually ensure that Xwayland is enabled. Skipping...'
         elif [[ "$xwayland_enabled" == "1" ]]; then
-            echo 'XWayland already enabled, skipping...'
+            echo 'Xwayland already enabled, skipping...'
         else
-            echo 'This VPN requires XWayland to be enabled.'
+            echo 'This VPN requires Xwayland to be enabled.'
             echo 'This will execute "ujust set-xwayland on". You can also manually do this later if you skip this step.'
             echo 'Warning: This is a security reduction!'
             read -rp 'Do you want to do this now? [Y/n] ' proceed_xwayland
             if ! [[ "$proceed_xwayland" == [nN]* ]]; then
-                echo 'Enabling XWayland...'
+                echo 'Enabling Xwayland...'
                 ujust set-xwayland on
-                echo 'Enabled XWayland.'
+                echo 'Enabled Xwayland.'
             fi
         fi
     fi

--- a/files/justfiles/desktop/steam.just
+++ b/files/justfiles/desktop/steam.just
@@ -16,7 +16,7 @@
 install-steam:
     #!/usr/bin/bash
     if [ -z "$(pgrep Xwayland)" ] && [ -z "$(pgrep Xorg)" ] ; then
-        echo "Steam requires X or XWayland, which your variant of secureblue has disabled by default."
+        echo "Steam requires X or Xwayland, which your variant of secureblue has disabled by default."
         echo "Please run 'ujust set-xwayland on' to re-enable it."
         enable_xwayland_now=""
         read -rp "Would you like to run 'ujust set-xwayland on' now? [Y/n] " enable_xwayland_now

--- a/files/justfiles/desktop/xwayland.just
+++ b/files/justfiles/desktop/xwayland.just
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Enable or disable XWayland
+# Enable or disable Xwayland
 [positional-arguments]
 set-xwayland *args:
     #!/bin/sh

--- a/files/po/audit_secureblue.pot
+++ b/files/po/audit_secureblue.pot
@@ -371,7 +371,7 @@ msgstr ""
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:698
 #, python-brace-format
-msgid "XWayland is enabled for {0}."
+msgid "Xwayland is enabled for {0}."
 msgstr ""
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:699

--- a/files/po/de/audit_secureblue.po
+++ b/files/po/de/audit_secureblue.po
@@ -383,8 +383,8 @@ msgstr "Sway"
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:698
 #, python-brace-format
-msgid "XWayland is enabled for {0}."
-msgstr "XWayland ist für {0} aktiviert."
+msgid "Xwayland is enabled for {0}."
+msgstr "Xwayland ist für {0} aktiviert."
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:699
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:798

--- a/files/po/en/audit_secureblue.po
+++ b/files/po/en/audit_secureblue.po
@@ -370,7 +370,7 @@ msgstr ""
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:698
 #, python-brace-format
-msgid "XWayland is enabled for {0}."
+msgid "Xwayland is enabled for {0}."
 msgstr ""
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:699

--- a/files/po/es/audit_secureblue.po
+++ b/files/po/es/audit_secureblue.po
@@ -391,8 +391,8 @@ msgstr "Sway"
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:698
 #, python-brace-format
-msgid "XWayland is enabled for {0}."
-msgstr "XWayland está habilitado para {0}"
+msgid "Xwayland is enabled for {0}."
+msgstr "Xwayland está habilitado para {0}"
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:699
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:798

--- a/files/po/pt/audit_secureblue.po
+++ b/files/po/pt/audit_secureblue.po
@@ -393,8 +393,8 @@ msgstr "Sway"
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:698
 #, python-brace-format
-msgid "XWayland is enabled for {0}."
-msgstr "XWayland está ativado para {0}."
+msgid "Xwayland is enabled for {0}."
+msgstr "Xwayland está ativado para {0}."
 
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:699
 #: files/system/usr/libexec/secureblue/audit_secureblue.py:798

--- a/files/system/desktop/usr/libexec/secureblue/set_xwayland.py
+++ b/files/system/desktop/usr/libexec/secureblue/set_xwayland.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Enable or disable XWayland."""
+"""Enable or disable Xwayland."""
 
 import os
 import subprocess  # nosec
@@ -42,20 +42,20 @@ DE_NAMES: Final[dict[Image, str]] = {
 }
 
 HELP_MESSAGE: Final[str] = """\
-Enable or disable XWayland for the current desktop environment.
+Enable or disable Xwayland for the current desktop environment.
 
 usage:
 ujust set-xwayland
     Enables or disables interactively based on the user's preference.
 
 ujust set-xwayland on
-    Enables XWayland; does nothing if already on.
+    Enables Xwayland; does nothing if already on.
 
 ujust set-xwayland off
-    Disables XWayland; does nothing if already off.
+    Disables Xwayland; does nothing if already off.
 
 ujust set-xwayland status
-    Reports if XWayland is enabled or disabled.
+    Reports if Xwayland is enabled or disabled.
 
 ujust set-xwayland --help
     Prints this message.
@@ -71,7 +71,7 @@ def run(mode: ToggleMode) -> int:
 
     image = Image.from_image_ref(booted_image_ref())
     if image not in XWAYLAND_OVERRIDE_FILES:
-        print("The booted image does not support toggling XWayland.")
+        print("The booted image does not support toggling Xwayland.")
         return 1
 
     override_file = XWAYLAND_OVERRIDE_FILES[image]
@@ -83,12 +83,12 @@ def run(mode: ToggleMode) -> int:
             print("enabled" if enabled else "disabled")
         case ToggleMode.ON:
             if enabled:
-                print(f"XWayland for {de_name} is already enabled.")
+                print(f"Xwayland for {de_name} is already enabled.")
             else:
                 subprocess.run(
                     ["/usr/bin/run0", "/usr/bin/rm", "-f", "--", override_file], check=True
                 )  # nosec
-                print(f"XWayland for {de_name} has been enabled. Reboot to take effect.")
+                print(f"Xwayland for {de_name} has been enabled. Reboot to take effect.")
         case ToggleMode.OFF:
             if enabled:
                 subprocess.run(
@@ -102,9 +102,9 @@ def run(mode: ToggleMode) -> int:
                     ],
                     check=True,
                 )  # nosec
-                print(f"XWayland for {de_name} has been disabled. Reboot to take effect.")
+                print(f"Xwayland for {de_name} has been disabled. Reboot to take effect.")
             else:
-                print(f"XWayland for {de_name} is already disabled.")
+                print(f"Xwayland for {de_name} is already disabled.")
 
     return 0
 
@@ -112,7 +112,7 @@ def run(mode: ToggleMode) -> int:
 def main() -> int:
     """Main script entry point."""
     try:
-        mode = parse_basic_toggle_args(prompt="Would you like XWayland to be enabled?")
+        mode = parse_basic_toggle_args(prompt="Would you like Xwayland to be enabled?")
     except CommandUsageError as e:
         print(f"Usage error: {e}. See usage with --help.")
         return 2

--- a/files/system/kinoite/usr/lib/systemd/user/disable-kde-splash.service
+++ b/files/system/kinoite/usr/lib/systemd/user/disable-kde-splash.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Disable the KDE splash screen as it is broken without XWayland. See https://secureblue.dev/faq#kde-splash-disabled
+Description=Disable the KDE splash screen as it is broken without Xwayland. See https://secureblue.dev/faq#kde-splash-disabled
 Before=dbus-broker.service
 ConditionUser=!@system
 

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -775,12 +775,12 @@ def audit_xwayland(state):
     else:
         status = FAIL
         rec_lines = (
-            _("XWayland is enabled for {0}.").format(de),
+            _("Xwayland is enabled for {0}.").format(de),
             _("To disable it, run:"),
             "$ ujust set-xwayland off",
         )
         rec = "\n".join(rec_lines)
-    yield Report(_("Ensuring {0} is disabled for {1}").format("XWayland", de), status, recs=rec)
+    yield Report(_("Ensuring {0} is disabled for {1}").format("Xwayland", de), status, recs=rec)
 
 
 @audit


### PR DESCRIPTION
The official documentation consistently spells it "Xwayland".