### PR TITLE
ci: allow manually clearing layer plan

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -16,6 +16,12 @@ on:
       - "**.md"
 
   workflow_dispatch: # allow manually triggering builds
+    inputs:
+      clear-plan:
+        description: 'Clear previous layer plan?'
+        type: boolean
+        required: true
+        default: false
 
 # Cancels running workflows if a new workflow run for
 # the same workflow is started
@@ -35,6 +41,7 @@ jobs:
     with:
       recipe: general/recipe-silverblue-main.yml
       rechunk: true
+      clear-plan: ${{ inputs.clear-plan || false }}
     secrets:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
@@ -51,6 +58,7 @@ jobs:
     with:
       recipe: general/recipe-kinoite-main.yml
       rechunk: true
+      clear-plan: ${{ inputs.clear-plan || false }}
     secrets:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
@@ -67,6 +75,7 @@ jobs:
     with:
       recipe: general/recipe-sericea-main.yml
       rechunk: true
+      clear-plan: ${{ inputs.clear-plan || false }}
     secrets:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
@@ -83,6 +92,7 @@ jobs:
     with:
       recipe: general/recipe-cosmic-main.yml
       rechunk: true
+      clear-plan: ${{ inputs.clear-plan || false }}
     secrets:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
@@ -187,6 +197,7 @@ jobs:
     with:
       recipe: securecore/recipe-securecore-main.yml
       rechunk: true
+      clear-plan: ${{ inputs.clear-plan || false }}
     secrets:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
@@ -263,6 +274,7 @@ jobs:
     with:
       recipe: iot/recipe-iot-main.yml
       rechunk: true
+      clear-plan: ${{ inputs.clear-plan || false }}
     secrets:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}

--- a/.github/workflows/build-one-recipe.yml
+++ b/.github/workflows/build-one-recipe.yml
@@ -14,6 +14,10 @@ on:
         type: boolean
         required: false
         default: false
+      clear-plan:
+        type: boolean
+        required: false
+        default: false
     secrets:
       SIGNING_SECRET:
         required: true
@@ -190,10 +194,13 @@ jobs:
         shell: bash
         env:
           rechunk: ${{ inputs.rechunk }}
+          input_clear_plan: ${{ inputs.clear-plan }}
           FULL_IMAGE_REF: ${{ steps.runner_setup.outputs.FULL_IMAGE_REF }}
         run: |
           clear_plan='false'
-          if [[ "$rechunk" == 'true' ]]; then
+          if [[ "$input_clear_plan" == 'true' ]]; then
+            clear_plan='true'
+          elif [[ "$rechunk" == 'true' ]]; then
             previous_build_created=$(skopeo inspect -n "docker://${FULL_IMAGE_REF}" 2>/dev/null | jq -cr '.Created' || echo "")
             if [[ -n "$previous_build_created" ]]; then
               # Clear previous layer plan only on the first build of each month.


### PR DESCRIPTION
Add an input to the `workflow_dispatch` trigger for the build workflow that forces the prior build's layer plan to be cleared. This is useful in case a build-chunked-oci bug is encountered that requires redoing the layer plan.