### PR TITLE
feat(sysctl): set kernel.panic_on_warn=1

### DIFF
--- a/files/system/usr/lib/sysctl.d/55-hardening.conf
+++ b/files/system/usr/lib/sysctl.d/55-hardening.conf
@@ -86,6 +86,12 @@ kernel.warn_limit=100
 # https://docs.kernel.org/admin-guide/sysctl/kernel.html#panic
 kernel.panic=-1
 
+# WARN() and friends should never have their control flow paths reached
+# in normal operation:
+# https://docs.kernel.org/process/coding-style.html#do-not-warn-lightly
+# https://docs.kernel.org/admin-guide/sysctl/kernel.html#panic-on-warn
+kernel.panic_on_warn=1
+
 # https://docs.kernel.org/admin-guide/binfmt-misc.html
 fs.binfmt_misc.status = 0
 


### PR DESCRIPTION
The WARN() macro and friends are only intended for control flow paths which are not intended to ever be reached during normal operation. As opposed to bug, some WARN() calls do indeed attempt to provide at least some error recovery[1]:

> Instead, use a WARN*() variant, preferably WARN_ON_ONCE(), and possibly with recovery code. Recovery code is not required if there is no reasonable way to at least partially recover.

However, WARN() and friends are fundamentally control flow paths that should not be reached[2]. As such, it can be desirable to simply panic the system if uncharted control flow territory is reached.

Given that the error path of WARN() is not intended to be reached, we can expect minimal impact for users: the error path of WARN() being reached at all is not only treated as a kernel bug but also as a kernel CVE.

[1] https://docs.kernel.org/process/coding-style.html#use-warn-rather-than-bug
[2] https://docs.kernel.org/process/coding-style.html#do-not-warn-lightly