### PR TITLE
fix(audit): use clearer emoji for note statuses

### DIFF
--- a/files/system/usr/libexec/secureblue/auditor/__init__.py
+++ b/files/system/usr/libexec/secureblue/auditor/__init__.py
@@ -81,15 +81,15 @@ class Status(enum.Enum):
         """Colored icon associated with status."""
         match self:
             case Status.PASS:
-                icon = "🟢"
+                icon = "✅"
             case Status.INFO:
-                icon = "🔵"
+                icon = "ℹ️"  # noqa: RUF001
             case Status.WARN:
-                icon = "🟡"
+                icon = "⚠️"
             case Status.FAIL:
-                icon = "🔴"
+                icon = "❌"
             case Status.UNKNOWN:
-                icon = "⚪"
+                icon = "❔"
         return icon
 
     def width(self) -> int:


### PR DESCRIPTION
Colored circles are ambiguous and are also less accessible for colorblind users. It's better to use emoji with commonly understood semantics that correspond to the statuses.