### PR TITLE
fix: disable fedora flatpak via systemctl command as well

### DIFF
--- a/files/scripts/removefedoraflatpakremoteservice.sh
+++ b/files/scripts/removefedoraflatpakremoteservice.sh
@@ -4,4 +4,5 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+systemctl disable flatpak-add-fedora-repos.service
 rm -f /usr/lib/systemd/system/flatpak-add-fedora-repos.service


### PR DESCRIPTION
It seems a `systemctl disable` is also necessary, in addition to https://github.com/secureblue/secureblue/commit/15f1b0b63e5b32ede62b40e82290be53c8fd3543, to actually get rid of the broken symlink.