### PR TITLE
fix: add CAP_FOWNER to spice-client-glib-usb-acl-helper

### DIFF
--- a/files/scripts/removesuid.sh
+++ b/files/scripts/removesuid.sh
@@ -82,6 +82,10 @@ set_caps_if_present "cap_dac_read_search,cap_audit_write=ep" "/usr/bin/chage"
 set_caps_if_present "cap_sys_admin=ep" "/usr/bin/fusermount3"
 set_caps_if_present "cap_dac_read_search,cap_audit_write=ep" "/usr/sbin/unix_chkpwd"
 
+# spice-client-glib-usb-acl-helper drops all capabilities except CAP_FOWNER:
+# https://gitlab.freedesktop.org/spice/spice-gtk/-/blob/7a2779182b003ec5e8192dc5186f0b1c3eb8e831/src/spice-client-glib-usb-acl-helper.c#L304
+set_caps_if_present "cap_fowner=ep" "/usr/libexec/spice-gtk-$(uname -m)/spice-client-glib-usb-acl-helper"
+
 # The below capabilities are expected by these QEMU-related executables but do
 # not seem to be needed for ordinary libvirt/QEMU/KVM usage. They are left
 # commented out for reference in case we later determine that the capabilities
@@ -93,7 +97,3 @@ set_caps_if_present "cap_dac_read_search,cap_audit_write=ep" "/usr/sbin/unix_chk
 # qemu-bridge-helper drops all capabilities except CAP_NET_ADMIN:
 # https://gitlab.com/qemu-project/qemu/-/blob/667e1fff878326c35c7f5146072e60a63a9a41c8/qemu-bridge-helper.c#L252
 # set_caps_if_present "cap_net_admin=ep" "/usr/libexec/qemu-bridge-helper"
-
-# spice-client-glib-usb-acl-helper drops all capabilities except CAP_FOWNER:
-# https://gitlab.freedesktop.org/spice/spice-gtk/-/blob/7a2779182b003ec5e8192dc5186f0b1c3eb8e831/src/spice-client-glib-usb-acl-helper.c#L304
-# set_caps_if_present "cap_fowner=ep" "/usr/libexec/spice-gtk-$(uname -m)/spice-client-glib-usb-acl-helper"


### PR DESCRIPTION
The program expects this capability, but it was removed by `removesuid.sh`. This capability seems to be necessary for USB passthrough in some setups. The program uses polkit to authenticate non-root users and uses `CAP_FOWNER` only to write ACLs to USB devices, so it shouldn't be a security issue.