### PR TITLE
feat: disable automatic systemd SSH vsock creation

### DIFF
--- a/files/scripts/addchromiumdesktopfile.sh
+++ b/files/scripts/addchromiumdesktopfile.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
-#
-# SPDX-License-Identifier: Apache-2.0
-
-set -euo pipefail
-
-sed -i 's/org.mozilla.firefox/trivalent/' /usr/share/wayfire/wf-shell.ini

--- a/files/scripts/disable-sshd-vsock.sh
+++ b/files/scripts/disable-sshd-vsock.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+echo "Disabling systemd sshd vsock socket"
+
+# For more info, see https://blog.nsrun.io/2026/01/15/systemd-vsock-openssh-server/
+systemctl disable sshd-vsock.socket
+systemctl mask sshd-vsock.socket

--- a/files/system/usr/lib/bootc/kargs.d/10-secureblue.toml
+++ b/files/system/usr/lib/bootc/kargs.d/10-secureblue.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 kargs = [
   "hash_pointers=always",
   "init_on_alloc=1",
@@ -30,6 +34,7 @@ kargs = [
   "spec_store_bypass_disable=on",
   "spectre_v2=on",
   "ssbd=force-on",
+  "systemd.ssh_auto=no",
   "vdso32=0",
   "vsyscall=none",
 ]

--- a/files/system/usr/lib/systemd/system-preset/40-secureblue.preset
+++ b/files/system/usr/lib/systemd/system-preset/40-secureblue.preset
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 enable dnsconfd.service
 enable fwupd-refresh.timer
 enable podman-auto-update.timer
@@ -6,4 +10,5 @@ enable secureblue-unbound-key.service
 
 disable flatpak-add-fedora-repos.service
 disable geoclue.service
+disable sshd-vsock.socket
 disable systemd-resolved.service

--- a/recipes/common/common-scripts.yml
+++ b/recipes/common/common-scripts.yml
@@ -14,6 +14,7 @@ scripts:
   - setfilepermissions.sh
   - createmissingdirectories.sh
   - disablegeoclue.sh
+  - disable-sshd-vsock.sh
   - createjustcompletions.sh
   - removefedoraflatpakremoteservice.sh
   - localization.sh


### PR DESCRIPTION
Add `systemd.ssh_auto=no` kernel argument, and disable and mask `sshd-vsock.socket`. For motivation, see:
https://blog.nsrun.io/2026/01/15/systemd-vsock-openssh-server/

Also delete unused script `addchromiumdesktopfile.sh`.