### PR TITLE
fix: remove unneeded reboot from luks-enable-tpm2-autounlock.sh

### DIFF
--- a/files/system/usr/libexec/luks-enable-tpm2-autounlock.sh
+++ b/files/system/usr/libexec/luks-enable-tpm2-autounlock.sh
@@ -105,9 +105,8 @@ else
   echo "TPM2 already present in initramfs."
 fi
 
-## Now reboot
 echo
-echo "TPM2 LUKS unlock configured. Reboot now."
+echo "TPM2 LUKS unlock configured."
 
 
 # References:


### PR DESCRIPTION
There's no need to reboot right after setting up TPM LUKS unlock.