### PR TITLE
fix: move mem_encrypt=on to unstable kargs

### DIFF
--- a/files/system/usr/lib/bootc/kargs.d/10-secureblue.toml
+++ b/files/system/usr/lib/bootc/kargs.d/10-secureblue.toml
@@ -15,7 +15,6 @@ kargs = [
   "l1tf=full,force",
   "lockdown=confidentiality",
   "loglevel=0",
-  "mem_encrypt=on",
   "mitigations=auto,nosmt",
   "module.sig_enforce=1",
   "page_alloc.shuffle=1",

--- a/files/system/usr/libexec/secureblue/kargs_hardening_common/__init__.py
+++ b/files/system/usr/libexec/secureblue/kargs_hardening_common/__init__.py
@@ -40,6 +40,7 @@ UNSTABLE_KARGS = [
     "debugfs=off",
     "efi=disable_early_pci_dma",
     "gather_data_sampling=force",
+    "mem_encrypt=on",
     "oops=panic",
 ]
 


### PR DESCRIPTION
There are reports of the kernel argument `mem_encrypt=on` causing boot failures on some AMD hardware, so I think it would be better not to apply this one by default.