### PR TITLE
fix: missing arguments in ujust set-libvirt-daemons

### DIFF
--- a/files/justfiles/desktop/desktop.just
+++ b/files/justfiles/desktop/desktop.just
@@ -3,7 +3,7 @@
 
 # Toggle libvirt daemons on or off
 [positional-arguments]
-set-libvirt-daemons:
+set-libvirt-daemons *args:
     #!/bin/sh
     exec /usr/bin/python3 /usr/libexec/secureblue/set_libvirt_daemons.py "$@"
 


### PR DESCRIPTION
Need to have `*args` in the ujust signature to properly pass command-line arguments on to the script.