### PR TITLE
chore: add PR template asking for risk assessment

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!--
+Thanks for submitting a pull request!
+
+For more information, please review our contributing guidelines:
+https://secureblue.dev/contributing#pull-requests
+-->
+
+<!-- Please summarize the changes made by the PR. -->
+
+### Risk assessment
+
+<!--
+Please briefly assess the potential for these changes to cause breakage.
+In particular:
+* Are there user-facing changes?
+* What would be the worst-case impact if the PR doesn't work as intended?
+* Is there any potential for these changes to cause systems to fail to boot,
+  or otherwise impact core functionality like networking or updates?
+-->


### PR DESCRIPTION
Add a PR template that asks for the contributor to provide a brief risk assessment.

#### Risk assessment

This PR has no user-facing changes; the only impact is on the text seen by contributors submitting PRs to this repo.