### PR TITLE
fix: workaround for the flatpak-system-update service bug

### DIFF
--- a/files/system/desktop/usr/lib/systemd/system/flatpak-system-update.service
+++ b/files/system/desktop/usr/lib/systemd/system/flatpak-system-update.service
@@ -9,6 +9,6 @@ StartLimitBurst=3
 [Service]
 Type=oneshot
 ExecCondition=/bin/bash -c '[[ "$(busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Metered | cut -c 3-)" == @(2|4) ]]'
-ExecStart=/usr/bin/run0 -i /usr/bin/flatpak --system uninstall --unused -y --noninteractive ; /usr/bin/run0 -i /usr/bin/flatpak --system update -y --noninteractive ; /usr/bin/run0 -i /usr/bin/flatpak --system repair
+ExecStart=/usr/bin/sh -c '/usr/bin/flatpak --system uninstall --unused -y --noninteractive ; /usr/bin/flatpak --system update -y --noninteractive ; /usr/bin/flatpak --system repair'
 RestartSec=1h
 Restart=on-failure

--- a/files/system/desktop/usr/lib/systemd/system/flatpak-system-update.service
+++ b/files/system/desktop/usr/lib/systemd/system/flatpak-system-update.service
@@ -9,6 +9,6 @@ StartLimitBurst=3
 [Service]
 Type=oneshot
 ExecCondition=/bin/bash -c '[[ "$(busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Metered | cut -c 3-)" == @(2|4) ]]'
-ExecStart=/usr/bin/flatpak --system uninstall --unused -y --noninteractive ; /usr/bin/flatpak --system update -y --noninteractive ; /usr/bin/flatpak --system repair
+ExecStart=/usr/bin/run0 -i /usr/bin/flatpak --system uninstall --unused -y --noninteractive ; /usr/bin/run0 -i /usr/bin/flatpak --system update -y --noninteractive ; /usr/bin/run0 -i /usr/bin/flatpak --system repair
 RestartSec=1h
 Restart=on-failure


### PR DESCRIPTION
Closes: https://github.com/secureblue/secureblue/issues/1977

This PR fixes the original service unit so that it can work without issues. 

I've tested this in a vm under the qemu user session in the kinoite-main-hardened image, and I was able to properly update various system flatpaks and runtimes.