### PR TITLE
fix: bug where ujust update-system keeps running until the notification clears

### DIFF
--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -45,7 +45,7 @@ update-system:
     /usr/libexec/secureblue/verify-provenance.sh
     /usr/bin/rpm-ostree upgrade
     if [ -f /usr/libexec/secureblue/security-update-notification ]; then
-        /usr/libexec/secureblue/security-update-notification
+        /usr/libexec/secureblue/security-update-notification >/dev/null 2>&1 &
     fi
 
 # Update device firmware


### PR DESCRIPTION
Also suppresses the annoying "warning: Failed to query journal: couldn't find current boot in journal"