### PR TITLE
chore: clear dnf transaction history from build

### DIFF
--- a/files/scripts/libdnf5-clear-history.sh
+++ b/files/scripts/libdnf5-clear-history.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# dnf transaction history is a source of non-reproducibility between builds.
+# The upstream base images also leave this directory empty.
+# Note: this causes `dnf history list` and similar commands to fail. That isn't
+# a useful command anyway right now, but at some point in the future, if dnf
+# adds support for local layering, we will probably need to remove this.
+find /usr/lib/sysimage/libdnf5 -mindepth 1 -delete

--- a/recipes/common/final-modules.yml
+++ b/recipes/common/final-modules.yml
@@ -15,3 +15,4 @@ modules:
         - removesudo.sh
         - ensuresudoabsent.sh
         - check-selinux-fcontext.sh
+        - libdnf5-clear-history.sh


### PR DESCRIPTION
Erasing the contents of `/usr/lib/sysimage/libdnf5` eliminates a source of non-reproducibility from the build and avoids the layer containing `libdnf5` having to be re-downloaded with every update. This directory is also empty in the upstream base images.