### PR TITLE
chore: remove authselect check from audit script

### DIFF
--- a/.github/workflows/integration_tests/expected-audit-silverblue-main-hardened.txt
+++ b/.github/workflows/integration_tests/expected-audit-silverblue-main-hardened.txt
@@ -3,7 +3,6 @@
 {"name":"audit_signed_image","description":"Ensuring a signed image is in use","status":"fail","notes":[]}
 {"name":"audit_modprobe","description":"Ensuring no modprobe overrides","status":"pass","notes":[]}
 {"name":"audit_ptrace","description":"Ensuring ptrace is forbidden","status":"pass","notes":[]}
-{"name":"audit_authselect","description":"Ensuring no authselect overrides","status":"pass","notes":[]}
 {"name":"audit_container_policy","description":"Analyzing container policy","status":"pass","notes":[]}
 {"name":"audit_unconfined_userns","description":"Ensuring unconfined user namespace creation disallowed","status":"pass","notes":[]}
 {"name":"audit_container_userns","description":"Ensuring container user namespace creation disallowed","status":"pass","notes":[]}

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -224,16 +224,6 @@ def audit_ptrace(state):
 
 
 @audit
-def audit_authselect():
-    """Ensure no authselect overrides have been made."""
-    status = PASS
-    cmp = filecmp.dircmp("/usr/etc/authselect", "/etc/authselect", shallow=False, ignore=[])
-    if cmp.left_only or cmp.right_only or cmp.diff_files or cmp.funny_files:
-        status = FAIL
-    yield Report(_("Ensuring no authselect overrides"), status)
-
-
-@audit
 def audit_container_policy():
     """Check for modifications to container policy."""
     status = PASS


### PR DESCRIPTION
This check is a leftover from when rebasing was the recommended installation method; it no longer serves much purpose, and can even be misleading since it flags certain changes that are entirely reasonable from a security standpoint, such as adding a hardware security key as a second authentication factor.