### PR TITLE
chore: add com.jiosphere.JioSphere to Bazaar blocklist

### DIFF
--- a/files/system/desktop/usr/share/bazaar/blocklist.yaml
+++ b/files/system/desktop/usr/share/bazaar/blocklist.yaml
@@ -3,6 +3,7 @@ blocklists:
     block:
       # Verified Chromium-based browsers.
       - com.brave.Browser
+      - com.jiosphere.JioSphere
       - io.github.ungoogled_software.ungoogled_chromium
       - org.kde.falkon
       - ru.yandex.Browser


### PR DESCRIPTION
[JioSphere](https://flathub.org/en/apps/com.jiosphere.JioSphere) appears to be a proprietary Chromium-based browser, though as far as I can tell, their website doesn't actually say this. The same reasoning for blocking it in Bazaar applies here as it does for other Chromium-based browsers.

(Spotted this one in the "trending" page when I opened up Bazaar.)