### PR TITLE
chore: revert pinning Trivalent to version 144

### DIFF
--- a/files/scripts/install-trivalent.sh
+++ b/files/scripts/install-trivalent.sh
@@ -14,40 +14,24 @@ curl -fLsS --retry 5 -o /etc/yum.repos.d/repo.secureblue.dev.secureblue.repo htt
 secureblue_gpg_key_path="$(dnf repo info secureblue --json | jq -r '.[0].gpg_key.[0]')"
 rpmkeys --import "${secureblue_gpg_key_path}"
 
+# The package signature is NOT being checked at this stage,
+# see https://github.com/rpm-software-management/dnf5/issues/1985
+dnf --best --repo=secureblue -y download trivalent
 
+trivalent_rpms_found=0
+for trivalent_rpm in trivalent-*."${ARCH}".rpm; do
+    (( ++trivalent_rpms_found ))
+done
 
-# TEMP: Uncomment after trivalent is fixed
-# trivalent_rpms_found=0
-# for trivalent_rpm in trivalent-*."${ARCH}".rpm; do
-#     (( ++trivalent_rpms_found ))
-# done
-
-# if [ "$trivalent_rpms_found" -eq 1 ]; then
-#     echo "Found: ${trivalent_rpms_found}"
-# else
-#     echo "Number of trivalent rpms not one, found: ${trivalent_rpms_found}"
-#     exit 1
-# fi
-
-# trivalent_rpm_sans_prefix=${trivalent_rpm#trivalent-}
-# trivalent_version=${trivalent_rpm_sans_prefix%".${ARCH}.rpm"}
-
-# TEMP: Revert after trivalent is fixed
-if [[ "$ARCH" == 'x86_64' ]]; then
-  trivalent_version="144.0.7559.132-442539"
-
-  # The package signature is NOT being checked at this stage,
-  # see https://github.com/rpm-software-management/dnf5/issues/1985
-  dnf --repo=secureblue -y download trivalent-${trivalent_version}.x86_64
+if [ "$trivalent_rpms_found" -eq 1 ]; then
+    echo "Found: ${trivalent_rpms_found}"
 else
-  trivalent_version="144.0.7559.132-442541"
-
-  # The package signature is NOT being checked at this stage,
-  # see https://github.com/rpm-software-management/dnf5/issues/1985
-  dnf --best --repo=secureblue -y download trivalent
+    echo "Number of trivalent rpms not one, found: ${trivalent_rpms_found}"
+    exit 1
 fi
 
-trivalent_rpm="trivalent-${trivalent_version}.${ARCH}.rpm"
+trivalent_rpm_sans_prefix=${trivalent_rpm#trivalent-}
+trivalent_version=${trivalent_rpm_sans_prefix%".${ARCH}.rpm"}
 
 provenance_file="${trivalent_rpm}.intoto.jsonl"
 wget "https://github.com/secureblue/Trivalent/releases/download/${trivalent_version}/${provenance_file}"


### PR DESCRIPTION
A working build of Trivalent 145 is now available.

This reverts commit d9d302ca7c0e89e35efa61e1bd105844cbf75979.