### PR TITLE
fix: nautilus policy for thumbnailing

### DIFF
--- a/files/scripts/selinux/nautilus/nautilus.te
+++ b/files/scripts/selinux/nautilus/nautilus.te
@@ -26,12 +26,10 @@ optional_policy(`
 		type unconfined_t;
 		attribute trivalent_domain;
 		attribute user_home_type;
-		type bin_t;
 		role unconfined_r;
 	')
 
 	nautilus_run(unconfined_t, unconfined_r)
 	nautilus_run(trivalent_domain, unconfined_r)
-	domtrans_pattern(nautilus_t, bin_t, unconfined_t)
 	domtrans_pattern(nautilus_t, user_home_type, unconfined_t)
 ')


### PR DESCRIPTION
Nautilus directly calls `bwrap` for thumbnail sandboxing, whereas Thunar uses glycin via tumblerd, which runs as a separate process. What we need here is a policy to give bwrap a separate domain so that we can re-add this bin_t transition, but this unbreaks thumbnailing for now.