### PR TITLE
feat: add ujust toggle for dhcp hostname sending

### DIFF
--- a/files/justfiles/common/wrappers.just
+++ b/files/justfiles/common/wrappers.just
@@ -65,3 +65,10 @@ install-dangerzone:
 toggle-user-motd:
     #!/bin/sh
     exec /usr/bin/python3 /usr/libexec/secureblue/toggle_user_motd.py
+
+# Toggle DHCP hostname sending.
+[positional-arguments]
+set-dhcp-hostname-sending *args:
+    #!/bin/sh
+    exec /usr/bin/python3 /usr/libexec/secureblue/dhcp_hostname_sending_main.py "$@"
+

--- a/files/justfiles/common/wrappers.just
+++ b/files/justfiles/common/wrappers.just
@@ -71,4 +71,3 @@ toggle-user-motd:
 set-dhcp-hostname-sending *args:
     #!/bin/sh
     exec /usr/bin/python3 /usr/libexec/secureblue/dhcp_hostname_sending_main.py "$@"
-

--- a/files/system/usr/libexec/secureblue/dhcp_hostname_sending_main.py
+++ b/files/system/usr/libexec/secureblue/dhcp_hostname_sending_main.py
@@ -90,8 +90,8 @@ def main() -> int:
     """Handle the arguments and execute the toggle"""
     try:
         mode = parse_basic_toggle_args(
-                prompt = "Would you like to send the system's hostname to the DHCP server?"
-                )
+            prompt="Would you like to send the system's hostname to the DHCP server?"
+        )
     except CommandUsageError as e:
         print(f"Usage error: {e}. see usage with --help.")
         return 2

--- a/files/system/usr/libexec/secureblue/dhcp_hostname_sending_main.py
+++ b/files/system/usr/libexec/secureblue/dhcp_hostname_sending_main.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Final
 
 import sandbox
-from utils import ask_yes_no
+from utils import CommandUsageError, ToggleMode, parse_basic_toggle_args
 
 HOSTNAME_SENDING_HELP: Final[str] = """
 This python script toggles if the system's hostname is sent to the DHCP server
@@ -58,48 +58,44 @@ def print_status() -> None:
         f"DHCP hostname sending is currently {cur_status}",
     )
 
-
-def main() -> int:
-    """Handle the arguments and execute the toggle"""
-
-    argc_interactive = 1
-    argc_on_off = 2
-
-    if len(sys.argv) == argc_interactive:
-        # Ask interactively.
-        mode = (
-            "on"
-            if ask_yes_no("Would you like to send the system's hostname to the DHCP server?")
-            else "off"
-        )
-    elif len(sys.argv) == argc_on_off:
-        # Take mode from first argument, i.e. 'on' or 'off'.
-        mode = sys.argv[1].casefold()
-    else:
-        print("Too many options specified, see usage with --help.", file=sys.stderr)
-        return 1
+def run(mode: ToggleMode) -> int:
+    """Run the logic for enabling or disabling DHCP hostname sending"""
 
     disabled_by_file = Path(HOSTNAME_SENDING_FILE).exists()
+    target_state_disabled = mode == "off"
+    state_already_set = target_state_disabled == disabled_by_file
     hostname_sending_function = sandbox.SandboxedFunction(
         "dhcp_hostname_sending.py", read_write_paths=[HOSTNAME_SENDING_DIR]
     )
+
+    if mode == ToggleMode.HELP:
+        print(HOSTNAME_SENDING_HELP)
+        return 0
+    enabled = hostname_sending_enabled()
     match mode:
-        case "on" | "off":
-            target_state_disabled = mode == "off"
-            state_already_set = target_state_disabled == disabled_by_file
+        case ToggleMode.STATUS:
+            print("enabled" if enabled else "disabled")
+            return 0
+        case ToggleMode.ON | ToggleMode.OFF:
             if state_already_set:
                 print_status()
-            else:
-                return sandbox.run(hostname_sending_function, mode)
-        case "status":
-            print_status()
-        case "--help":
-            print(HOSTNAME_SENDING_HELP)
+                return 0
+            return sandbox.run(hostname_sending_function, mode)
         case _:
-            print("Invalid option selected. Try --help.")
-            return 1
-    return 0
+            raise ValueError(f"Invalid mode value: {mode}")
 
+
+def main() -> int:
+    """Handle the arguments and execute the toggle"""
+    try:
+        mode = parse_basic_toggle_args(
+                prompt = "Would you like to send the system's hostname to the DHCP server?"
+                )
+    except CommandUsageError as e:
+        print(f"Usage error: {e}. see usage with --help.")
+        return 2
+
+    return run(mode)
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/files/system/usr/libexec/secureblue/dhcp_hostname_sending_main.py
+++ b/files/system/usr/libexec/secureblue/dhcp_hostname_sending_main.py
@@ -44,8 +44,6 @@ HOSTNAME_SENDING_FILE: Final[str] = f"{HOSTNAME_SENDING_DIR}/dhcp_no_hostname.co
 
 def hostname_sending_enabled() -> bool:
     """Return whether the system is set to send its hostname to the DHCP server or not."""
-    if Path(HOSTNAME_SENDING_FILE).exists():
-        return False
     return not Path(HOSTNAME_SENDING_FILE).exists()
 
 

--- a/files/system/usr/libexec/secureblue/dhcp_hostname_sending_main.py
+++ b/files/system/usr/libexec/secureblue/dhcp_hostname_sending_main.py
@@ -61,7 +61,7 @@ def run(mode: ToggleMode) -> int:
     """Run the logic for enabling or disabling DHCP hostname sending"""
 
     disabled_by_file = Path(HOSTNAME_SENDING_FILE).exists()
-    target_state_disabled = mode == "off"
+    target_state_disabled = mode == ToggleMode.OFF
     state_already_set = target_state_disabled == disabled_by_file
     hostname_sending_function = sandbox.SandboxedFunction(
         "dhcp_hostname_sending.py", read_write_paths=[HOSTNAME_SENDING_DIR]

--- a/files/system/usr/libexec/secureblue/dhcp_hostname_sending_main.py
+++ b/files/system/usr/libexec/secureblue/dhcp_hostname_sending_main.py
@@ -16,8 +16,9 @@ import sandbox
 from utils import ask_yes_no
 
 HOSTNAME_SENDING_HELP: Final[str] = """
-This python script toggles if the system's hostname is sent to the DHCP server by creating or deleting a configuration file at
-"/etc/NetworkManager/conf.d/dhcp_no_hostname.conf" to disable or enable this functionality.
+This python script toggles if the system's hostname is sent to the DHCP server
+by creating or deleting a configuration file at /etc/NetworkManager/conf.d/dhcp_no_hostname.conf"
+to disable or enable this functionality.
 
 usage:
 ujust set-dhcp-hostname-sending
@@ -45,12 +46,11 @@ def hostname_sending_enabled() -> bool:
     """Return whether the system is set to send its hostname to the DHCP server or not."""
     if Path(HOSTNAME_SENDING_FILE).exists():
         return False
-    else:
-        return True
+    return not Path(HOSTNAME_SENDING_FILE).exists()
 
 
-def print_status(disabled_by_file: bool) -> None:
-    """Print the current file and runtime status"""
+def print_status() -> None:
+    """Print the current file status"""
 
     cur_status = "enabled" if hostname_sending_enabled() else "disabled"
 
@@ -67,7 +67,11 @@ def main() -> int:
 
     if len(sys.argv) == argc_interactive:
         # Ask interactively.
-        mode = "on" if ask_yes_no("Would you like to send the system's hostname to the DHCP server?") else "off"
+        mode = (
+            "on"
+            if ask_yes_no("Would you like to send the system's hostname to the DHCP server?")
+            else "off"
+        )
     elif len(sys.argv) == argc_on_off:
         # Take mode from first argument, i.e. 'on' or 'off'.
         mode = sys.argv[1].casefold()
@@ -76,17 +80,19 @@ def main() -> int:
         return 1
 
     disabled_by_file = Path(HOSTNAME_SENDING_FILE).exists()
-    hostname_sending_function = sandbox.SandboxedFunction("dhcp_hostname_sending.py", read_write_paths=[HOSTNAME_SENDING_DIR])
+    hostname_sending_function = sandbox.SandboxedFunction(
+        "dhcp_hostname_sending.py", read_write_paths=[HOSTNAME_SENDING_DIR]
+    )
     match mode:
         case "on" | "off":
             target_state_disabled = mode == "off"
             state_already_set = target_state_disabled == disabled_by_file
             if state_already_set:
-                print_status(disabled_by_file)
+                print_status()
             else:
                 return sandbox.run(hostname_sending_function, mode)
         case "status":
-            print_status(disabled_by_file)
+            print_status()
         case "--help":
             print(HOSTNAME_SENDING_HELP)
         case _:

--- a/files/system/usr/libexec/secureblue/dhcp_hostname_sending_main.py
+++ b/files/system/usr/libexec/secureblue/dhcp_hostname_sending_main.py
@@ -58,6 +58,7 @@ def print_status() -> None:
         f"DHCP hostname sending is currently {cur_status}",
     )
 
+
 def run(mode: ToggleMode) -> int:
     """Run the logic for enabling or disabling DHCP hostname sending"""
 
@@ -96,6 +97,7 @@ def main() -> int:
         return 2
 
     return run(mode)
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/files/system/usr/libexec/secureblue/dhcp_hostname_sending_main.py
+++ b/files/system/usr/libexec/secureblue/dhcp_hostname_sending_main.py
@@ -1,0 +1,99 @@
+#!/usr/bin/python3
+
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+The DHCP hostname sending toggle implementation for ujust
+"""
+
+import sys
+from pathlib import Path
+from typing import Final
+
+import sandbox
+from utils import ask_yes_no
+
+HOSTNAME_SENDING_HELP: Final[str] = """
+This python script toggles if the system's hostname is sent to the DHCP server by creating or deleting a configuration file at
+"/etc/NetworkManager/conf.d/dhcp_no_hostname.conf" to disable or enable this functionality.
+
+usage:
+ujust set-hostname-sending
+    Enables or disables interactively based on the user's preference.
+
+ujust set-hostname-sending on
+    Enables hostname sending to the DHCP server; does nothing if already on.
+
+ujust set-hostname-sending off
+    Disables hostname sending to the DHCP server; does nothing if already off.
+
+ujust set-hostname-sending status
+    Reports whether the system is set to send its hostname to the DHCP server or not.
+
+ujust set-hostname-sending --help
+    Prints this message.
+"""
+
+
+HOSTNAME_SENDING_DIR: Final[str] = "/etc/NetworkManager/conf.d"
+HOSTNAME_SENDING_FILE: Final[str] = f"{HOSTNAME_SENDING_DIR}/dhcp_no_hostname.conf"
+
+
+def hostname_sending_enabled() -> bool:
+    """Return whether the system is set to send its hostname to the DHCP server or not."""
+    if Path(HOSTNAME_SENDING_FILE).exists():
+        return False
+    else:
+        return True
+
+
+def print_status(disabled_by_file: bool) -> None:
+    """Print the current file and runtime status"""
+
+    cur_status = "enabled" if hostname_sending_enabled() else "disabled"
+
+    print(
+        f"DHCP hostname sending is currently {cur_status}",
+    )
+
+
+def main() -> int:
+    """Handle the arguments and execute the toggle"""
+
+    argc_interactive = 1
+    argc_on_off = 2
+
+    if len(sys.argv) == argc_interactive:
+        # Ask interactively.
+        mode = "on" if ask_yes_no("Would you like to send the system's hostname to the DHCP server?") else "off"
+    elif len(sys.argv) == argc_on_off:
+        # Take mode from first argument, i.e. 'on' or 'off'.
+        mode = sys.argv[1].casefold()
+    else:
+        print("Too many options specified, see usage with --help.", file=sys.stderr)
+        return 1
+
+    disabled_by_file = Path(HOSTNAME_SENDING_FILE).exists()
+    hostname_sending_function = sandbox.SandboxedFunction("dhcp_hostname_sending.py", read_write_paths=[HOSTNAME_SENDING_DIR])
+    match mode:
+        case "on" | "off":
+            target_state_disabled = mode == "off"
+            state_already_set = target_state_disabled == disabled_by_file
+            if state_already_set:
+                print_status(disabled_by_file)
+            else:
+                return sandbox.run(hostname_sending_function, mode)
+        case "status":
+            print_status(disabled_by_file)
+        case "--help":
+            print(HOSTNAME_SENDING_HELP)
+        case _:
+            print("Invalid option selected. Try --help.")
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/files/system/usr/libexec/secureblue/dhcp_hostname_sending_main.py
+++ b/files/system/usr/libexec/secureblue/dhcp_hostname_sending_main.py
@@ -20,19 +20,19 @@ This python script toggles if the system's hostname is sent to the DHCP server b
 "/etc/NetworkManager/conf.d/dhcp_no_hostname.conf" to disable or enable this functionality.
 
 usage:
-ujust set-hostname-sending
+ujust set-dhcp-hostname-sending
     Enables or disables interactively based on the user's preference.
 
-ujust set-hostname-sending on
+ujust set-dhcp-hostname-sending on
     Enables hostname sending to the DHCP server; does nothing if already on.
 
-ujust set-hostname-sending off
+ujust set-dhcp-hostname-sending off
     Disables hostname sending to the DHCP server; does nothing if already off.
 
-ujust set-hostname-sending status
+ujust set-dhcp-hostname-sending status
     Reports whether the system is set to send its hostname to the DHCP server or not.
 
-ujust set-hostname-sending --help
+ujust set-dhcp-hostname-sending --help
     Prints this message.
 """
 

--- a/files/system/usr/libexec/secureblue/inner/dhcp_hostname_sending.py
+++ b/files/system/usr/libexec/secureblue/inner/dhcp_hostname_sending.py
@@ -21,7 +21,7 @@ ipv6.dhcp-send-hostname=0
 """
 
 
-def restart_nm() -> None:
+def restart_nm() -> int:
     """Restart the NetworkManager service via systemctl."""
     systemctl = subprocess.run(
         ["/usr/bin/systemctl", "restart", "NetworkManager.service"],
@@ -29,8 +29,8 @@ def restart_nm() -> None:
         capture_output=True,
     )
 
-    if not systemctl.returncode:
-        return
+    if systemctl.returncode == 0:
+        return 0
 
     time.sleep(3)
     systemctl = subprocess.run(
@@ -41,7 +41,7 @@ def restart_nm() -> None:
 
     if systemctl.returncode:
         print("Failed to restart NetworkManager.", file=sys.stderr)
-        sys.exit(systemctl.returncode)
+        return systemctl.returncode
 
 
 def main() -> int:
@@ -57,13 +57,11 @@ def main() -> int:
                 fd.write(HOSTNAME_SENDING_TEXT)
             os.chmod(HOSTNAME_SENDING_FILE, 0o644)
             print("DHCP hostname sending has been disabled. Restarting NetworkManager.")
-            restart_nm()
-            return 0
+            return restart_nm()
         case "on":
             os.remove(HOSTNAME_SENDING_FILE)
             print("DHCP hostname sending has been enabled. Restarting NetworkManager.")
-            restart_nm()
-            return 0
+            return restart_nm()
         case _:
             print("Invalid inner script argument.")
             return 1

--- a/files/system/usr/libexec/secureblue/inner/dhcp_hostname_sending.py
+++ b/files/system/usr/libexec/secureblue/inner/dhcp_hostname_sending.py
@@ -39,9 +39,10 @@ def restart_nm() -> int:
         stdout=subprocess.PIPE,
     )
 
-    if systemctl.returncode:
+    if systemctl.returncode != 0:
         print("Failed to restart NetworkManager.", file=sys.stderr)
-        return systemctl.returncode
+
+    return systemctl.returncode
 
 
 def main() -> int:

--- a/files/system/usr/libexec/secureblue/inner/dhcp_hostname_sending.py
+++ b/files/system/usr/libexec/secureblue/inner/dhcp_hostname_sending.py
@@ -9,9 +9,9 @@ The sandboxed dhcp hostname sending toggle function
 """
 
 import os
+import subprocess  # nosec
 import sys
 import time
-import subprocess # nosec
 from typing import Final
 
 HOSTNAME_SENDING_FILE: Final[str] = "/etc/NetworkManager/conf.d/dhcp_no_hostname.conf"
@@ -20,26 +20,29 @@ ipv4.dhcp-send-hostname=0
 ipv6.dhcp-send-hostname=0
 """
 
+
 def restart_nm() -> None:
     """Restart the NetworkManager service via systemctl."""
-    systemctl = subprocess.run( # nosec
-        ["/usr/bin/systemctl", "restart", "NetworkManager.service"], check=False, capture_output=True
+    systemctl = subprocess.run(  # nosec
+        ["/usr/bin/systemctl", "restart", "NetworkManager.service"],
+        check=False,
+        capture_output=True,
     )
 
     if not systemctl.returncode:
         return
-    
+
     time.sleep(3)
     systemctl = subprocess.run(  # nosec
-        ["/usr/bin/systemctl", "restart", "NetworkManager.service"], check=False, stdout=subprocess.PIPE
+        ["/usr/bin/systemctl", "restart", "NetworkManager.service"],
+        check=False,
+        stdout=subprocess.PIPE,
     )
 
     if systemctl.returncode:
         print("Failed to restart NetworkManager.", file=sys.stderr)
         sys.exit(systemctl.returncode)
-    
-    
-    
+
 
 def main() -> int:
     """Set or remove the hostname sending block"""

--- a/files/system/usr/libexec/secureblue/inner/dhcp_hostname_sending.py
+++ b/files/system/usr/libexec/secureblue/inner/dhcp_hostname_sending.py
@@ -9,7 +9,7 @@ The sandboxed dhcp hostname sending toggle function
 """
 
 import os
-import subprocess  # nosec
+import subprocess
 import sys
 import time
 from typing import Final
@@ -23,7 +23,7 @@ ipv6.dhcp-send-hostname=0
 
 def restart_nm() -> None:
     """Restart the NetworkManager service via systemctl."""
-    systemctl = subprocess.run(  # nosec
+    systemctl = subprocess.run(
         ["/usr/bin/systemctl", "restart", "NetworkManager.service"],
         check=False,
         capture_output=True,
@@ -33,7 +33,7 @@ def restart_nm() -> None:
         return
 
     time.sleep(3)
-    systemctl = subprocess.run(  # nosec
+    systemctl = subprocess.run(
         ["/usr/bin/systemctl", "restart", "NetworkManager.service"],
         check=False,
         stdout=subprocess.PIPE,

--- a/files/system/usr/libexec/secureblue/inner/dhcp_hostname_sending.py
+++ b/files/system/usr/libexec/secureblue/inner/dhcp_hostname_sending.py
@@ -10,6 +10,7 @@ The sandboxed dhcp hostname sending toggle function
 
 import os
 import sys
+import time
 import subprocess # nosec
 from typing import Final
 
@@ -18,10 +19,26 @@ HOSTNAME_SENDING_TEXT: Final[str] = """[connection]
 ipv4.dhcp-send-hostname=0
 ipv6.dhcp-send-hostname=0
 """
-def restart_nm():
-    subprocess.run( # nosec
-                   ["systemctl", "restart", "NetworkManager.service"]
-            )
+
+def restart_nm() -> None:
+    """Restart the NetworkManager service via systemctl."""
+    systemctl = subprocess.run( # nosec
+        ["/usr/bin/systemctl", "restart", "NetworkManager.service"], check=False, capture_output=True
+    )
+
+    if not systemctl.returncode:
+        return
+    
+    time.sleep(3)
+    systemctl = subprocess.run(  # nosec
+        ["/usr/bin/systemctl", "restart", "NetworkManager.service"], check=False, stdout=subprocess.PIPE
+    )
+
+    if systemctl.returncode:
+        print("Failed to restart NetworkManager.", file=sys.stderr)
+        sys.exit(systemctl.returncode)
+    
+    
     
 
 def main() -> int:

--- a/files/system/usr/libexec/secureblue/inner/dhcp_hostname_sending.py
+++ b/files/system/usr/libexec/secureblue/inner/dhcp_hostname_sending.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python3
+
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+The sandboxed dhcp hostname sending toggle function
+"""
+
+import os
+import sys
+import subprocess # nosec
+from typing import Final
+
+HOSTNAME_SENDING_FILE: Final[str] = "/etc/NetworkManager/conf.d/dhcp_no_hostname.conf"
+HOSTNAME_SENDING_TEXT: Final[str] = """[connection]
+ipv4.dhcp-send-hostname=0
+ipv6.dhcp-send-hostname=0
+"""
+def restart_nm():
+    subprocess.run( # nosec
+                   ["systemctl", "restart", "NetworkManager.service"]
+            )
+    
+
+def main() -> int:
+    """Set or remove the hostname sending block"""
+    required_args_count = 2
+    if len(sys.argv) != required_args_count:
+        return 1
+
+    mode = sys.argv[1]
+    match mode:
+        case "off":
+            with open(HOSTNAME_SENDING_FILE, "w", encoding="utf8") as fd:
+                fd.write(HOSTNAME_SENDING_TEXT)
+            os.chmod(HOSTNAME_SENDING_FILE, 0o644)
+            print("DHCP hostname sending has been disabled. Restarting NetworkManager.")
+            restart_nm()
+            return 0
+        case "on":
+            os.remove(HOSTNAME_SENDING_FILE)
+            print("DHCP hostname sending has been enabled. Restarting NetworkManager.")
+            restart_nm()
+            return 0
+        case _:
+            print("Invalid inner script argument.")
+            return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This creates a ujust script to toggle whether NetworkManager will send the system's static hostname to the DHCP server.