### PR TITLE
fix: disable KSplash properly using KDE Kiosk

### DIFF
--- a/files/system/kinoite/etc/skel/.config/ksplashrc
+++ b/files/system/kinoite/etc/skel/.config/ksplashrc
@@ -1,3 +1,0 @@
-[KSplash]
-Engine=none
-Theme=None

--- a/files/system/kinoite/etc/xdg/ksplashrc
+++ b/files/system/kinoite/etc/xdg/ksplashrc
@@ -3,5 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Disable KDE Plasma splash screen, which is broken with Xwayland disabled.
-# The file is set to read-only to prevent KDE Plasma from overwriting it.
-f+ %h/.config/ksplashrc 0400 - - - [KSplash]\nEngine=none\nTheme=None\n
+[KSplash][$i]
+Engine=none
+Theme=None


### PR DESCRIPTION
This ensures that the splash screen remains disabled, and that it being disabled is properly reflected in the KDE settings app (preventing the user from trying to change it through the graphical interface).