### PR TITLE
fix: unpin kernel

### DIFF
--- a/recipes/common/common-modules.yml
+++ b/recipes/common/common-modules.yml
@@ -19,7 +19,7 @@ modules:
         - httpsmirrors.sh
         - unprotectsudo.sh
         # comment/uncomment the line below to disable/enable kernel pinning
-        - installpinnedkernel.sh
+        # - installpinnedkernel.sh
     - from-file: common/common-packages.yml
     - type: files
       source: ghcr.io/blue-build/modules@sha256:8e92fcaaef385a1728b8d8224296484260b67126ac83f7ed85b4ae3dde4ad19d


### PR DESCRIPTION
This reverts commit 3592e331c6f84ab9e745172ec59f1e68a6591bb6.

Kernel 6.18.5 is stable in Fedora 43: https://bodhi.fedoraproject.org/updates/FEDORA-2026-1118e5854e

6.18.5 contains the fix for https://github.com/coreos/fedora-coreos-tracker/issues/2087