### PR TITLE
chore: update ujust set-brew to use tmpfiles.d config

### DIFF
--- a/files/system/desktop/etc/tmpfiles.d/homebrew.conf
+++ b/files/system/desktop/etc/tmpfiles.d/homebrew.conf
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This file is intentionally empty.
+#
+# It is here to override /usr/lib/tmpfiles.d/homebrew.conf to prevent
+# the Homebrew installation from being recreated for users who have
+# already opted out of Homebrew.
+#
+# For users who have not opted out of installing Homebrew, this file
+# will be automatically deleted by brew-setup-migration.service.
+#
+# This file can be removed from the secureblue images after enough time
+# has passed that users should all be migrated to the new Homebrew setup
+# method based on tmpfiles.d.

--- a/files/system/desktop/usr/lib/systemd/system-preset/35-secureblue-desktop.preset
+++ b/files/system/desktop/usr/lib/systemd/system-preset/35-secureblue-desktop.preset
@@ -1,7 +1,9 @@
 enable flatpak-system-update.timer
 
-# Homebrew
-enable brew-setup.service
+# Homebrew setup migration
+# TODO: remove after enough time has passed that users should all be
+# migrated to the new Homebrew setup method based on tmpfiles.d
+enable brew-setup-migration.service
 
 # Disable NFS daemons
 disable gssproxy.service

--- a/files/system/desktop/usr/lib/systemd/system/brew-setup-migration.service
+++ b/files/system/desktop/usr/lib/systemd/system/brew-setup-migration.service
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[Unit]
+Description=Homebrew setup migration
+Wants=multi-user.target
+After=multi-user.target
+ConditionPathExists=/etc/.linuxbrew
+ConditionPathExists=/etc/tmpfiles.d/homebrew.conf
+
+[Service]
+ExecStart=rm -f /etc/tmpfiles.d/homebrew.conf /etc/.linuxbrew
+
+[Install]
+WantedBy=multi-user.target

--- a/files/system/desktop/usr/libexec/secureblue/brew_main.py
+++ b/files/system/desktop/usr/libexec/secureblue/brew_main.py
@@ -7,19 +7,16 @@
 """Disable brew."""
 
 import os
-import shutil
-import subprocess
 import sys
-from pathlib import Path
 from typing import Final
 
 import sandbox
 from utils import CommandUsageError, ToggleMode, parse_basic_toggle_args
 
 BREW_HELP: Final[str] = """
-This python script toggles if brew is enabled by enabling or disabling
-brew-setup.service, removing or replacing the brew.sh profile.d file,
-and removing the .linuxbrew directory.
+This python script toggles if Homebrew is enabled by enabling or
+disabling its tmpfiles.d configuration, removing or replacing the
+brew.sh profile.d file, and removing the .linuxbrew directory.
 
 usage:
 ujust set-brew
@@ -38,33 +35,42 @@ ujust set-brew --help
     Prints this message.
 """
 
+BREW_TOGGLE_FUNCTION: Final[sandbox.SandboxedFunction] = sandbox.SandboxedFunction(
+    "brew.py",
+    read_write_paths=["/home/linuxbrew", "/etc/tmpfiles.d", "/etc/profile.d"],
+    capabilities=["CAP_CHOWN", "CAP_DAC_OVERRIDE"],
+)
 
-LINUXBREW_HOMEDIR: Final[str] = "/home/linuxbrew/"
-ETC_DIR: Final[str] = "/etc"
-BREW_ETC_STAMP: Final[str] = "/etc/.linuxbrew"
+
+def is_brew_installed() -> bool:
+    """Test if Homebrew is installed."""
+    return os.path.exists("/home/linuxbrew/.linuxbrew/bin/brew")
 
 
-def print_status(linuxbrew_installed_by_stamp: bool) -> None:
+def print_status() -> None:
     """Print the current file and runtime status"""
-
-    # nosemgrep: dangerous-subprocess-use-audit
-    brew_setup_status = subprocess.run(
-        ["/usr/bin/systemctl", "is-enabled", "--quiet", "brew-setup.service"],
-        check=False,
-        capture_output=True,
-    )
-
-    is_brew_setup_enabled = brew_setup_status.returncode == 0
-    if linuxbrew_installed_by_stamp and is_brew_setup_enabled:
+    if is_brew_installed():
         print("Brew is enabled.")
-    elif not linuxbrew_installed_by_stamp and not is_brew_setup_enabled:
-        print("Brew is disabled.")
-    elif not linuxbrew_installed_by_stamp and is_brew_setup_enabled:
-        print("Brew has been locally modified. Brew is enabled but not installed.")
-        print("Ensure state consistency between /etc/.linuxbrew and brew-setup.service.")
     else:
-        print("Brew has been locally modified. Brew is installed but disabled.")
-        print("Ensure state consistency between /etc/.linuxbrew and brew-setup.service.")
+        print("Brew is disabled.")
+
+
+def enable_brew() -> int:
+    """Enable Homebrew."""
+    if is_brew_installed():
+        print("Brew is already enabled.")
+        return 0
+
+    return sandbox.run(BREW_TOGGLE_FUNCTION, "on")
+
+
+def disable_brew() -> int:
+    """Disable Homebrew."""
+    if not is_brew_installed():
+        print("Brew is already disabled.")
+        return 0
+
+    return sandbox.run(BREW_TOGGLE_FUNCTION, "off")
 
 
 def main() -> int:
@@ -75,23 +81,13 @@ def main() -> int:
         print(f"Usage error: {e}. See usage with --help.")
         return 2
 
-    linuxbrew_is_installed = Path(BREW_ETC_STAMP).exists()
-    brew_disable_function = sandbox.SandboxedFunction(
-        "brew.py", read_write_paths=[LINUXBREW_HOMEDIR, ETC_DIR], capabilities=["CAP_DAC_OVERRIDE"]
-    )
     match mode:
-        case ToggleMode.ON | ToggleMode.OFF:
-            target_state_enabled = mode == ToggleMode.ON
-            state_already_set = target_state_enabled == linuxbrew_is_installed
-            if state_already_set:
-                print_status(linuxbrew_is_installed)
-            else:
-                if not target_state_enabled:
-                    brew_cache_dir = os.path.expanduser("~/.cache/Homebrew")
-                    shutil.rmtree(brew_cache_dir, ignore_errors=True)
-                return sandbox.run(brew_disable_function, str(mode))
+        case ToggleMode.ON:
+            return enable_brew()
+        case ToggleMode.OFF:
+            return disable_brew()
         case ToggleMode.STATUS:
-            print_status(linuxbrew_is_installed)
+            print("Brew is enabled." if is_brew_installed() else "Brew is disabled.")
         case ToggleMode.HELP:
             print(BREW_HELP)
     return 0

--- a/files/system/desktop/usr/libexec/secureblue/inner/brew.py
+++ b/files/system/desktop/usr/libexec/secureblue/inner/brew.py
@@ -11,14 +11,51 @@ The sandboxed brew disable function
 import contextlib
 import os
 import shutil
-import subprocess
 import sys
 from typing import Final
 
-LINUXBREW_DIR: Final[str] = "/home/linuxbrew/.linuxbrew/"
-BREW_ETC_STAMP: Final[str] = "/etc/.linuxbrew"
+TMPFILES_OVERRIDE: Final[str] = "/etc/tmpfiles.d/homebrew.conf"
+LINUXBREW_DIR: Final[str] = "/home/linuxbrew/.linuxbrew"
+BREW_CACHE_DIR: Final[str] = "/home/linuxbrew/.cache"
 BREW_PROFILE_FILE: Final[str] = "/etc/profile.d/brew.sh"
 BREW_PROFILE_COMPLETIONS_FILE: Final[str] = "/etc/profile.d/brew-bash-completions.sh"
+BREW_OWNER_UID: Final[int] = 1000
+
+
+def _copy_and_chown(src: str, dst: str, *, follow_symlinks: bool = True) -> None:
+    """Copy src to dest and chown the copy to the given UID."""
+    shutil.copy2(src, dst, follow_symlinks=follow_symlinks)
+    os.chown(dst, BREW_OWNER_UID, BREW_OWNER_UID, follow_symlinks=follow_symlinks)
+
+
+def enable_brew() -> None:
+    """Enable Homebrew."""
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(TMPFILES_OVERRIDE)
+    with contextlib.suppress(FileExistsError):
+        shutil.copytree(
+            "/usr/share/homebrew/.linuxbrew",
+            LINUXBREW_DIR,
+            symlinks=True,
+            ignore_dangling_symlinks=True,
+            copy_function=_copy_and_chown,
+        )
+    shutil.copy2(f"/usr{BREW_PROFILE_FILE}", BREW_PROFILE_FILE)
+    shutil.copy2(f"/usr{BREW_PROFILE_COMPLETIONS_FILE}", BREW_PROFILE_COMPLETIONS_FILE)
+
+
+def disable_brew() -> None:
+    """Disable Homebrew."""
+    with contextlib.suppress(FileExistsError):
+        os.symlink("/dev/null", TMPFILES_OVERRIDE)
+    with contextlib.suppress(FileNotFoundError):
+        shutil.rmtree(LINUXBREW_DIR)
+    with contextlib.suppress(FileNotFoundError):
+        shutil.rmtree(BREW_CACHE_DIR)
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(BREW_PROFILE_FILE)
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(BREW_PROFILE_COMPLETIONS_FILE)
 
 
 def main() -> int:
@@ -28,32 +65,15 @@ def main() -> int:
     if len(sys.argv) != required_args_count:
         return 1
 
-    mode = sys.argv[1]
+    mode = sys.argv[1].casefold()
     match mode:
         case "on":
-            subprocess.run(
-                ["/usr/bin/systemctl", "enable", "--now", "brew-setup.service"],
-                check=False,
-                capture_output=True,
-            )
-            shutil.copy(f"/usr{BREW_PROFILE_FILE}", BREW_PROFILE_FILE)
-            shutil.copy(f"/usr{BREW_PROFILE_COMPLETIONS_FILE}", BREW_PROFILE_COMPLETIONS_FILE)
+            enable_brew()
             print("Brew is now enabled. Start a new shell to use brew.")
             return 0
         case "off":
-            with contextlib.suppress(OSError):
-                shutil.rmtree(LINUXBREW_DIR, ignore_errors=False)
-            with contextlib.suppress(OSError):
-                os.remove(BREW_ETC_STAMP)
-            with contextlib.suppress(OSError):
-                os.remove(BREW_PROFILE_FILE)
-            with contextlib.suppress(OSError):
-                os.remove(BREW_PROFILE_COMPLETIONS_FILE)
-            subprocess.run(
-                ["/usr/bin/systemctl", "disable", "brew-setup.service"],
-                check=False,
-                capture_output=True,
-            )
+            disable_brew()
+            print("Brew is now disabled.")
             return 0
         case _:
             print("Invalid inner script argument.")


### PR DESCRIPTION
With secureblue/homebrew#15, Homebrew setup uses tmpfiles.d instead of a systemd service unit to create the `/home/linuxbrew/.linuxbrew` directory. The `ujust set-brew` script needs to be changed to match.

To ensure the Homebrew installation is *not* recreated for users who have opted out with `ujust set-brew off`, we override this tmpfiles.d config file by default by creating an empty `/etc/tmpfiles.d/homebrew.conf`, and add a systemd service `brew-setup-migration.service` that removes this override if the stamp `/etc/.linuxbrew` used by the old Homebrew setup method is present.