### PR TITLE
fix: install_dangerzone.py warning should refer to correct ptrace permission

### DIFF
--- a/files/system/usr/libexec/secureblue/install_dangerzone.py
+++ b/files/system/usr/libexec/secureblue/install_dangerzone.py
@@ -17,9 +17,9 @@ from utils import ask_yes_no, print_wrapped
 
 WARNING_MESSAGE: Final[str] = """
 Warning: Dangerzone (https://dangerzone.rocks/) requires enabling both container-domain
-user namespace creation and (restricted) ptrace. This is a security tradeoff, as other
-programs on your system will also be able to use container tools such as podman and to
-use ptrace to inspect child processes.
+user namespace creation and (admin-only attach) ptrace. This is a security tradeoff, as
+other programs on your system will also be able to use container tools such as podman
+and to use ptrace to inspect child processes.
 """
 
 


### PR DESCRIPTION
install_dangerzone script requires and sets `ptrace_scope` to `2`, also known as "admin-only attach" ptrace. However, the current warning message mentions _restricted_ ptrace which refers to the permissions when `ptrace_scope` is set to `1`. The warning message should be changed to more accurately reflect the `ptrace_scope` value. See this section of the `ptrace(2)` Linux man page:

```
       A process that has the CAP_SYS_PTRACE capability can update the /proc/sys/kernel/yama/ptrace_scope  file
       with one of the following values:

       0 ("classic ptrace permissions")
              No additional restrictions on operations that perform PTRACE_MODE_ATTACH checks (beyond those im‐
              posed by the commoncap and other LSMs).

              The use of PTRACE_TRACEME is unchanged.

       1 ("restricted ptrace") [default value]
              When  performing  an operation that requires a PTRACE_MODE_ATTACH check, the calling process must
              either have the CAP_SYS_PTRACE capability in the user namespace of the target process or it  must
              have  a predefined relationship with the target process.  By default, the predefined relationship
              is that the target process must be a descendant of the caller.

              A target process can employ the prctl(2) PR_SET_PTRACER operation to declare  an  additional  PID
              that  is  allowed  to perform PTRACE_MODE_ATTACH operations on the target.  See the kernel source
              file  Documentation/admin-guide/LSM/Yama.rst  (or  Documentation/security/Yama.txt  before  Linux
              4.13) for further details.

              The use of PTRACE_TRACEME is unchanged.

       2 ("admin-only attach")
              Only processes with the CAP_SYS_PTRACE capability in the user namespace of the target process may
              perform PTRACE_MODE_ATTACH operations or trace children that employ PTRACE_TRACEME.

       3 ("no attach")
              No   process   may   perform   PTRACE_MODE_ATTACH   operations  or  trace  children  that  employ
              PTRACE_TRACEME.

              Once this value has been written to the file, it cannot be changed.
```