### PR TITLE
feat(config): Disable Xwayland eavesdropping in KWin by default

### DIFF
--- a/files/system/kinoite/etc/xdg/kwinrc
+++ b/files/system/kinoite/etc/xdg/kwinrc
@@ -1,0 +1,2 @@
+[Xwayland]
+XwaylandEavesdrops=None


### PR DESCRIPTION
Though Xwayland is disabled in secureblue by default, it can still be enabled with a `ujust`. In KWin, the default setting for Xwayland access to key presses is one of the more relaxed ones. This commit changes the default to the most secure setting. Resolves #797