### PR TITLE
feat: Remove XWayland requirement for mullvad

### DIFF
--- a/.github/workflows/justlint.yml
+++ b/.github/workflows/justlint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Lint justfiles
         run: |          
           sudo apt update
-          sudo apt-get install pipx
+          sudo apt install pipx
           pipx install rust-just
           find "./files/justfiles" -type f -name "*.just" | while read -r file; do
             echo "Checking syntax: $file"

--- a/.github/workflows/justlint.yml
+++ b/.github/workflows/justlint.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Lint justfiles
         run: |          
+          sudo apt update
           sudo apt-get install pipx
           pipx install rust-just
           find "./files/justfiles" -type f -name "*.just" | while read -r file; do

--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -233,7 +233,7 @@ install-vpn:
     # supported VPN providers and the security features they need disabled, separated by spaces
     declare -A vpn_providers=(
         ["ivpn"]="gui_needs_unconfined_userns gui_needs_xwayland"
-        ["mullvad"]="gui_needs_unconfined_userns gui_needs_xwayland"
+        ["mullvad"]="gui_needs_unconfined_userns"
         ["proton"]=""
         ["tailscale"]=""
     )


### PR DESCRIPTION
Remove the requirement to enable XWayland in the Justfile to install Mullvad VPN. The UI component of Mullvad has supported Wayland by default for a few months (by virtue of being relatively up to date in its use of Electron), and will use Wayland transparently when XDG_SESSION_TYPE=wayland is in the environment. Anecdotally, I've been using it with XWayland disabled on GNOME with no issues.