### PR TITLE
fix: update dangerzone repo

### DIFF
--- a/files/system/etc/yum.repos.d/dangerzone.repo
+++ b/files/system/etc/yum.repos.d/dangerzone.repo
@@ -1,7 +1,7 @@
 [dangerzone]
 name = Dangerzone repository
 baseurl = https://packages.freedom.press/yum-tools-prod/dangerzone/f$releasever
-gpgkey = https://packages.freedom.press/yum-tools-prod/fpf-yum-tools-archive-keyring.gpg
+gpgkey = https://packages.freedom.press/yum-tools-prod/dangerzone/fpf-yum-tools-archive-keyring.gpg
 gpgcheck = 1
 repo_gpgcheck = 0
 enabled = 0


### PR DESCRIPTION
Dangerzone seems to have moved their GPG keyring and updated their .repo file to point to the new location; the old URL is currently giving HTTP 404.