### PR TITLE
chore: Update motd and notification to ujust

### DIFF
--- a/files/system/desktop/usr/libexec/secureblue/secureblueoutofdatenotify
+++ b/files/system/desktop/usr/libexec/secureblue/secureblueoutofdatenotify
@@ -14,4 +14,4 @@
 
 set -euo pipefail
 
-notify-send -a 'secureblue' -i 'dialog-warning' 'Your system is out of date' 'Run <i>rpm-ostree upgrade</i> to resolve this issue.' -u critical
+notify-send -a 'secureblue' -i 'dialog-warning' 'Your system is out of date' 'Run <i>ujust update-system</i> to resolve this issue.' -u critical

--- a/files/system/usr/libexec/ublue-motd
+++ b/files/system/usr/libexec/ublue-motd
@@ -52,7 +52,7 @@ elif [ "$IMAGE_TAG" == 'ERROR-IMAGE-TAG-MISSING' ]; then
 elif [ "$IMAGE_TAG" != "latest" ]; then
     TIP="${bold}You are on a specific tag, which is unsupported by secureblue. Rebase to the ${reset}${slight_red} latest ${reset}${bold} tag to ensure you continue to receive updates.${reset}"
 elif [ "$DIFFERENCE" -ge "$WEEK" ]; then
-    TIP="${bold}Your current image is over 1 week old, run ${reset}${slight_red} rpm-ostree upgrade ${reset}${reset}"
+    TIP="${bold}Your current image is over 1 week old, run ${reset}${slight_red} ujust update-system ${reset}${reset}"
 fi
 
 cat << EOF


### PR DESCRIPTION
Point users to `ujust update-system` in the user-motd and out-of-date notifications instead of `rpm-ostree upgrade` so they do not inadvertently skip SLSA verification.

Are there other places that need to be updated?