### PR TITLE
chore: update BlueBuild CLI to v0.9.28

### DIFF
--- a/.github/workflows/build-one-recipe.yml
+++ b/.github/workflows/build-one-recipe.yml
@@ -119,7 +119,7 @@ jobs:
         env:
           KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
         with:
-          cli_version: v0.9.27
+          cli_version: v0.9.28
           recipe: ${{ inputs.recipe }}
           cosign_private_key: ${{ secrets.SIGNING_SECRET }}
           registry_token: ${{ github.token }}

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -119,7 +119,7 @@ jobs:
         env:
           KERNEL_PRIVKEY: ${{ steps.test_keys.outputs.kernel_privkey }}
         with:
-          cli_version: v0.9.27
+          cli_version: v0.9.28
           recipe: ${{ inputs.recipe }}
           push: false
           registry_token: ${{ github.token }}


### PR DESCRIPTION
This version fixes handling of the layer annotations created by build-chunked-oci, which means builds should start taking into account the layer plan from the prior build, improving rechunking effectiveness.

For details, see: https://github.com/blue-build/cli/releases/tag/v0.9.28