### PR TITLE
fix: set LANG to ensure msginit works properly in update_po.py

### DIFF
--- a/files/po/update_po.py
+++ b/files/po/update_po.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Run this script to update POT and PO files to reflect source code changes.
 """
@@ -40,6 +44,10 @@ os.chdir(git_root)
 
 with open(SOURCE_FILES_PATH, encoding="utf8") as f:
     domain_map = json.load(f)
+
+# This is the locale used for translatable strings in the repo.
+# `msginit` requires this to be set to work properly.
+os.environ["LANG"] = "en_US.UTF-8"
 
 for domain, source_files in domain_map.items():
     pot_path = f"files/po/{domain}.pot"

--- a/files/scripts/localization.sh
+++ b/files/scripts/localization.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 
 cd ../po
 for po_file in */*.po; do
-    lang_code=$(dirname -- "$po_file")
-    mo_filename=$(basename -- "$po_file" | sed 's/\.po$/.mo/')
-    msgfmt -o /usr/share/locale/"$lang_code"/LC_MESSAGES/"$mo_filename" -- "$po_file"
+    lang_code="${po_file%/*}"
+    po_filename="${po_file##*/}"
+    mo_filename="${po_filename%.po}.mo"
+    msgfmt -o "/usr/share/locale/${lang_code}/LC_MESSAGES/${mo_filename}" -- "${po_file}"
 done


### PR DESCRIPTION
Since `msginit` is used to generate the PO file for the `en_US` locale (which is the locale used for translatable strings in the source code), the `LANG` environment variable should be set to the same locale.

Also use shell built-ins to avoid unnecessary external command calls in `localization.sh`.