### PR TITLE
Add ujust bios-info

### DIFF
--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -15,6 +15,16 @@
 uid := `id -u`
 shell := `grep :$(id -u): /etc/passwd | cut -d: -f7`
 
+# Show BIOS/UEFI info
+bios-info:
+    #!/usr/bin/bash
+    run0 bash <<'EOF'
+    echo "Manufacturer: $(dmidecode -s baseboard-manufacturer)"
+    echo "Product Name: $(dmidecode -s baseboard-product-name)"
+    echo "Version: $(dmidecode -s bios-version)"
+    echo "Release Date: $(dmidecode -s bios-release-date)"
+    EOF
+
 # Boot into this device's BIOS/UEFI screen
 bios:
     #!/usr/bin/bash


### PR DESCRIPTION
I have a device that requires a dual-boot (or Windows To-Go) to update the firmware, and I wanted to check if it is updated without going through the hassle of booting into the BIOS

### Rationale

Bluefin, Aurora, and Bazzite already has this feature so it would be parity in a sense. Plus I think it might also be useful for other people to just quickly check if fwupd updated their BIOS successfully

Please be kind this is my first PR :P