### PR TITLE
fix: add missing quotes to chrony OPTIONS variable

### DIFF
--- a/files/scripts/setchronysysconfig.sh
+++ b/files/scripts/setchronysysconfig.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if [[ "$OS_ARCH" == 'x86_64' ]]; then
-    echo "OPTIONS=-F1 -r" > /etc/sysconfig/chronyd
+    echo 'OPTIONS="-F1 -r"' > /etc/sysconfig/chronyd
 else
-    echo "OPTIONS=-F2 -r" > /etc/sysconfig/chronyd
+    echo 'OPTIONS="-F2 -r"' > /etc/sysconfig/chronyd
 fi


### PR DESCRIPTION
The `OPTIONS` variable is missing quotes, which leads to the `-r` flag being interpreted as a command, rather than part of the variable value. This results in the `coreos-platform-chrony-config.service` systemd unit failing on securecore.