### PR TITLE
refactor(ujust): Make `create-admin` create a system user

### DIFF
--- a/files/system/usr/libexec/secureblue/inner/admin.py
+++ b/files/system/usr/libexec/secureblue/inner/admin.py
@@ -33,7 +33,9 @@ def main() -> int:
         return 1
 
     new_username: Final[str] = sys.argv[1]
-    result = subprocess.run(["/usr/sbin/useradd", "-G", "wheel", "-r", "-F", new_username], check=False)  # nosec
+    result = subprocess.run(
+        ["/usr/sbin/useradd", "-G", "wheel", "-r", "-F", new_username], check=False
+    )  # nosec
     if result.returncode != 0:
         print("useradd has failed.")
         return 1

--- a/files/system/usr/libexec/secureblue/inner/admin.py
+++ b/files/system/usr/libexec/secureblue/inner/admin.py
@@ -33,7 +33,7 @@ def main() -> int:
         return 1
 
     new_username: Final[str] = sys.argv[1]
-    result = subprocess.run(["/usr/sbin/useradd", "-M", "-G", "wheel", new_username], check=False)  # nosec
+    result = subprocess.run(["/usr/sbin/useradd", "-G", "wheel", "-r", "-F", new_username], check=False)  # nosec
     if result.returncode != 0:
         print("useradd has failed.")
         return 1


### PR DESCRIPTION
Judging by the `-M` option in the original `useradd` invocation, the newly created admin user isn't supposed to ever be logged into, only used for authentication. This commit makes the admin user a system user, so that it doesn't show up on login screens of display managers