### PR TITLE
ci: make update_po.py more robust

### DIFF
--- a/.github/workflows/update-modules.yml
+++ b/.github/workflows/update-modules.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          persist-credentials: true  # zizmor: ignore[artipacked]
+          persist-credentials: false
 
       - name: Get image metadata
         id: metadata

--- a/.github/workflows/update-po.yml
+++ b/.github/workflows/update-po.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          persist-credentials: true  # zizmor: ignore[artipacked]
+          persist-credentials: false
 
       - name: Update PO files
         shell: bash

--- a/files/po/update_po.py
+++ b/files/po/update_po.py
@@ -38,16 +38,17 @@ LOCALE: Final[str] = "en_US.UTF-8"
 # `msginit` requires this to be set to work properly.
 os.environ["LC_MESSAGES"] = LOCALE
 os.environ["LANG"] = LOCALE
-del os.environ["LANGUAGE"]
-del os.environ["LC_ALL"]
+os.environ.pop("LANGUAGE", None)
+os.environ.pop("LC_ALL", None)
 
 
 def command_stdout(*args: str) -> str:
     """Run a command in the shell and return the contents of stdout."""
-    return subprocess.run(args, check=True, capture_output=True, text=True).stdout.strip()
+    return subprocess.run(args, check=True, capture_output=True, text=True).stdout.rstrip("\n")
 
 
-os.chdir(os.path.dirname(sys.argv[0]))
+script_path = os.path.abspath(os.path.dirname(sys.argv[0]))
+os.chdir(script_path)
 git_root = command_stdout("git", "rev-parse", "--show-toplevel")
 os.chdir(git_root)
 


### PR DESCRIPTION
`update_po.py` should work even if certain localization-related environment variables aren't set. Also get rid of unnecessary `persist-credentials: true` in workflows.