### PR TITLE
refactor: clean-up all rpmsave and rpmnew files in removeunusedrepos.sh

### DIFF
--- a/files/scripts/removeunusedrepos.sh
+++ b/files/scripts/removeunusedrepos.sh
@@ -6,14 +6,18 @@
 
 set -oue pipefail
 
-rm -f /etc/yum.repos.d/negativo17-fedora-nvidia.repo
-rm -f /etc/yum.repos.d/eyecantcu-supergfxctl.repo
-rm -f /etc/yum.repos.d/_copr_ublue-os-akmods.repo
+# https://docs.fedoraproject.org/en-US/workstation-working-group/third-party-repos/#_included_software
+
 rm -f /etc/yum.repos.d/_copr:copr.fedorainfracloud.org:phracek:PyCharm.repo
-rm -f /etc/yum.repos.d/google-chrome.repo
-rm -f /etc/yum.repos.d/rpmfusion-nonfree-nvidia-driver.repo
-rm -f /etc/yum.repos.d/rpmfusion-nonfree-steam.repo
-rm -f /etc/yum.repos.d/rpmfusion-nonfree-nvidia-driver.repo.rpmsave
-rm -f /etc/yum.repos.d/rpmfusion-nonfree-steam.repo.rpmsave
+rm -f /etc/yum.repos.d/_copr_ublue-os-akmods.repo
+rm -f /etc/yum.repos.d/eyecantcu-supergfxctl.repo
 rm -f /etc/yum.repos.d/fedora-cisco-openh264.repo
 rm -f /etc/yum.repos.d/fedora-nvidia-580.repo
+rm -f /etc/yum.repos.d/google-chrome.repo
+rm -f /etc/yum.repos.d/negativo17-fedora-nvidia.repo
+rm -f /etc/yum.repos.d/rpmfusion-nonfree-nvidia-driver.repo
+rm -f /etc/yum.repos.d/rpmfusion-nonfree-steam.repo
+
+# Clean-up rpmsave and rpmnew files
+rm -f /etc/yum.repos.d/*.rpmsave
+rm -f /etc/yum.repos.d/*.rpmnew


### PR DESCRIPTION
Also sorts item alphabetically and adds a link to the Fedora docs about 3rd-party software included when you click "Enable Third-Party Software" in a default Fedora install.