### PR TITLE
chore: remove plasma-browser-integration

### DIFF
--- a/recipes/common/kinoite-modules.yml
+++ b/recipes/common/kinoite-modules.yml
@@ -23,6 +23,7 @@ modules:
         - fuse-encfs
         - krfb
         - krfb-libs
+        - plasma-browser-integration
         - plasma-discover-rpm-ostree
 
         # depends on fedora-flathub-remote


### PR DESCRIPTION
This package provides some components for integrating web browsers more tightly into the KDE Plasma DE, which we don't want as it potentially adds attack surface. The package isn't a dependency of anything that isn't already removed.