### PR TITLE
fix: make provenance verification work in update service

### DIFF
--- a/files/system/usr/libexec/secureblue/verify-provenance.sh
+++ b/files/system/usr/libexec/secureblue/verify-provenance.sh
@@ -5,6 +5,9 @@
 
 set -euo pipefail
 
+# Ensure $HOME is set.
+export HOME=${HOME:-~}
+
 image_ref=$(rpm-ostree status --booted --json | jq -cr '.deployments[0]."container-image-reference"')
 image_ref=${image_ref#*:docker://}
 case "${image_ref}" in


### PR DESCRIPTION
`verify-provenance.sh` was failing in `rpm-ostreed-automatic.service` due to `$HOME` not being set. Fix this by setting `$HOME` inside `verify-provenance.sh` if not already set.