### PR TITLE
fix: just-lint: update package data before trying to install pipx

### DIFF
--- a/.github/workflows/justlint.yml
+++ b/.github/workflows/justlint.yml
@@ -31,7 +31,8 @@ jobs:
 
       - name: Lint justfiles
         run: |
-          sudo apt-get install pipx
+          sudo apt update
+          sudo apt install pipx
           pipx install rust-just
           find "./files/justfiles" -type f -name "*.just" | while read -r file; do
             echo "Checking syntax: $file"


### PR DESCRIPTION
This fixes the just-lint workflow, which has been failing due to inability to install pipx. credit @HastD https://github.com/secureblue/secureblue/pull/1859#pullrequestreview-3709000149