### PR TITLE
fix(selinux): allow only specified domains to create userns

### DIFF
--- a/files/scripts/selinux/user_namespace/harden_userns.cil
+++ b/files/scripts/selinux/user_namespace/harden_userns.cil
@@ -2,5 +2,14 @@
 ;;
 ;; SPDX-License-Identifier: Apache-2.0 OR MIT
 
-(deny userdomain self (user_namespace (create)))
-(deny unconfined_service_t self (user_namespace (create)))
+(typeattribute userns_privileged_domain)
+(typeattributeset userns_privileged_domain (
+    colord_t container_domain container_runtime_domain devicekit_power_t
+    file_manager_type flatpak_t init_t initrc_t install_t kernel_t spc_t
+    systemsettings_t trivalent_domain trivalent_script_domain
+))
+
+(typeattribute userns_restricted_domain)
+(typeattributeset userns_restricted_domain (and (domain) (not (userns_privileged_domain))))
+
+(deny userns_restricted_domain self (user_namespace (create)))


### PR DESCRIPTION
Switch to an allow-list rather than deny-list approach to denying user namespace creation. This gets rid of a bunch of random SELinux domains that were still permitted to create user namespaces only because they had been omitted from the deny-list, which was a hole in the policy.