### PR TITLE
chore: preinstall arm-image-installer

### DIFF
--- a/recipes/common/common-packages.yml
+++ b/recipes/common/common-packages.yml
@@ -38,3 +38,6 @@ install:
     # provenance deps
     - crane
     - slsa-verifier
+
+    # tiny, pulls in sudo if locally layered
+    - arm-image-installer


### PR DESCRIPTION
`arm-image-installer` is used to install Fedora arm images onto [supported](https://github.com/fedora-arm/arm-image-installer/blob/main/SUPPORTED-BOARDS) ARM SBCs. This is therefore one of the primary methods by which secureblue IoT is installed onto ARM hardware. Preinstalling it (a 50KB package with few deps) allows it to be installed without pulling in sudo (a Required dep) or using it via a container, which requires exporting it since it needs system root to write to the sd card.

In short: preinstalling `arm-image-installer` allows users of any secureblue image to install Fedora IoT onto their SBCs without layering `sudo`.