### PR TITLE
feat: Add Thunderbird and Betterbird to the Bazaar blocklist

### DIFF
--- a/files/system/desktop/usr/share/bazaar/blocklist.yaml
+++ b/files/system/desktop/usr/share/bazaar/blocklist.yaml
@@ -38,8 +38,12 @@ blocklists:
       # Other apps.
       ## We ship the RPM.
       - io.github.kolunmi.Bazaar
-      # Uses an internal browser
+      ## Uses an internal browser.
       - net.codelogistics.webapps
-      # Appears to only support flatpaked browsers
+      ## Appears to only support flatpaked browsers.
       - org.pvermeer.WebAppHub
+      ## These apps were meant to be email clients, but they can also work as web browsers.
+      - org.mozilla.Thunderbird
+      - eu.betterbird.Betterbird
+      
 


### PR DESCRIPTION
Thunderbird and Betterbird are gecko-based email clients and although their main purpose is to function as email clients, they can also be used as web browsers. So I think it would be better to block them from appearing in Bazaar.