### PR TITLE
feat: remove left-over repo files from Kinoite

### DIFF
--- a/files/scripts/removefedorathirdpartyrefreshservice.sh
+++ b/files/scripts/removefedorathirdpartyrefreshservice.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/files/scripts/removefedorathirdpartyrefreshservice.sh
+++ b/files/scripts/removefedorathirdpartyrefreshservice.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+rm -f /usr/lib/systemd/system/fedora-third-party-refresh.service

--- a/files/system/usr/lib/systemd/system-preset/40-secureblue.preset
+++ b/files/system/usr/lib/systemd/system-preset/40-secureblue.preset
@@ -3,5 +3,6 @@ enable podman-auto-update.timer
 enable rpm-ostreed-automatic.timer
 enable secureblue-unbound-key.service
 
+disable fedora-third-party-refresh.service
 disable geoclue.service
 disable systemd-resolved.service

--- a/recipes/common/kinoite-modules.yml
+++ b/recipes/common/kinoite-modules.yml
@@ -12,6 +12,7 @@ modules:
         - kdeconnectd
         - fedora-chromium-config-kde
         - fedora-flathub-remote
+        - fedora-workstation-repositories
         - fuse-encfs
         - krfb
         - krfb-libs

--- a/recipes/common/kinoite-modules.yml
+++ b/recipes/common/kinoite-modules.yml
@@ -34,5 +34,6 @@ modules:
   - type: script
     source: ghcr.io/blue-build/modules@sha256:8e92fcaaef385a1728b8d8224296484260b67126ac83f7ed85b4ae3dde4ad19d
     scripts:
+      - removefedorathirdpartyrefreshservice.sh
       - setdefaultkdewallpapers.sh
       - systemsettings-standard-malloc.sh


### PR DESCRIPTION
Improved version of https://github.com/secureblue/secureblue/pull/1821, which does not cause dependency issues.