### PR TITLE
feat: remove left-over repo files from Kinoite

### DIFF
--- a/recipes/common/kinoite-modules.yml
+++ b/recipes/common/kinoite-modules.yml
@@ -17,6 +17,8 @@ modules:
         - krfb-libs
         - plasma-browser-integration
         - plasma-discover-rpm-ostree
+        - fedora-third-party
+        - fedora-workstation-repositories
 
         # depends on fedora-flathub-remote
         - plasma-welcome-fedora

--- a/recipes/common/kinoite-modules.yml
+++ b/recipes/common/kinoite-modules.yml
@@ -12,16 +12,18 @@ modules:
         - kdeconnectd
         - fedora-chromium-config-kde
         - fedora-flathub-remote
+        - fedora-third-party
         - fuse-encfs
         - krfb
         - krfb-libs
         - plasma-browser-integration
         - plasma-discover-rpm-ostree
-        - fedora-third-party
-        - fedora-workstation-repositories
 
         # depends on fedora-flathub-remote
         - plasma-welcome-fedora
+
+        # depends on fedora-third-party
+        - fedora-workstation-repositories
   - type: files
     source: ghcr.io/blue-build/modules@sha256:8e92fcaaef385a1728b8d8224296484260b67126ac83f7ed85b4ae3dde4ad19d
     files:


### PR DESCRIPTION
Secureblue Kinoite includes the packages `fedora-third-party` and `fedora-workstation-repositories` which only serve for updating purposes for repos we don't use.

Oddly enough, only Kinoite includes those packages.

Removing them to avoid unnecessary files plus a service that is active at all times, called `fedora-third-party-refresh.service`.