### PR TITLE
fix: swap Discover icon for Bazaar in Plasma 6.6

### DIFF
--- a/files/system/kinoite/usr/share/plasma/shells/org.kde.plasma.desktop/contents/updates/secureblue-launchers.js
+++ b/files/system/kinoite/usr/share/plasma/shells/org.kde.plasma.desktop/contents/updates/secureblue-launchers.js
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Copyright 2026 Universal Blue
+// SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Sets default launchers in KDE Plasma taskbar.
+// For documentation on this scripting mechanism, see:
+// https://develop.kde.org/docs/plasma/scripting/
+
+/* global panelIds, panelById */
+
+panelIds.forEach((panelId) => {
+    const panel = panelById(panelId);
+    if (!panel) {
+        return;
+    }
+    panel.widgetIds.forEach((widgetId) => {
+        const widget = panel.widgetById(widgetId);
+        if (widget.type === "org.kde.plasma.taskmanager") {
+            widget.currentConfigGroup = ["General"];
+
+            // Read the current launchers value
+            const currentLaunchers = widget.readConfig("launchers", "");
+
+            // Only set our default if launchers is empty
+            if (!currentLaunchers || currentLaunchers.trim() === "") {
+                widget.writeConfig("launchers", [
+                    "applications:systemsettings.desktop",
+                    "applications:io.github.kolunmi.Bazaar.desktop",
+                    "preferred://filemanager",
+                    "preferred://browser"
+                ]);
+                widget.reloadConfig();
+            }
+        }
+    });
+});


### PR DESCRIPTION
The previous method of setting default taskbar icons no longer works in Plasma 6.6. Instead, we can use [Plasma scripting](https://develop.kde.org/docs/plasma/scripting/), which allows a piece of JavaScript to be run once on update. This sets the taskbar icons to system settings, Bazaar, the file manager, and the web browser (but only if the list of taskbar icons for the user was unset or empty, so it won't override users' existing selections).

This is based on a draft of code used by Bazzite and Aurora to solve the same issue, with some changes to follow more modern JS idioms.

I tested this code on my own system using `plasma-interactiveconsole` and it seems to work as intended.