### PR TITLE
feat: special-case kernel.printk in sysctl audit

### DIFF
--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -31,6 +31,7 @@ from audit_utils import (
     get_flatpak_permissions,
     get_legend,
     get_width,
+    normalize_sysctl,
     validate_sysctl,
     warn_if_root,
 )
@@ -112,18 +113,28 @@ def audit_sysctl():
         conf = f.readlines()
     sysctl_expected = parse_config(conf)
     status = PASS
-    sysctl_errors = []
+    notes = []
     for sysctl, expected in sysctl_expected.items():
         sysctl_path = f"/proc/sys/{sysctl.replace('.', '/')}"
         for path in glob.iglob(sysctl_path):
             try:
                 with open(path, encoding="utf-8") as f:
-                    actual = f.read().strip()
+                    actual = normalize_sysctl(f.read())
             except PermissionError:
                 continue
+            if sysctl == "kernel.printk" and actual == "15 3 3 3":
+                status = WARN
+                note_lines = [
+                    _("{0} should be {1}, but is actually {2}.").format(sysctl, expected, actual),
+                    _("This is likely due to a kernel fault, as documented in `{0}`.").format(
+                        "man 2 syslog"
+                    ),
+                ]
+                notes.append(Note("\n".join(note_lines), WARN))
+                break
             if not validate_sysctl(sysctl, actual, expected):
                 status = FAIL
-                sysctl_errors.append(
+                notes.append(
                     Note(
                         _("{0} should be {1}, but is actually {2}.").format(
                             sysctl, expected, actual
@@ -132,7 +143,7 @@ def audit_sysctl():
                     )
                 )
                 break
-    yield Report(_("Ensuring no sysctl overrides"), status, notes=sysctl_errors)
+    yield Report(_("Ensuring no sysctl overrides"), status, notes=notes)
 
 
 @audit

--- a/files/system/usr/libexec/secureblue/audit_utils/__init__.py
+++ b/files/system/usr/libexec/secureblue/audit_utils/__init__.py
@@ -125,12 +125,15 @@ async def get_flatpak_permissions(name: str, version: str) -> str:
     return await async_command_stdout("flatpak", "info", "--show-permissions", name, version)
 
 
+def normalize_sysctl(sysctl: str) -> str:
+    """Normalize a sysctl value."""
+    result = re.sub(r"\s+", " ", sysctl.strip())
+    replacements = {"disabled": "0", "enabled": "1"}
+    return replacements.get(result, result)
+
+
 def validate_sysctl(sysctl: str, actual: str, expected: str) -> bool:
     """Validate a sysctl value against an expected value."""
-    actual = re.sub(r"\s+", " ", actual.strip())
-    replace = {"disabled": "0", "enabled": "1"}.get(actual)
-    if replace is not None:
-        actual = replace
     if sysctl == "kernel.sysrq":
         # Both 0 and 4 are secure values for this setting. For details, see:
         # https://www.kernel.org/doc/html/latest/admin-guide/sysrq.html


### PR DESCRIPTION
Under certain error conditions, the kernel will automatically increase the console log level. This results in the `kernel.printk` sysctl being set to `15 3 3 3` even if it was previously set to the expected value of `3 3 3 3`.