### PR TITLE
fix: make dependency installation work with ubuntu-slim

### DIFF
--- a/.github/workflows/update-modules.yml
+++ b/.github/workflows/update-modules.yml
@@ -22,17 +22,10 @@ jobs:
       pull-requests: write  # needed to create pull request
 
     steps:
-      - name: Optimize build times
-        shell: bash
-        run: |
-          echo 'set man-db/auto-update false' | sudo debconf-communicate
-          sudo dpkg-reconfigure man-db
-          sudo rm -f /var/lib/man-db/auto-update
-          sudo sed -i -e 's/^update_initramfs=.*/update_initramfs=no/' /etc/initramfs-tools/update-initramfs.conf
-
       - name: Install dependencies
         shell: bash
         run: |
+          sudo apt update
           sudo apt install jq skopeo
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/update-po.yml
+++ b/.github/workflows/update-po.yml
@@ -22,18 +22,11 @@ jobs:
       pull-requests: write  # needed to create pull request
 
     steps:
-      - name: Optimize build times
-        shell: bash
-        run: |
-          echo 'set man-db/auto-update false' | sudo debconf-communicate
-          sudo dpkg-reconfigure man-db
-          sudo rm -f /var/lib/man-db/auto-update
-          sudo sed -i 's/^update_initramfs=.*/update_initramfs=no/' /etc/initramfs-tools/update-initramfs.conf
-
       - name: Install gettext
         shell: bash
         run: |
-          sudo apt-get install gettext
+          sudo apt update
+          sudo apt install gettext
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:


### PR DESCRIPTION
The ubuntu-slim runners don't need to disable man-db or initramfs updates, but do need to run `sudo apt update` before installing packages.