### PR TITLE
feat: add Bazaar app store

### DIFF
--- a/files/gschema-overrides/zz1-secureblue.gschema.override
+++ b/files/gschema-overrides/zz1-secureblue.gschema.override
@@ -5,10 +5,9 @@
 # Disable GNOME user extensions installation & usage
 # Only GNOME system extensions are trusted if installed
 
-# Switch from Warehouse to Bazaar once it's ready
 [org.gnome.shell]
 allow-extension-installation=false
-favorite-apps = ['trivalent.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Ptyxis.desktop', 'com.github.tchx84.Flatseal.desktop', 'io.github.flattool.Warehouse.desktop']
+favorite-apps = ['trivalent.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Ptyxis.desktop', 'com.github.tchx84.Flatseal.desktop', 'io.github.kolunmi.Bazaar.desktop']
 enabled-extensions = []
 
 [org.gnome.desktop.interface]

--- a/files/justfiles/desktop/flatpak.just
+++ b/files/justfiles/desktop/flatpak.just
@@ -31,11 +31,10 @@ flatpak-permissions-lockdown:
     kKnownSessionBusNames=("org.xfce.ScreenSaver" "org.mate.ScreenSaver" "org.cinnamon.ScreenSaver" "org.gnome.ScreenSaver" "org.kde.kwalletd6" "org.gnome.Mutter.IdleMonitor.*" "org.gnome.ControlCenter" "org.gnome.Settings" "org.gnome.SettingsDaemon.MediaKeys" "org.gnome.SessionManager" "org.gnome.Shell.Screenshot" "org.kde.kiod5" "org.kde.kwin.Screenshot" "org.kde.JobViewServer" "org.gtk.vfs.*" "org.freedesktop.secrets" "org.kde.kconfig.notify" "org.kde.kpasswdserver" "org.kde.*" "org.kde.StatusNotifierWatcher" "org.kde.kded6" "org.kde.kpasswdserver6" "org.kde.kiod6" "com.canonical.Unity" "org.freedesktop.Notifications" "org.freedesktop.FileManager1" "org.freedesktop.impl.portal.PermissionStore" "org.freedesktop.Flatpak" "com.canonical.AppMenu.Registrar" "org.kde.KGlobalSettings" "org.kde.kded5" "com.canonical.Unity.LauncherEntry" "org.kde.kwalletd5" "org.gnome.SettingsDaemon" "org.a11y.Bus" "com.canonical.indicator.application" "org.freedesktop.ScreenSaver" "ca.desrt.dconf" "org.freedesktop.PowerManagement" "org.gnome.Software" "org.freedesktop.Tracker3.Writeback" "io.missioncenter.MissionCenter.Gatherer")
     kKnownSystemBusNames=("org.bluez" "org.freedesktop.home1" "org.freedesktop.hostname1" "org.freedesktop.import1" "org.freedesktop.locale1" "org.freedesktop.LogControl1" "org.freedesktop.machine1" "org.freedesktop.network1" "org.freedesktop.oom1" "org.freedesktop.portable1" "org.freedesktop.resolve1" "org.freedesktop.sysupdate1" "org.freedesktop.timesync1" "org.freedesktop.timedate1" "org.freedesktop.systemd1" "org.freedesktop.Avahi" "org.freedesktop.Avahi.*" "org.freedesktop.login1" "org.freedesktop.NetworkManager" "org.freedesktop.UPower" "org.freedesktop.UDisks2" "org.freedesktop.fwupd")
     kFlatsealNameAccess=("org.gnome.Software" "org.freedesktop.impl.portal.PermissionStore")
-    kWarehouseNameAccess=("org.freedesktop.Flatpak")
     confirmation=""
 
     echo "This will configure flatpak to automatically reject most permissions (with the exception of the Wayland socket and the Dri device, since these are commonly used and ensure at the very least most apps will work without crashing)."
-    echo "This will also grant Flatseal and Warehouse access to certain permissions to allow them to operate and make reconfiguring much easier."
+    echo "This will also grant Flatseal access to certain permissions to allow them to operate and make reconfiguring much easier."
     echo "NOTE: This will break just about all Flatpaks by default, it is ON YOU to configure them to work with this configuration."
     echo "NOTE 2: This DOES NOT enable hardened_malloc, use the harden-flatpak ujust command."
     echo ""
@@ -106,12 +105,6 @@ flatpak-permissions-lockdown:
         for i in "${kFlatsealNameAccess[@]}"; do
             echo "	Granting $i..."
             $kCommand --talk-name="$i" com.github.tchx84.Flatseal
-        done
-        echo ""
-        echo "-- Granting Warehouse Access to Bus Names --"
-        for i in "${kWarehouseNameAccess[@]}"; do
-            echo "	Granting $i..."
-            $kCommand --talk-name="$i" io.github.flattool.Warehouse
         done
         echo ""
         echo "Done"

--- a/files/scripts/removekrunnerappstream.sh
+++ b/files/scripts/removekrunnerappstream.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+rm -f /usr/lib64/qt6/plugins/kf6/krunner/krunner_appstream.so

--- a/files/scripts/selinux/flatpakfull/flatpakfull.fc
+++ b/files/scripts/selinux/flatpakfull/flatpakfull.fc
@@ -10,3 +10,4 @@
 /usr/libexec/flatpak-session-helper	--	gen_context(system_u:object_r:flatpak_exec_t,s0)
 /usr/libexec/flatpak-validate-icon	--	gen_context(system_u:object_r:flatpak_exec_t,s0)
 /usr/libexec/revokefs-fuse	--	gen_context(system_u:object_r:flatpak_exec_t,s0)
+/usr/bin/bazaar  --  gen_context(system_u:object_r:flatpak_exec_t,s0)

--- a/files/scripts/selinux/flatpakfull/flatpakfull.if
+++ b/files/scripts/selinux/flatpakfull/flatpakfull.if
@@ -41,7 +41,7 @@ interface(`flatpak_domtrans',`
 interface(`flatpak_run',`
 	gen_require(`
 		type flatpak_t;
-        attribute_role flatpak_roles;
+		attribute_role flatpak_roles;
 	')
 
 	flatpak_domtrans($1)

--- a/files/scripts/selinux/nautilus/nautilus.if
+++ b/files/scripts/selinux/nautilus/nautilus.if
@@ -42,7 +42,7 @@ interface(`nautilus_domtrans',`
 interface(`nautilus_run',`
 	gen_require(`
 		type nautilus_t;
-        attribute_role nautilus_roles;
+		attribute_role nautilus_roles;
 	')
 
 	nautilus_domtrans($1)

--- a/files/scripts/selinux/thunar/thunar.if
+++ b/files/scripts/selinux/thunar/thunar.if
@@ -42,7 +42,7 @@ interface(`thunar_domtrans',`
 interface(`thunar_run',`
 	gen_require(`
 		type thunar_t;
-        attribute_role thunar_roles;
+		attribute_role thunar_roles;
 	')
 
 	thunar_domtrans($1)

--- a/files/scripts/selinux/trivalent/trivalent.te
+++ b/files/scripts/selinux/trivalent/trivalent.te
@@ -346,6 +346,16 @@ optional_policy(`
 
 optional_policy(`
 	gen_require(`
+		type flatpak_t;
+    type unconfined_trivalent_script_t;
+	')
+
+	domtrans_pattern(flatpak_t, trivalent_script_exec_t, unconfined_trivalent_script_t)
+')
+
+
+optional_policy(`
+	gen_require(`
 		type sysadm_t;
 		role sysadm_r;
 	')

--- a/files/system/desktop/usr/lib/systemd/user-preset/35-secureblue-desktop.preset
+++ b/files/system/desktop/usr/lib/systemd/user-preset/35-secureblue-desktop.preset
@@ -1,5 +1,4 @@
 enable flatpak-user-update.timer
-enable io.github.kolunmi.Bazaar.service
 enable secureblue-firmware-check.timer
 enable secureblue-flatpak-setup.timer
 enable secureblue-key-enrollment-verification.timer

--- a/files/system/desktop/usr/lib/systemd/user-preset/35-secureblue-desktop.preset
+++ b/files/system/desktop/usr/lib/systemd/user-preset/35-secureblue-desktop.preset
@@ -1,4 +1,6 @@
 enable flatpak-user-update.timer
+enable io.github.kolunmi.Bazaar.service
+enable secureblue-firmware-check.timer
 enable secureblue-flatpak-setup.timer
 enable secureblue-key-enrollment-verification.timer
 enable secureblue-update-verification.timer

--- a/files/system/desktop/usr/lib/systemd/user/secureblue-firmware-check.service
+++ b/files/system/desktop/usr/lib/systemd/user/secureblue-firmware-check.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=secureblue Firmware Update Notifications
+Wants=graphical-session.target
+After=graphical-session.target
+ConditionUser=!@system
+ConditionPathIsDirectory=/var/home/%u
+
+[Service]
+Type=simple
+ExecCondition=/usr/libexec/secureblue/firmwarecheckoutofdate
+ExecStart=/usr/libexec/secureblue/firmwareoutofdatenotify

--- a/files/system/desktop/usr/lib/systemd/user/secureblue-firmware-check.timer
+++ b/files/system/desktop/usr/lib/systemd/user/secureblue-firmware-check.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=secureblue Firmware Update Checks
+ConditionUser=!@system
+
+[Timer]
+RandomizedDelaySec=1m
+OnStartupSec=2m
+OnUnitActiveSec=1d
+
+[Install]
+WantedBy=timers.target

--- a/files/system/desktop/usr/libexec/secureblue/firmwarecheckoutofdate
+++ b/files/system/desktop/usr/libexec/secureblue/firmwarecheckoutofdate
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+fwupdmgr get-updates --json | jq -e '.Devices != []' > /dev/null

--- a/files/system/desktop/usr/libexec/secureblue/firmwareoutofdatenotify
+++ b/files/system/desktop/usr/libexec/secureblue/firmwareoutofdatenotify
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+/usr/bin/notify-send -a secureblue -i dialog-warning -u critical "A firmware update is available." "Run <i>ujust update-firmware</i> to resolve this issue."

--- a/files/system/desktop/usr/libexec/secureblue/secureblueflatpaksetup
+++ b/files/system/desktop/usr/libexec/secureblue/secureblueflatpaksetup
@@ -21,9 +21,5 @@ if [[ "$IMAGE_REF_NAME" != *"kinoite"* ]]; then
     flatpak install --user -y --noninteractive flathub-verified com.github.tchx84.Flatseal
 fi
 
-if [[ "$IMAGE_REF_NAME" == *"silverblue"* ]]; then
-    flatpak install --user -y --noninteractive flathub-verified io.github.flattool.Warehouse
-fi
-
 notify-send -a 'secureblue' -i 'dialog-information' -u normal 'Flatpak provisioning completed.'
 rm -f "$in_progress_indicator"

--- a/files/system/desktop/usr/share/bazaar/blocklist.yaml
+++ b/files/system/desktop/usr/share/bazaar/blocklist.yaml
@@ -3,15 +3,16 @@ blocklists:
     block:
       # Verified Chromium-based browsers.
       - com.brave.Browser
+      - io.github.ungoogled_software.ungoogled_chromium
       - org.kde.falkon
       - ru.yandex.Browser
-      - io.github.ungoogled_software.ungoogled_chromium
 
       # Unverified Chromium-based browsers.
       - com.google.Chrome
       - com.google.ChromeDev
       - com.microsoft.Edge
       - com.opera.Opera
+      - com.vivaldi.Vivaldi
       - org.chromium.Chromium
 
       # Verified Firefox-based browsers.
@@ -24,20 +25,21 @@ blocklists:
       - org.torproject.torbrowser-launcher
 
       # Unverified Firefox-based browsers.
-      - net.mullvad.MullvadBrowser
       - com.humatarayici.od
+      - net.mullvad.MullvadBrowser
 
       # Other browsers.
       ## org.gnome.Epiphany uses WebKitGTK and flatpak-spawn for process-level sandboxing.
       ## Nyxt seems to use WebKitGTK, but without clear sandboxing.
       - engineer.atlas.Nyxt
-      - org.netsurf_browser.NetSurf
       - org.catacombing.kumo
+      - org.netsurf_browser.NetSurf
+
+      # Other apps.
+      ## We ship the RPM.
+      - io.github.kolunmi.Bazaar
       # Uses an internal browser
       - net.codelogistics.webapps
       # Appears to only support flatpaked browsers
       - org.pvermeer.WebAppHub
 
-      # Other apps.
-      ## We ship the RPM.
-      - io.github.kolunmi.Bazaar

--- a/files/system/desktop/usr/share/bazaar/blocklist.yaml
+++ b/files/system/desktop/usr/share/bazaar/blocklist.yaml
@@ -1,0 +1,43 @@
+blocklists:
+  - priority: 0
+    block:
+      # Verified Chromium-based browsers.
+      - com.brave.Browser
+      - org.kde.falkon
+      - ru.yandex.Browser
+      - io.github.ungoogled_software.ungoogled_chromium
+
+      # Unverified Chromium-based browsers.
+      - com.google.Chrome
+      - com.google.ChromeDev
+      - com.microsoft.Edge
+      - com.opera.Opera
+      - org.chromium.Chromium
+
+      # Verified Firefox-based browsers.
+      - app.zen_browser.zen
+      - io.gitlab.librewolf-community
+      - net.waterfox.waterfox
+      - one.ablaze.floorp
+      - org.garudalinux.firedragon
+      - org.mozilla.firefox
+      - org.torproject.torbrowser-launcher
+
+      # Unverified Firefox-based browsers.
+      - net.mullvad.MullvadBrowser
+      - com.humatarayici.od
+
+      # Other browsers.
+      ## org.gnome.Epiphany uses WebKitGTK and flatpak-spawn for process-level sandboxing.
+      ## Nyxt seems to use WebKitGTK, but without clear sandboxing.
+      - engineer.atlas.Nyxt
+      - org.netsurf_browser.NetSurf
+      - org.catacombing.kumo
+      # Uses an internal browser
+      - net.codelogistics.webapps
+      # Appears to only support flatpaked browsers
+      - org.pvermeer.WebAppHub
+
+      # Other apps.
+      ## We ship the RPM.
+      - io.github.kolunmi.Bazaar

--- a/files/system/desktop/usr/share/bazaar/curated.yaml
+++ b/files/system/desktop/usr/share/bazaar/curated.yaml
@@ -1,0 +1,43 @@
+css: |
+  .main banner {
+    background: linear-gradient(45deg, #754e7680, #3bc5f580);
+    box-shadow: 3px 3px 10px rgba(0, 0, 0, 0.2);
+    margin: 25px 25px 0px 25px;
+  }
+  .main banner-text {
+    padding: 50px 50px 25px 50px;
+    font-size: 60%;
+  }
+  .main subtitle {
+    font-weight: normal;
+  }
+
+rows:
+  - sections:
+    - expand-horizontally: true
+      category:
+        title: "Suggested by secureblue"
+        subtitle: "These apps provide security functionality or are well-maintained applications that provide common functionality."
+        # This is static in pixels, but there seems to be no way to change that yet.
+        banner-height: 250
+        # see https://docs.gtk.org/gtk4/enum.Align.html
+        banner-text-halign: start
+        banner-text-valign: center
+        # see https://docs.gtk.org/gtk4/property.Label.xalign.html
+        banner-text-label-xalign: 0.0
+        appids:
+          - org.gnome.Firmware
+          - org.fedoraproject.MediaWriter
+          - com.github.tchx84.Flatseal
+          - org.kde.kleopatra
+          - org.gnome.Loupe
+          - io.github.diegopvlk.Cine
+          - org.kde.haruna
+          - io.github.mpobaschnig.Vaults
+          - io.github.mhogomchungu.sirikali
+          - org.gnome.World.PikaBackup
+          - io.github.vmkspv.lenspect
+          - org.keepassxc.KeePassXC
+          - io.github.flattool.Ignition
+      classes:
+        - main

--- a/files/system/desktop/usr/share/bazaar/main.yaml
+++ b/files/system/desktop/usr/share/bazaar/main.yaml
@@ -1,0 +1,4 @@
+yaml-blocklist-paths:
+  - /usr/share/bazaar/blocklist.yaml
+curated-config-paths:
+  - /usr/share/bazaar/curated.yaml

--- a/files/system/usr/lib/systemd/system-preset/40-secureblue.preset
+++ b/files/system/usr/lib/systemd/system-preset/40-secureblue.preset
@@ -1,4 +1,5 @@
 enable dnsconfd.service
+enable fwupd-refresh.timer
 enable podman-auto-update.timer
 enable rpm-ostreed-automatic.timer
 enable secureblue-unbound-key.service

--- a/files/system/usr/libexec/secureblue/audit_flatpak/__init__.py
+++ b/files/system/usr/libexec/secureblue/audit_flatpak/__init__.py
@@ -216,7 +216,6 @@ FLATPAK_PERMISSION_CHECKS: list[PermissionCheck] = [
 
 ARBITRARY_PERMISSIONS_EXPECTED: list[str] = [
     "com.github.tchx84.Flatseal",
-    "io.github.flattool.Warehouse",
     "io.github.kolunmi.Bazaar",
 ]
 

--- a/recipes/common/cosmic-modules.yml
+++ b/recipes/common/cosmic-modules.yml
@@ -10,7 +10,6 @@ modules:
         packages:
           - NetworkManager-tui
           - NetworkManager-openvpn
-          - cosmic-store
           - cosmic-player
       remove:
         packages:

--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -18,6 +18,7 @@ install:
     - wl-clipboard
     - alsa-firmware
     - fzf
+    - bazaar
     - homebrew
 
     # yubikey enablement

--- a/recipes/common/kinoite-modules.yml
+++ b/recipes/common/kinoite-modules.yml
@@ -12,14 +12,21 @@ modules:
         - kdeconnectd
         - fedora-chromium-config-kde
         - fedora-flathub-remote
+        # depends on fedora-flathub-remote
+        - plasma-welcome-fedora
         - fuse-encfs
         - krfb
         - krfb-libs
         - plasma-browser-integration
-        - plasma-discover-rpm-ostree
-
-        # depends on fedora-flathub-remote
-        - plasma-welcome-fedora
+        - plasma-discover
+        - fedora-workstation-repositories
+        - fedora-third-party
+  - type: dnf
+    source: ghcr.io/blue-build/modules@sha256:8e92fcaaef385a1728b8d8224296484260b67126ac83f7ed85b4ae3dde4ad19d
+    install:
+      install-weak-deps: false
+      packages:
+        - krunner-bazaar
   - type: files
     source: ghcr.io/blue-build/modules@sha256:8e92fcaaef385a1728b8d8224296484260b67126ac83f7ed85b4ae3dde4ad19d
     files:
@@ -35,3 +42,4 @@ modules:
     scripts:
       - setdefaultkdewallpapers.sh
       - systemsettings-standard-malloc.sh
+      - removekrunnerappstream.sh

--- a/recipes/common/silverblue-modules.yml
+++ b/recipes/common/silverblue-modules.yml
@@ -26,7 +26,8 @@ modules:
           - gnome-remote-desktop
           - libvncserver
           - fedora-chromium-config-gnome
-          - gnome-software-rpm-ostree
+          - gnome-software
+          - epiphany-runtime
           - totem-video-thumbnailer
           - fedora-flathub-remote
           - fedora-third-party


### PR DESCRIPTION
**Changelog**
- Add bazaar to desktop builds
- Add krunner-bazaar to KDE builds
- Add curated page to Bazaar
- Blocklist all browsers from Flathub except for GNOME Web
- Remove gnome-software and plasma-discover
- Add firmware update reminders
- Patch Bazaar to properly support flathub-verified remote without flathub
- Allow user namespaces for Bazaar with flatpakfull SELinux policy

**Infrastructure**
- RPMs built from https://github.com/secureblue/bazaar-rpm