### PR TITLE
feat(config): Disable thumbnails in Dolphin by default

### DIFF
--- a/files/system/kinoite/etc/skel/.config/dolphinrc
+++ b/files/system/kinoite/etc/skel/.config/dolphinrc
@@ -1,0 +1,2 @@
+[PreviewSettings]
+Plugins=


### PR DESCRIPTION
As discussed [here](https://secureblue.dev/images#security-recommendation), thumbnail generation may be a source of security vulnerabilities. This commit creates a preset configuration file for Dolphin in `/etc/skel/` so that by default thumbnails are disabled