### PR TITLE
fix: make dangerzone worker non-interactive

### DIFF
--- a/files/system/usr/libexec/secureblue/install_dangerzone.py
+++ b/files/system/usr/libexec/secureblue/install_dangerzone.py
@@ -42,7 +42,6 @@ def main() -> int:
 
     inner_script = sandbox.SandboxedFunction(
         "dangerzone.py",
-        subprocess_interactive=True,
         read_write_paths=[
             "/etc/yum.repos.d/dangerzone.repo",
             "/etc/containers/policy.json",


### PR DESCRIPTION
Removes the unneeded `subprocess_interactive=True` from the dangerzone.py sandboxed function.

It doesn't make much difference, except for removing part of the red `run0` overlay where no user input is expected.