### PR TITLE
refactor(install-trivalent.sh): Move from dnf4 to dnf5 preserving GPG-checking behaviour

### DIFF
--- a/files/scripts/install-trivalent.sh
+++ b/files/scripts/install-trivalent.sh
@@ -20,8 +20,9 @@ dnf5 install python3-dnf -y
 
 curl -fLsS --retry 5 -o /etc/yum.repos.d/repo.secureblue.dev.secureblue.repo https://repo.secureblue.dev/secureblue.repo
 
-# dnf4 must be used here due to https://github.com/rpm-software-management/dnf5/issues/1985
-dnf4 install --repoid=secureblue --downloadonly --best --downloaddir=. -y trivalent
+# The package signature IS NOT being checked at this stage,
+# see https://github.com/rpm-software-management/dnf5/issues/1985
+dnf5 --best --repo=secureblue download -y trivalent
 
 trivalent_rpms_found=0
 for trivalent_rpm in trivalent-*."${ARCH}".rpm; do
@@ -43,6 +44,7 @@ wget "https://github.com/secureblue/Trivalent/releases/download/${trivalent_vers
 
 slsa-verifier verify-artifact "${trivalent_rpm}" --provenance-path "${provenance_file}" --source-uri github.com/secureblue/Trivalent --source-branch live
 
-dnf install "${trivalent_rpm}" -y
+# Forcing GPG check of a package installed from outside a repository
+dnf5 --setopt=localpkg_gpgcheck=True install "${trivalent_rpm}" -y
 
 sed -i 's/org\.mozilla\.firefox\.desktop/trivalent.desktop/' /usr/share/applications/mimeapps.list

--- a/files/scripts/install-trivalent.sh
+++ b/files/scripts/install-trivalent.sh
@@ -19,6 +19,8 @@ ARCH="$(uname -m)"
 dnf5 install python3-dnf -y
 
 curl -fLsS --retry 5 -o /etc/yum.repos.d/repo.secureblue.dev.secureblue.repo https://repo.secureblue.dev/secureblue.repo
+secureblue_gpg_key_path="$(dnf repo info secureblue --json | jq -r '.[0].gpg_key.[0]')"
+rpmkeys --import "${secureblue_gpg_key_path}"
 
 # The package signature IS NOT being checked at this stage,
 # see https://github.com/rpm-software-management/dnf5/issues/1985


### PR DESCRIPTION
Previously, DNF4 was used instead of DNF5 for downloading the Trivalent package, as DNF4 performs GPG check after download and DNF5 does not. Neither DNF4 nor DNF5 check the signature of a package installed from outside of a repository (by local path or URL) by default. This commit switches to using DNF5 to download the package (without checking the signature at that point), and subsequently forcing a signature check when installing this package from a local file.