### PR TITLE
fix: make libvirt daemons toggle self-documenting

### DIFF
--- a/files/system/desktop/usr/libexec/secureblue/set_libvirt_daemons.py
+++ b/files/system/desktop/usr/libexec/secureblue/set_libvirt_daemons.py
@@ -167,12 +167,13 @@ def get_selection(current: LibvirtDaemonSelection) -> LibvirtDaemonSelection | N
     questions = [
         inquirer.Checkbox(
             "daemons",
-            message="Select libvirt daemons to enable or disable",
+            message="(space to toggle, up/down to navigate, enter to confirm, Ctrl+C to cancel)",
             choices=all_daemons,
             default=current.daemons(),
             carousel=True,
         )
     ]
+    print("Select libvirt daemons (https://libvirt.org/daemons.html) to enable or disable:")
     answers = inquirer.prompt(questions)
     if answers is None:
         return None


### PR DESCRIPTION
The controls for the checkbox prompt on `ujust set-libvirt-daemons` are not necessarily obvious to users, so it's better to have the prompt document them. Also link to the libvirt documentation in the prompt.

For reference, here's what it looks like:
<img width="1284" height="185" alt="image" src="https://github.com/user-attachments/assets/a05b1a78-8479-4e28-9cad-bbd2b809d756" />