### PR TITLE
feat: remove fedora-testing repo as well in securebluecleanup

### DIFF
--- a/files/system/usr/lib/systemd/system-preset/40-secureblue.preset
+++ b/files/system/usr/lib/systemd/system-preset/40-secureblue.preset
@@ -3,5 +3,6 @@ enable podman-auto-update.timer
 enable rpm-ostreed-automatic.timer
 enable secureblue-unbound-key.service
 
+disable flatpak-add-fedora-repos.service
 disable geoclue.service
 disable systemd-resolved.service

--- a/files/system/usr/libexec/secureblue/securebluecleanup
+++ b/files/system/usr/libexec/secureblue/securebluecleanup
@@ -20,6 +20,8 @@ if command -v flatpak &> /dev/null
 then
     flatpak remote-delete --system --force fedora || true
     flatpak remote-delete --user --force fedora || true
+    flatpak remote-delete --system --force fedora-testing || true
+    flatpak remote-delete --user --force fedora-testing || true
     flatpak remote-delete --system --force flathub || true
     flatpak remote-delete --user --force flathub || true
     flatpak remove --system --noninteractive --all || true


### PR DESCRIPTION
Also adds .sh extension to the script.
Also disables the `flatpak-add-fedora-repos.service` to fix a broken symlink.