### PR TITLE
perf: stop disabling TCP SACK on desktop images

### DIFF
--- a/files/system/server/usr/lib/sysctl.d/56-server-hardening.conf
+++ b/files/system/server/usr/lib/sysctl.d/56-server-hardening.conf
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# https://docs.kernel.org/networking/ip-sysctl.html
+# Disabling TCP SACK mitigates certain DoS attacks
+net.ipv4.tcp_sack = 0
+net.ipv4.tcp_dsack = 0

--- a/files/system/usr/lib/sysctl.d/55-hardening.conf
+++ b/files/system/usr/lib/sysctl.d/55-hardening.conf
@@ -48,8 +48,6 @@ net.ipv4.conf.all.drop_gratuitous_arp = 1
 # https://docs.kernel.org/networking/ip-sysctl.html
 net.ipv4.conf.*.accept_source_route = 0
 net.ipv6.conf.*.accept_source_route = 0
-net.ipv4.tcp_sack=0
-net.ipv4.tcp_dsack=0
 
 # Enable ipv6 privacy extension
 # https://docs.kernel.org/networking/ip-sysctl.html


### PR DESCRIPTION
Disabling TCP SACK seems to have a significant negative impact on network performance. The recommendation that was the original motivation for disabling TCP SACK seems to have been largely based on a few CVEs from 2019 whose impact was limited to DoS. The risk of an attacker sending malicious SACK packets to a server to cause a DoS isn't a significant concern for desktop images, so we can limit disabling SACK to server images.