### PR TITLE
fix: secureblue-unbound-key systemd unit

### DIFF
--- a/files/system/usr/lib/systemd/system/secureblue-unbound-key.service
+++ b/files/system/usr/lib/systemd/system/secureblue-unbound-key.service
@@ -9,6 +9,7 @@
 
 [Unit]
 Description=Secureblue Unbound Root Key Installation Service
+ConditionPathExists=!/var/lib/unbound/root.key
 After=local-fs.target
 Before=unbound.service unbound-anchor.service
 RequiresMountsFor=/var/lib

--- a/files/system/usr/lib/systemd/system/secureblue-unbound-key.service
+++ b/files/system/usr/lib/systemd/system/secureblue-unbound-key.service
@@ -9,7 +9,6 @@
 
 [Unit]
 Description=Secureblue Unbound Root Key Installation Service
-ConditionPathExists=!/var/lib/unbound/root.key
 After=local-fs.target
 Before=unbound.service unbound-anchor.service
 RequiresMountsFor=/var/lib
@@ -17,6 +16,7 @@ RequiresMountsFor=/usr/etc
 
 [Service]
 Type=oneshot
+ExecCondition=/usr/bin/test ! -e /var/lib/unbound/root.key
 ExecStartPre=/usr/bin/mkdir -p /var/lib/unbound
 ExecStart=/usr/bin/cp /etc/unbound/dnssec-root.key /var/lib/unbound/root.key
 ExecStartPost=/usr/bin/chown -R unbound:unbound /var/lib/unbound

--- a/files/system/usr/lib/systemd/system/secureblue-unbound-key.service
+++ b/files/system/usr/lib/systemd/system/secureblue-unbound-key.service
@@ -18,7 +18,7 @@ RequiresMountsFor=/usr/etc
 [Service]
 Type=oneshot
 ExecStartPre=/usr/bin/mkdir -p /var/lib/unbound
-ExecStart=/usr/bin/cp /usr/etc/unbound/dnssec-root.key /var/lib/unbound/root.key
+ExecStart=/usr/bin/cp /etc/unbound/dnssec-root.key /var/lib/unbound/root.key
 ExecStartPost=/usr/bin/chown -R unbound:unbound /var/lib/unbound
 ExecStartPost=/usr/bin/chmod 0644 /var/lib/unbound/root.key
 ExecStartPost=/usr/bin/restorecon -R /var/lib/unbound

--- a/files/system/usr/lib/systemd/system/secureblue-unbound-key.service
+++ b/files/system/usr/lib/systemd/system/secureblue-unbound-key.service
@@ -12,7 +12,7 @@ Description=Secureblue Unbound Root Key Installation Service
 After=local-fs.target
 Before=unbound.service unbound-anchor.service
 RequiresMountsFor=/var/lib
-RequiresMountsFor=/usr/etc
+RequiresMountsFor=/etc
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The `secureblue-unbound-key.service` systemd unit is currently broken in two ways:
- ~~The `ConditionPathExists` precondition only works on files and ignores symlinks.~~
    _Edit: ConditionPathExists does work on symlinks, but doesn't in this case due to SELinux._
    `/var/lib/unbound/root.key` can be a symlink (e.g. on a fresh securecore install) so this PR reworks this to use `ExecCondition` with a negated `test` call ~~instead~~ additionally, which does work on symlinks.
- Both `/usr/etc/unbound/dnssec-root.key` and `/etc/unbound/dnssec-root.key` are identical symlinks, pointing to `../../usr/share/dns-root-data/root.key`. Due to the path being relative and only going back two folders, the symlink in `/usr/etc/unbound/` is broken and leads to the copy operation failing. This PR switches to using the working one in `/etc/unbound/` instead.