### PR TITLE
feat(deprecated): Purge some remaining pieces of FUSE2

### DIFF
--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -39,7 +39,12 @@ remove:
   packages:
     - firefox
     - firefox-langpacks
+
+    # FUSE2 is deprecated in favor of FUSE3, but is pre-installed
+    # in the base images for AppImage compatibility
     - fuse
+    - fuse-libs
+
     - passim
     - fedora-chromium-config
 replace:

--- a/recipes/common/kinoite-modules.yml
+++ b/recipes/common/kinoite-modules.yml
@@ -20,7 +20,14 @@ modules:
         - kdeconnectd
         - fedora-chromium-config-kde
         - fedora-flathub-remote
+
+        # Backends of Plasma Vault that have since been dropped,
+        # see https://invent.kde.org/plasma/plasma-vault/-/commit/ba292cce35907707cab41e651fd86b847117ed73,
+        # and also depend on deprecated FUSE2,
+        # but are still installed as recommended dependencies
         - fuse-encfs
+        - cryfs
+
         - krfb
         - krfb-libs
         - plasma-discover-rpm-ostree


### PR DESCRIPTION
According to https://secureblue.dev/faq#appimage, secureblue aims to remove FUSE2 by default, as it is deprecated and unmaintained. This is supported by the removal of `fuse` package during image building. However, some pieces of FUSE2 remained in the built images. This commit purges them.