### PR TITLE
fix: adjust install-vpn messages for clarity and default no to gui

### DIFF
--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -341,7 +341,7 @@ install-vpn:
     echo
 
     echo 'NOTE: You can also install wireguard profiles from your provider directly into your DE, if you prefer.'
-    read -rp 'Do you want to continue? [y/N] ' proceed
+    read -rp 'Do you want to continue with installing a VPN app anyway? [y/N] ' proceed
     if ! [[ "$proceed" == [yY]* ]]; then
         echo 'Aborting...'
         exit 0
@@ -355,14 +355,14 @@ install-vpn:
     needs_gui="1"
     if [[ "$vpn_requirements" =~ "gui_needs_" ]]; then
         echo
-        echo 'Notice: This VPN requires additional security features to be disabled if you intend to use its graphical interface.'
+        echo 'Notice: This VPN requires additional security features to be disabled in order to use its graphical interface.'
         echo 'If you only intend on using the command-line interface, you can skip those.'
-        read -rp 'Do you intend to use the GUI? [Y/n] ' proceed_gui
-        if [[ "$proceed_gui" == [nN]* ]]; then
-            echo 'Additional hardening features required for the GUI will not be disabled.'
-            needs_gui="0"
+        read -rp 'Do you intend to use the GUI? [y/N] ' proceed_gui
+        if [[ "$proceed_gui" == [yY]* ]]; then
+            echo 'Additional hardening features that break the GUI will be disabled.'
         else
-            echo 'Additional hardening features required for the GUI will be disabled.'
+            echo 'Additional hardening features that break the GUI will not be disabled.'
+            needs_gui="0"
         fi
     fi
 

--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -359,9 +359,9 @@ install-vpn:
         echo 'You can instead use the VPN app's command-line interface, which does not require disabling hardening.'
         read -rp 'Do you intend to use the graphical interface? [y/N] ' proceed_gui
         if [[ "$proceed_gui" == [yY]* ]]; then
-            echo 'Additional hardening features that break the GUI will be disabled.'
+            echo 'Additional hardening features that break the graphical interface will be disabled.'
         else
-            echo 'Additional hardening features that break the GUI will not be disabled.'
+            echo 'Additional hardening features that break the graphical interface will not be disabled.'
             needs_gui="0"
         fi
     fi

--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -356,8 +356,8 @@ install-vpn:
     if [[ "$vpn_requirements" =~ "gui_needs_" ]]; then
         echo
         echo 'Notice: This VPN requires additional security features to be disabled in order to use its graphical interface.'
-        echo 'If you only intend on using the command-line interface, you can skip those.'
-        read -rp 'Do you intend to use the GUI? [y/N] ' proceed_gui
+        echo 'You can instead use the VPN app's command-line interface, which does not require disabling hardening.'
+        read -rp 'Do you intend to use the graphical interface? [y/N] ' proceed_gui
         if [[ "$proceed_gui" == [yY]* ]]; then
             echo 'Additional hardening features that break the GUI will be disabled.'
         else


### PR DESCRIPTION
This PR sets the question about disabling hardening for VPN app GUIs to default to no.

This PR also tweaks the text in messages to convey their meaning more clearly.

#1907 