### PR TITLE
feat: manage ptrace access using SELinux

### DIFF
--- a/files/justfiles/common/toggles.just
+++ b/files/justfiles/common/toggles.just
@@ -76,43 +76,10 @@ toggle-debug-mode:
         rm /etc/systemd/user.conf.d/60-disable-coredump.conf
         echo "kernel.core_pattern = |/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h" >/etc/sysctl.d/99-enable-coredump.conf
         echo "Debug mode enabled."
-        if [[ $(</proc/sys/kernel/yama/ptrace_scope) != 1 ]]; then
-            echo "ptrace is restricted in this session. Some debuggers may not work as intended. Use ujust toggle-ptrace-scope to manage ptrace."
+        if [[ "$(getsebool deny_ptrace)" == *'--> on' ]]; then
+            setsebool deny_ptrace off
+            echo "Temporarily enabled ptrace for this session."
         fi
-    fi
-
-alias toggle-ptrace-scope := toggle-anticheat-support
-
-# Toggle anticheat support by changing ptrace scope (requires restart)
-toggle-anticheat-support:
-    #! /bin/run0 /bin/bash
-    set -euo pipefail
-    source /usr/lib/ujust/libformatting.sh
-    sysctl_ptrace_file='/etc/sysctl.d/61-ptrace-scope.conf'
-    umask 022
-    # Remove ptrace_scope = 3 from any lexicographically earlier sysctl conf files.
-    # This is because ptrace_scope = 3 cannot be overridden.
-    for conf_file in /etc/sysctl.d/*.conf; do
-        if [[ "$conf_file" < "$sysctl_ptrace_file" ]]; then
-            sed -i -e '/^kernel.yama.ptrace_scope[[:blank:]]*=[[:blank:]]*3/d' "$conf_file"
-        fi
-    done
-    # Set the ptrace_scope value we want in 61-ptrace-scope.conf
-    if grep -q '^kernel.yama.ptrace_scope[[:blank:]]*=[[:blank:]]*1$' "$sysctl_ptrace_file" 2>/dev/null; then
-        if rpm -q dangerzone > /dev/null; then
-            echo "${bold}WARNING${unbold} Dangerzone (https://dangerzone.rocks) is installed on this system and requires ptrace_scope set to 2 or lower to work."
-            echo 'This script disables Anticheat and sets ptrace_scope to 3 which will break Dangerzone.'
-            echo 'If you still want Dangerzone to work you can keep Anticheat enabled or edit /etc/sysctl.d/61-ptrace-scope.conf.'
-            read -r -p "Are you sure you would like to break Dangerzone by setting ptrace_scope to 3? [y/N] " user_choice
-            if [[ "$user_choice" != [yY]* ]]; then
-                exit
-            fi
-        fi
-        echo 'kernel.yama.ptrace_scope = 3' > "$sysctl_ptrace_file"
-        echo 'Anticheat support disabled. ptrace_scope set back to 3. Reboot to take effect.'
-    else
-        echo 'kernel.yama.ptrace_scope = 1' > "$sysctl_ptrace_file"
-        echo 'Anticheat support enabled. ptrace_scope set to 1. Reboot to take effect.'
     fi
 
 # Toggle bash environment lockdown (mitigates LD_PRELOAD attacks). Use skip_approval to bypass initial prompt, and apply_for_all_users to bypass secondary prompt.

--- a/files/justfiles/common/wrappers.just
+++ b/files/justfiles/common/wrappers.just
@@ -83,3 +83,11 @@ set-dhcp-hostname-sending *args:
 set-always-upgrade-on-boot *args:
     #!/bin/sh
     exec /usr/bin/python3 /usr/libexec/secureblue/set_always_upgrade_on_boot.py "$@"
+
+# Configure ptrace support (for anticheat, debugging tools, etc.)
+[positional-arguments]
+set-ptrace *args:
+    #!/bin/sh
+    exec /usr/bin/python3 /usr/libexec/secureblue/set_ptrace.py "$@"
+
+alias set-anticheat-support := set-ptrace

--- a/files/justfiles/desktop/steam.just
+++ b/files/justfiles/desktop/steam.just
@@ -55,7 +55,7 @@ install-steam:
             echo "Granting Steam necessary permissions for basic functionality, including access to X11 and PulseAudio." | fold -s
             echo "This will override the flatpak-permissions-lockdown command, or any other global overrides." | fold -s
             echo "Note that to use controllers, you must additionally grant device=input if it is globally denied." | fold -s
-            echo "Games with anti-cheats will likely require granting allow=devel alongside running ujust toggle-anticheat-support." | fold -s
+            echo "Games with anti-cheats will likely require granting allow=devel alongside running 'ujust set-ptrace on'." | fold -s
             flatpak override --user --share=network --share=ipc --socket=x11 --socket=pulseaudio --allow=multiarch --allow=per-app-dev-shm com.valvesoftware.Steam
             echo ""
             ;;
@@ -89,14 +89,13 @@ install-steam:
     fi
     echo "Remember: Steam requires 32-bit support; do not set the 'ia32_emulation=0' kernel argument."
 
-    if [[ $(</proc/sys/kernel/yama/ptrace_scope) != 1 ]]; then
-        echo "Some game anti-cheats require ptrace_scope set to 1."
-        echo "You can change your ptrace_scope setting by running 'ujust toggle-anticheat-support'."
-        toggle_anticheat=""
-        read -rp "Would you like to set ptrace_scope to 1 now? [y/N] " toggle_anticheat
-        if [[ "$toggle_anticheat" == [Yy]* ]]; then
-            ujust toggle-anticheat-support
-            need_reboot=true
+    if [[ $(ujust set-ptrace status) != *'ptrace is enabled' ]]; then
+        echo "Some game anti-cheats require the use of ptrace."
+        echo "You can enable ptrace support by running 'ujust set-ptrace on'."
+        enable_ptrace=""
+        read -rp "Would you like to enable ptrace support now? [y/N] " enable_ptrace
+        if [[ "$enable_ptrace" == [Yy]* ]]; then
+            ujust set-ptrace on
         fi
     fi
 

--- a/files/scripts/installselinuxpolicies.sh
+++ b/files/scripts/installselinuxpolicies.sh
@@ -14,6 +14,7 @@ policy_modules=(flatpakfull nautilus systemsettings thunar)
 
 cil_policy_modules=(
     './selinux/flatpakfull/grant_systemd_flatpak_exec.cil'
+    './selinux/ptrace/container-ptrace.cil'
     './selinux/sockets/secureblue_audit_sockets.cil'
     './selinux/sockets/secureblue_deny_alg_sockets.cil'
     './selinux/sockets/secureblue_deny_ipsec_sockets.cil'

--- a/files/scripts/selinux/ptrace/container-ptrace.cil
+++ b/files/scripts/selinux/ptrace/container-ptrace.cil
@@ -4,9 +4,7 @@
 
 (boolean container_allow_ptrace false)
 (booleanif container_allow_ptrace
-    (true
-        (allow container_domain self (process (ptrace)))
-        (allow container_runtime_domain self (process (ptrace)))
-        (allow spc_t self (process (ptrace)))
-    )
-)
+           (true
+             (allow container_domain self (process (ptrace)))
+             (allow container_runtime_domain self (process (ptrace)))
+             (allow spc_t self (process (ptrace)))))

--- a/files/scripts/selinux/ptrace/container-ptrace.cil
+++ b/files/scripts/selinux/ptrace/container-ptrace.cil
@@ -1,0 +1,12 @@
+; SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+;
+; SPDX-License-Identifier: Apache-2.0 OR MIT
+
+(boolean container_allow_ptrace false)
+(booleanif container_allow_ptrace
+    (true
+        (allow container_domain self (process (ptrace)))
+        (allow container_runtime_domain self (process (ptrace)))
+        (allow spc_t self (process (ptrace)))
+    )
+)

--- a/files/scripts/set-selinux-booleans.sh
+++ b/files/scripts/set-selinux-booleans.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+setsebool -P deny_ptrace=on container_allow_ptrace=off

--- a/files/system/etc/sysctl.d/61-ptrace-scope.conf
+++ b/files/system/etc/sysctl.d/61-ptrace-scope.conf
@@ -1,1 +1,0 @@
-kernel.yama.ptrace_scope = 3

--- a/files/system/usr/lib/sysctl.d/55-hardening.conf
+++ b/files/system/usr/lib/sysctl.d/55-hardening.conf
@@ -62,6 +62,16 @@ net.ipv4.conf.default.log_martians = 1
 # https://docs.kernel.org/admin-guide/sysctl/net.html#bpf-jit-harden
 net.core.bpf_jit_harden = 2
 
+# https://www.kernel.org/doc/html/latest/admin-guide/LSM/Yama.html
+#
+# Note: in addition to restricting ptrace using Yama, secureblue also restricts
+# ptrace access using SELinux. In particular, `ujust set-ptrace` offers three
+# possible states for ptrace access (independent of the value of `ptrace_scope`):
+# * enabled: no additional ptrace restrictions beyond those set by Yama.
+# * container-only: ptrace is only available to processes in the container domain.
+# * disabled: all processes are denied ptrace access.
+kernel.yama.ptrace_scope = 1
+
 # https://docs.kernel.org/admin-guide/sysctl/kernel.html#unprivileged-bpf-disabled
 kernel.unprivileged_bpf_disabled = 1
 

--- a/files/system/usr/lib/systemd/system-preset/40-secureblue.preset
+++ b/files/system/usr/lib/systemd/system-preset/40-secureblue.preset
@@ -12,6 +12,9 @@ enable secureblue-unbound-key.service
 # https://github.com/polkit-org/polkit/commit/c007940054392b67b84b6044dda8a215040d8eb5
 enable polkit-agent-helper.socket
 
+# TODO: remove this after sufficient time has passed
+enable secureblue-ptrace-migration.service
+
 disable flatpak-add-fedora-repos.service
 disable geoclue.service
 disable sshd-vsock.socket

--- a/files/system/usr/lib/systemd/system/secureblue-ptrace-migration.service
+++ b/files/system/usr/lib/systemd/system/secureblue-ptrace-migration.service
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This service exists to migrate users from secureblue's previous way of
+# restricting ptrace access only with Yama to the new way of using SELinux
+# booleans to manage ptrace access.
+#
+# TODO: remove this service after ISOs are rebuilt.
+
+[Unit]
+Description=Secureblue ptrace access management migration
+ConditionPathExists=!/var/lib/secureblue/secureblue-ptrace-migration.stamp
+After=multi-user.target
+Wants=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh /usr/libexec/secureblue/ptrace-migration.sh
+ExecStartPost=touch /var/lib/secureblue/secureblue-ptrace-migration.stamp
+
+[Install]
+WantedBy=multi-user.target

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -323,7 +323,9 @@ def audit_ptrace(state):
             rec = "\n".join(rec_lines)
         case PtraceStatus.RESTRICTED:
             status = WARN
-            note_text = _("ptrace is allowed, but restricted.")
+            note_text = _("ptrace is allowed, but restricted to child processes ({0}).").format(
+                "ptrace_scope = 1"
+            )
             note = Note(note_text, WARN)
             rec_lines = [
                 note_text,
@@ -335,7 +337,9 @@ def audit_ptrace(state):
             rec = "\n".join(rec_lines)
         case PtraceStatus.ADMIN_ONLY:
             status = INFO
-            note_text = _("ptrace access is restricted to administrative users.")
+            note_text = _("ptrace access is restricted to administrative users ({0}).").format(
+                "ptrace_scope = 2"
+            )
             note = Note(note_text, INFO)
             rec_lines = [
                 note_text,
@@ -347,12 +351,12 @@ def audit_ptrace(state):
             rec = "\n".join(rec_lines)
         case PtraceStatus.CONTAINER_ONLY:
             status = WARN if state["container_userns_enabled"] else INFO
-            note_text = _("Restricted ptrace access is allowed inside containers.")
+            note_text = _("ptrace on child processes ({0}) is allowed inside containers.").format(
+                "ptrace_scope = 1"
+            )
             note = Note(note_text, status)
             rec_lines = [
                 note_text,
-                _("For more info on what this means, see:"),
-                YAMA_DOC_URL,
                 _("To forbid ptrace, run:"),
                 "$ ujust set-ptrace off",
             ]

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -17,13 +17,11 @@ import glob
 import os
 import signal
 import stat
-
-# All subprocess calls we make have trusted inputs and do not use shell=True.
 import subprocess
 import sys
 import traceback
 from pathlib import Path
-from typing import Final
+from typing import Final, assert_never
 
 import kargs_hardening_common
 from audit_flatpak import check_flatpak_permissions, parse_flatpak_permissions
@@ -59,6 +57,7 @@ from utils import (
     parse_config,
     print_err,
 )
+from utils.ptrace import YAMA_DOC_URL, PtraceStatus, get_ptrace_status
 
 _: Final = gettext_marker()
 
@@ -207,55 +206,6 @@ def audit_modprobe(state):
 
 
 @audit
-def audit_ptrace(state):
-    """Ensure the ptrace syscall is forbidden."""
-    with open("/proc/sys/kernel/yama/ptrace_scope", encoding="utf-8") as f:
-        ptrace_scope = int(f.read())
-    match ptrace_scope:
-        case 3:
-            status = PASS
-            rec = None
-        case 2:
-            status = INFO
-            rec_lines = [
-                _("ptrace is allowed, but only for privileged users ({0}).").format(
-                    f"ptrace_scope = {ptrace_scope}"
-                ),
-                _("For more info on what this means, see:"),
-                "https://www.kernel.org/doc/html/latest/admin-guide/LSM/Yama.html",
-                _("To allow restricted ptrace, run:"),
-                "$ ujust toggle-ptrace-scope",
-                _("To forbid ptrace, run the above command twice."),
-            ]
-            rec = "\n".join(rec_lines)
-        case 0:
-            status = FAIL
-            rec_lines = [
-                _("ptrace is allowed and **unrestricted** ({0})!").format("ptrace_scope = 0"),
-                _("For more info on what this means, see:"),
-                "https://www.kernel.org/doc/html/latest/admin-guide/LSM/Yama.html",
-                _("To forbid ptrace, run:"),
-                "$ ujust toggle-ptrace-scope",
-                _("To allow restricted ptrace, run the above command twice."),
-            ]
-            rec = "\n".join(rec_lines)
-        case _:
-            status = WARN
-            rec_lines = [
-                _("ptrace is allowed, but restricted ({0}).").format(
-                    f"ptrace_scope = {ptrace_scope}"
-                ),
-                _("For more info on what this means, see:"),
-                "https://www.kernel.org/doc/html/latest/admin-guide/LSM/Yama.html",
-                _("To forbid ptrace, run:"),
-                "$ ujust toggle-ptrace-scope",
-            ]
-            rec = "\n".join(rec_lines)
-    state["ptrace_allowed"] = status != PASS
-    yield Report(_("Ensuring ptrace is forbidden"), status, recs=rec)
-
-
-@audit
 def audit_container_policy():
     """Check for modifications to container policy."""
     status = PASS
@@ -346,6 +296,71 @@ def audit_container_userns(state):
         ]
         recs = "\n".join(rec_lines)
     yield Report(_("Ensuring container user namespace creation disallowed"), status, recs=recs)
+
+
+@audit
+@depends_on("audit_container_userns")
+def audit_ptrace(state):
+    """Ensure ptrace is forbidden."""
+    ptrace_status = get_ptrace_status()
+    match ptrace_status:
+        case PtraceStatus.DISABLED:
+            status = PASS
+            note = None
+            rec = None
+        case PtraceStatus.UNRESTRICTED:
+            status = FAIL
+            note_text = _("ptrace is allowed and **unrestricted** ({0})!").format(
+                "ptrace_scope = 0"
+            )
+            note = Note(note_text, FAIL)
+            rec_lines = [
+                note_text,
+                _("For more info on what this means, see:"),
+                YAMA_DOC_URL,
+                _("Check the configuration in /etc/sysctl.d to fix this."),
+            ]
+            rec = "\n".join(rec_lines)
+        case PtraceStatus.RESTRICTED:
+            status = WARN
+            note_text = _("ptrace is allowed, but restricted.")
+            note = Note(note_text, WARN)
+            rec_lines = [
+                note_text,
+                _("For more info on what this means, see:"),
+                YAMA_DOC_URL,
+                _("To forbid ptrace, run:"),
+                "$ ujust set-ptrace off",
+            ]
+            rec = "\n".join(rec_lines)
+        case PtraceStatus.ADMIN_ONLY:
+            status = INFO
+            note_text = _("ptrace access is restricted to administrative users.")
+            note = Note(note_text, INFO)
+            rec_lines = [
+                note_text,
+                _("For more info on what this means, see:"),
+                YAMA_DOC_URL,
+                _("To forbid ptrace, run:"),
+                "$ ujust set-ptrace off",
+            ]
+            rec = "\n".join(rec_lines)
+        case PtraceStatus.CONTAINER_ONLY:
+            status = WARN if state["container_userns_enabled"] else INFO
+            note_text = _("Restricted ptrace access is allowed inside containers.")
+            note = Note(note_text, status)
+            rec_lines = [
+                note_text,
+                _("For more info on what this means, see:"),
+                YAMA_DOC_URL,
+                _("To forbid ptrace, run:"),
+                "$ ujust set-ptrace off",
+            ]
+            rec = "\n".join(rec_lines)
+        case unreachable:
+            assert_never(unreachable)
+    state["ptrace_allowed"] = status != PASS
+    yield Report(_("Ensuring ptrace is forbidden"), status, notes=note, recs=rec)
 
 
 @audit

--- a/files/system/usr/libexec/secureblue/inner/dangerzone.py
+++ b/files/system/usr/libexec/secureblue/inner/dangerzone.py
@@ -10,13 +10,11 @@ Privileged inner script to install Dangerzone.
 
 import configparser
 import json
-import re
 from typing import Final
 
 CONTAINERS_POLICY_PATH: Final[str] = "/etc/containers/policy.json"
 DZ_CONTAINER_PATH: Final[str] = "/usr/share/dangerzone/container.tar"
 DZ_REPO_PATH: Final[str] = "/etc/yum.repos.d/dangerzone.repo"
-PTRACE_CONF_PATH: Final[str] = "/etc/sysctl.d/61-ptrace-scope.conf"
 
 
 def enable_repo(path: str | bytes, name: str) -> None:
@@ -28,27 +26,6 @@ def enable_repo(path: str | bytes, name: str) -> None:
     config[name]["enabled"] = "1"
     with open(path, "w", encoding="utf8") as f:
         config.write(f)
-
-
-def set_ptrace_scope(path: str) -> None:
-    """Edit ptrace scope sysctl value in file."""
-    new_contents = b""
-    pattern = re.compile(rb"^kernel\.yama\.ptrace_scope\s*=\s*3")
-    ptrace_scope_line = b"kernel.yama.ptrace_scope = 2\n"
-    modified = False
-    try:
-        with open(path, "rb") as f:
-            for line in f:
-                if re.match(pattern, line):
-                    new_contents += ptrace_scope_line
-                    modified = True
-                else:
-                    new_contents += line
-    except FileNotFoundError:
-        return
-    if modified:
-        with open(path, "wb") as f:
-            f.write(new_contents)
 
 
 def set_container_policy() -> None:
@@ -66,8 +43,6 @@ def main() -> None:
     """Install Dangerzone."""
     print("Enabling Dangerzone repository...")
     enable_repo(DZ_REPO_PATH, "dangerzone")
-    print("Ensuring ptrace is allowed...")
-    set_ptrace_scope(PTRACE_CONF_PATH)
     print("Setting container policy to allow Dangerzone...")
     set_container_policy()
 

--- a/files/system/usr/libexec/secureblue/install_dangerzone.py
+++ b/files/system/usr/libexec/secureblue/install_dangerzone.py
@@ -13,14 +13,21 @@ import sys
 from typing import Final
 
 import sandbox
-from utils import ask_yes_no, print_wrapped
+from utils import ask_yes_no, get_selinux_booleans, print_wrapped
 
 WARNING_MESSAGE: Final[str] = """
 Warning: Dangerzone (https://dangerzone.rocks/) requires enabling both container-domain
-user namespace creation and (admin-only attach) ptrace. This is a security tradeoff, as
+user namespace creation and container-domain ptrace. This is a security tradeoff, as
 other programs on your system will also be able to use container tools such as podman
-and to use ptrace to inspect child processes.
+and to use ptrace to inspect child processes in containers.
 """
+
+
+def allow_container_ptrace() -> None:
+    """Ensure ptrace is allowed in containers."""
+    sebools = get_selinux_booleans("container_allow_ptrace", "deny_ptrace")
+    if "deny_ptrace" in sebools and "container_allow_ptrace" not in sebools:
+        subprocess.run(["/usr/bin/ujust", "set-ptrace", "container"], check=True)
 
 
 def main() -> int:
@@ -35,21 +42,20 @@ def main() -> int:
         read_write_paths=[
             "/etc/yum.repos.d/dangerzone.repo",
             "/etc/containers/policy.json",
-            "/etc/sysctl.d/61-ptrace-scope.conf",
         ],
-        capabilities=["CAP_DAC_OVERRIDE"],
     )
     exit_code = sandbox.run(inner_script)
     if exit_code != 0:
         return exit_code
-    print("Enabling container-domain user namespace creation...")
-    proc = subprocess.run(["/usr/bin/ujust", "set-container-userns", "on"], check=False)
-    if proc.returncode != 0:
-        return proc.returncode
-    print("Installing Dangerzone as layered package...")
-    proc = subprocess.run(["/usr/bin/rpm-ostree", "install", "dangerzone"], check=False)
-    if proc.returncode != 0:
-        return proc.returncode
+    try:
+        print("Enabling container-domain user namespace creation...")
+        subprocess.run(["/usr/bin/ujust", "set-container-userns", "on"], check=True)
+        print("Ensuring ptrace is allowed in containers...")
+        allow_container_ptrace()
+        print("Installing Dangerzone as layered package...")
+        subprocess.run(["/usr/bin/rpm-ostree", "install", "dangerzone"], check=True)
+    except subprocess.CalledProcessError:
+        return 1
     print("Reboot to complete the installation.")
     return 0
 

--- a/files/system/usr/libexec/secureblue/install_dangerzone.py
+++ b/files/system/usr/libexec/secureblue/install_dangerzone.py
@@ -13,7 +13,7 @@ import sys
 from typing import Final
 
 import sandbox
-from utils import ask_yes_no, get_selinux_booleans, print_wrapped
+from utils import ask_yes_no, print_wrapped
 
 WARNING_MESSAGE: Final[str] = """
 Warning: Dangerzone (https://dangerzone.rocks/) requires enabling both container-domain
@@ -21,13 +21,6 @@ user namespace creation and container-domain ptrace. This is a security tradeoff
 other programs on your system will also be able to use container tools such as podman
 and to use ptrace to inspect child processes in containers.
 """
-
-
-def allow_container_ptrace() -> None:
-    """Ensure ptrace is allowed in containers."""
-    sebools = get_selinux_booleans("container_allow_ptrace", "deny_ptrace")
-    if "deny_ptrace" in sebools and "container_allow_ptrace" not in sebools:
-        subprocess.run(["/usr/bin/ujust", "set-ptrace", "container"], check=True)
 
 
 def main() -> int:
@@ -51,7 +44,7 @@ def main() -> int:
         print("Enabling container-domain user namespace creation...")
         subprocess.run(["/usr/bin/ujust", "set-container-userns", "on"], check=True)
         print("Ensuring ptrace is allowed in containers...")
-        allow_container_ptrace()
+        subprocess.run(["/usr/bin/ujust", "set-ptrace", "container"], check=True)
         print("Installing Dangerzone as layered package...")
         subprocess.run(["/usr/bin/rpm-ostree", "install", "dangerzone"], check=True)
     except subprocess.CalledProcessError:

--- a/files/system/usr/libexec/secureblue/ptrace-migration.sh
+++ b/files/system/usr/libexec/secureblue/ptrace-migration.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+ptrace_scope=$(grep -oP '^kernel.yama.ptrace_scope\s*=\s*\K[0-9]+' /etc/sysctl.d/61-ptrace-scope.conf 2>/dev/null || echo 3)
+
+case "$ptrace_scope" in
+    0|1) ujust set-ptrace on ;;
+    2) ujust set-ptrace container ;;
+esac
+
+rm -f /etc/sysctl.d/61-ptrace-scope.conf

--- a/files/system/usr/libexec/secureblue/set_ptrace.py
+++ b/files/system/usr/libexec/secureblue/set_ptrace.py
@@ -1,0 +1,170 @@
+#!/usr/bin/python3
+
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configure ptrace support (for anticheat, debugging tools, etc.)"""
+
+import subprocess
+import sys
+from typing import Final, assert_never
+
+from utils import get_selinux_booleans, set_selinux_booleans
+from utils.ptrace import (
+    SEBOOL_CONTAINER_ALLOW_PTRACE,
+    SEBOOL_DENY_PTRACE,
+    YAMA_DOC_URL,
+    PtraceStatus,
+    get_ptrace_status,
+)
+
+HELP_MESSAGE: Final[str] = """\
+Configure ptrace support (for anticheat, debugging tools, etc.)
+
+usage:
+ujust set-ptrace
+    Configure ptrace support interactively.
+
+ujust set-ptrace on
+    Enable restricted ptrace: all processes can ptrace their child processes.
+
+ujust set-ptrace container
+    Enable restricted ptrace inside the container domain only.
+
+ujust set-ptrace off
+    Disable ptrace.
+
+ujust set-ptrace --help
+    Prints this message.
+"""
+
+
+def show_status() -> None:
+    """Show current ptrace status."""
+    match get_ptrace_status():
+        case PtraceStatus.DISABLED:
+            print("ptrace is disabled")
+        case PtraceStatus.ADMIN_ONLY:
+            print("ptrace is available only to administrative users")
+        case PtraceStatus.CONTAINER_ONLY:
+            print("Restricted ptrace is enabled inside containers only")
+        case PtraceStatus.RESTRICTED:
+            print("Restricted ptrace is enabled")
+        case PtraceStatus.UNRESTRICTED:
+            print("WARNING: Unrestricted ptrace is enabled!")
+        case unreachable:
+            assert_never(unreachable)
+
+
+def get_selection() -> str | None:
+    """Get user's selection of libvirt daemons, given current status."""
+    # This import is slow, so put it inside the function so it's only loaded if needed.
+    import inquirer  # noqa: PLC0415
+
+    print("(up/down to navigate, enter to confirm, Ctrl+C to cancel)")
+    try:
+        choice = inquirer.list_input(
+            "Set ptrace status", choices=["enabled", "container-only", "disabled"], carousel=True
+        )
+    except KeyboardInterrupt:
+        print("[canceled by user]")
+        return None
+    match choice:
+        case "enabled":
+            return "on"
+        case "container-only":
+            return "container"
+        case "disabled":
+            return "off"
+        case _:
+            raise ValueError("invalid selection")
+
+
+def check_ptrace_scope() -> None:
+    """Check for unexpected ptrace_scope values."""
+    with open("/proc/sys/kernel/yama/ptrace_scope", encoding="utf-8") as f:
+        ptrace_scope = int(f.read())
+    match ptrace_scope:
+        case 0:
+            print("WARNING: ptrace is unrestricted (kernel.yama.ptrace_scope = 0)")
+            print(YAMA_DOC_URL)
+        case 1:
+            pass
+        case 2:
+            print("Additional ptrace restrictions are configured (possibly in /etc/sysctl.d):")
+            print("kernel.yama.ptrace_scope is set to 2.")
+            print("This restricts the use of ptrace to administrative users only.")
+            print(YAMA_DOC_URL)
+        case 3:
+            print("Additional ptrace restrictions are configured (possibly in /etc/sysctl.d):")
+            print("kernel.yama.ptrace_scope is set to 3.")
+            print("This completely forbids the use of ptrace system-wide.")
+            print(YAMA_DOC_URL)
+        case _:
+            raise ValueError(f"invalid value '{ptrace_scope}' for ptrace_scope")
+
+
+def enable_ptrace() -> int:
+    """Enable (restricted) ptrace access."""
+    check_ptrace_scope()
+
+    if SEBOOL_DENY_PTRACE not in get_selinux_booleans(SEBOOL_DENY_PTRACE):
+        print("(Restricted) ptrace is already enabled.")
+        return 0
+
+    return set_selinux_booleans({SEBOOL_DENY_PTRACE: False}, perm=True)
+
+
+def set_container_ptrace() -> int:
+    """Enable (restricted) ptrace access in containers only."""
+    check_ptrace_scope()
+
+    sebools = get_selinux_booleans(SEBOOL_DENY_PTRACE, SEBOOL_CONTAINER_ALLOW_PTRACE)
+    if SEBOOL_DENY_PTRACE in sebools and SEBOOL_CONTAINER_ALLOW_PTRACE in sebools:
+        print("Container-only ptrace is already set.")
+        return 0
+
+    return set_selinux_booleans({SEBOOL_DENY_PTRACE: True, SEBOOL_CONTAINER_ALLOW_PTRACE: True})
+
+
+def disable_ptrace() -> int:
+    """Disable ptrace access."""
+    check_ptrace_scope()
+
+    sebools = get_selinux_booleans(SEBOOL_DENY_PTRACE, SEBOOL_CONTAINER_ALLOW_PTRACE)
+    if SEBOOL_DENY_PTRACE in sebools and SEBOOL_CONTAINER_ALLOW_PTRACE not in sebools:
+        print("ptrace is already disabled.")
+        return 0
+
+    return set_selinux_booleans({SEBOOL_DENY_PTRACE: True, SEBOOL_CONTAINER_ALLOW_PTRACE: False})
+
+
+def main() -> int:
+    """Handle the arguments and run the script."""
+    mode = sys.argv[1].casefold() if len(sys.argv) > 1 else get_selection()
+    try:
+        match mode:
+            case "help" | "-h" | "--help":
+                print(HELP_MESSAGE)
+            case "status":
+                show_status()
+            case "on":
+                return enable_ptrace()
+            case "container":
+                return set_container_ptrace()
+            case "off":
+                return disable_ptrace()
+            case None:
+                pass
+            case _:
+                print("Invalid argument. See usage with --help.", file=sys.stderr)
+                return 2
+    except subprocess.CalledProcessError:
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/files/system/usr/libexec/secureblue/set_ptrace.py
+++ b/files/system/usr/libexec/secureblue/set_ptrace.py
@@ -53,7 +53,7 @@ def show_status() -> None:
             print("Restricted ptrace is enabled")
         case PtraceStatus.UNRESTRICTED:
             print("WARNING: Unrestricted ptrace is enabled!")
-        case unreachable:
+        case _ as unreachable:
             assert_never(unreachable)
 
 
@@ -113,7 +113,7 @@ def enable_ptrace() -> int:
         print("(Restricted) ptrace is already enabled.")
         return 0
 
-    return set_selinux_booleans({SEBOOL_DENY_PTRACE: False}, perm=True)
+    return set_selinux_booleans({SEBOOL_DENY_PTRACE: False}, permanent=True)
 
 
 def set_container_ptrace() -> int:
@@ -147,23 +147,25 @@ def main() -> int:
         match mode:
             case "help" | "-h" | "--help":
                 print(HELP_MESSAGE)
+                exit_code = 0
             case "status":
                 show_status()
+                exit_code = 0
             case "on":
-                return enable_ptrace()
+                exit_code = enable_ptrace()
             case "container":
-                return set_container_ptrace()
+                exit_code = set_container_ptrace()
             case "off":
-                return disable_ptrace()
+                exit_code = disable_ptrace()
             case None:
-                pass
+                exit_code = 130  # SIGINT
             case _:
                 print("Invalid argument. See usage with --help.", file=sys.stderr)
-                return 2
+                exit_code = 2
     except subprocess.CalledProcessError:
-        return 1
+        exit_code = 1
 
-    return 0
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/files/system/usr/libexec/secureblue/set_ptrace.py
+++ b/files/system/usr/libexec/secureblue/set_ptrace.py
@@ -94,12 +94,12 @@ def check_ptrace_scope() -> None:
         case 2:
             print("Additional ptrace restrictions are configured (possibly in /etc/sysctl.d):")
             print("kernel.yama.ptrace_scope is set to 2.")
-            print("This restricts the use of ptrace to administrative users only.")
+            print("NOTE: This restricts the use of ptrace to administrative users only.")
             print(YAMA_DOC_URL)
         case 3:
             print("Additional ptrace restrictions are configured (possibly in /etc/sysctl.d):")
             print("kernel.yama.ptrace_scope is set to 3.")
-            print("This completely forbids the use of ptrace system-wide.")
+            print("NOTE: This completely forbids the use of ptrace system-wide.")
             print(YAMA_DOC_URL)
         case _:
             raise ValueError(f"invalid value '{ptrace_scope}' for ptrace_scope")
@@ -110,7 +110,7 @@ def enable_ptrace() -> int:
     check_ptrace_scope()
 
     if SEBOOL_DENY_PTRACE not in get_selinux_booleans(SEBOOL_DENY_PTRACE):
-        print("(Restricted) ptrace is already enabled.")
+        print("ptrace is already allowed by SELinux.")
         return 0
 
     return set_selinux_booleans({SEBOOL_DENY_PTRACE: False}, permanent=True)

--- a/files/system/usr/libexec/secureblue/utils/__init__.py
+++ b/files/system/usr/libexec/secureblue/utils/__init__.py
@@ -260,3 +260,20 @@ def ask_option(options_count: int) -> int:
                 print()
                 return option
         print(f"Please enter a number between 1 and {options_count}.")
+
+
+def get_selinux_booleans(*booleans: str) -> frozenset[str]:
+    """Get list of SELinux booleans and return the set of all of them that are true/on."""
+    output = command_stdout("/usr/bin/getsebool", *booleans)
+    split_lines = (line.split(" --> ", maxsplit=1) for line in output.splitlines())
+    return frozenset(key for key, value in split_lines if value == "on")
+
+
+def set_selinux_booleans(sebools: dict[str, bool], *, perm: bool = True) -> int:
+    """Set SELinux booleans"""
+    args = ["run0", "-i", "setsebool"]
+    if perm:
+        args.append("-P")
+    for key, value in sebools.items():
+        args.append(f"{key}={'on' if value else 'off'}")
+    return subprocess.run(args, check=False).returncode

--- a/files/system/usr/libexec/secureblue/utils/__init__.py
+++ b/files/system/usr/libexec/secureblue/utils/__init__.py
@@ -269,10 +269,10 @@ def get_selinux_booleans(*booleans: str) -> frozenset[str]:
     return frozenset(key for key, value in split_lines if value == "on")
 
 
-def set_selinux_booleans(sebools: dict[str, bool], *, perm: bool = True) -> int:
+def set_selinux_booleans(sebools: dict[str, bool], *, permanent: bool = True) -> int:
     """Set SELinux booleans"""
     args = ["run0", "-i", "setsebool"]
-    if perm:
+    if permanent:
         args.append("-P")
     for key, value in sebools.items():
         args.append(f"{key}={'on' if value else 'off'}")

--- a/files/system/usr/libexec/secureblue/utils/ptrace.py
+++ b/files/system/usr/libexec/secureblue/utils/ptrace.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python3
+
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Utility functions involving ptrace
+"""
+
+from enum import StrEnum
+from typing import Final
+
+from . import get_selinux_booleans
+
+SEBOOL_DENY_PTRACE: Final[str] = "deny_ptrace"
+SEBOOL_CONTAINER_ALLOW_PTRACE: Final[str] = "container_allow_ptrace"
+YAMA_DOC_URL: Final[str] = "https://www.kernel.org/doc/html/latest/admin-guide/LSM/Yama.html"
+
+
+class PtraceStatus(StrEnum):
+    """Representation of status of ptrace access on system"""
+
+    DISABLED = "disabled"
+    ADMIN_ONLY = "admin-only"
+    CONTAINER_ONLY = "container-only"
+    RESTRICTED = "restricted"
+    UNRESTRICTED = "unrestricted"
+
+
+def get_ptrace_status() -> PtraceStatus:
+    """Get current ptrace status on system."""
+    with open("/proc/sys/kernel/yama/ptrace_scope", encoding="utf-8") as f:
+        ptrace_scope = int(f.read())
+    sebools = get_selinux_booleans(SEBOOL_DENY_PTRACE, SEBOOL_CONTAINER_ALLOW_PTRACE)
+    ptrace_denied = SEBOOL_DENY_PTRACE in sebools
+    container_ptrace_allowed = SEBOOL_CONTAINER_ALLOW_PTRACE in sebools
+    match (ptrace_scope, ptrace_denied, container_ptrace_allowed):
+        case (0, _, _):
+            status = PtraceStatus.UNRESTRICTED
+        case (_, True, False) | (3, _, _):
+            status = PtraceStatus.DISABLED
+        case (2, False, _):
+            status = PtraceStatus.ADMIN_ONLY
+        case (1, False, _):
+            status = PtraceStatus.RESTRICTED
+        case (_, True, True):
+            status = PtraceStatus.CONTAINER_ONLY
+        case _ if ptrace_scope not in (0, 1, 2, 3):
+            raise ValueError(f"invalid value '{ptrace_scope}' for ptrace_scope")
+        case _:
+            raise RuntimeError("unreachable")
+    return status

--- a/recipes/common/selinux-modules.yml
+++ b/recipes/common/selinux-modules.yml
@@ -7,3 +7,4 @@ modules:
     source: ghcr.io/blue-build/modules@sha256:d0e85328fcfa4182c33d3920854001d0b7efbbd341ed6f45bc1ec26c0751889d
     scripts:
       - installselinuxpolicies.sh
+      - set-selinux-booleans.sh


### PR DESCRIPTION
Use SELinux in combination with Yama (instead of just Yama) to manage ptrace access in a more fine-grained way. See issue #2007 for more detailed discussion of the motivation for this change.

* Make `kernel.yama.ptrace_scope` default to 1 instead of 3.
* Enable the SELinux boolean `deny_ptrace` by default.
* Create a new SELinux boolean, `container_allow_ptrace`, that allows `container_domain` to use ptrace (irrespective of the `deny_ptrace` setting).
* Replace `ujust toggle-anticheat-support` (alias `ujust toggle-ptrace-scope`) with `ujust set-ptrace` (alias `ujust set-anticheat-support`). The new ujust script is written in Python, follows the usage conventions for other `ujust set-*` scripts, and allows selecting between three modes for ptrace access: on/enabled, container-only, and off/disabled.
* Make `ujust toggle-debug-mode` temporarily enable (restricted) ptrace for the session.
* Add a systemd service, `secureblue-ptrace-migration.service`, that automatically migrates users to the new SELinux-based ptrace controls: values of `kernel.yama.ptrace_scope` of 1, 2, or 3 will be respectively mapped to the ptrace modes "enabled", "container-only", and "disabled" (all with ptrace_scope = 1).
* Modify `ujust audit-secureblue`, `ujust install-dangerzone`, and `ujust install-steam` to take into account the new method of ptrace access management.

Resolves #2007.