### PR TITLE
fix(upstream): ensure rpm-ostreed conf is consistent

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-a*.yml linguist-detectable=true
+*.yml linguist-detectable=true
 *.yml linguist-language=YAML
 
 *.yaml linguist-detectable=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-*.yml linguist-detectable=true
+a*.yml linguist-detectable=true
 *.yml linguist-language=YAML
 
 *.yaml linguist-detectable=true

--- a/files/system/usr/lib/systemd/system-preset/40-secureblue.preset
+++ b/files/system/usr/lib/systemd/system-preset/40-secureblue.preset
@@ -8,7 +8,7 @@ enable fwupd-refresh.timer
 enable podman-auto-update.timer
 enable rpm-ostreed-automatic.timer
 enable secureblue-unbound-key.service
-enable seucreblue-rpm-ostreed-conf.service
+enable secureblue-rpm-ostreed-conf.service
 
 disable flatpak-add-fedora-repos.service
 disable geoclue.service

--- a/files/system/usr/lib/systemd/system-preset/40-secureblue.preset
+++ b/files/system/usr/lib/systemd/system-preset/40-secureblue.preset
@@ -8,6 +8,7 @@ enable fwupd-refresh.timer
 enable podman-auto-update.timer
 enable rpm-ostreed-automatic.timer
 enable secureblue-unbound-key.service
+enable seucreblue-rpm-ostreed-conf.service
 
 disable flatpak-add-fedora-repos.service
 disable geoclue.service

--- a/files/system/usr/lib/systemd/system/secureblue-rpm-ostreed-conf.service
+++ b/files/system/usr/lib/systemd/system/secureblue-rpm-ostreed-conf.service
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Works around an upstream packaging bug that mangles rpm-ostreed.conf 
+# if the rpm-ostree rpm package is layered locally
+
+[Unit]
+Description=Secureblue rpm-ostreed conf service
+ConditionPathExists=/etc/rpm-ostreed.conf
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/bash -c 'grep -q "Entries in this file show the compile time defaults." /etc/rpm-ostreed.conf'
+ExecStart=/usr/bin/cp /usr/etc/rpm-ostreed.conf /etc/rpm-ostreed.conf
+
+[Install]
+WantedBy=multi-user.target

--- a/files/system/usr/lib/systemd/system/secureblue-rpm-ostreed-conf.service
+++ b/files/system/usr/lib/systemd/system/secureblue-rpm-ostreed-conf.service
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -8,10 +8,12 @@
 [Unit]
 Description=Secureblue rpm-ostreed conf service
 ConditionPathExists=/etc/rpm-ostreed.conf
+Wants=multi-user.target
+After=multi-user.target
 
 [Service]
 Type=oneshot
-ExecStartPre=/bin/bash -c 'grep -q "Entries in this file show the compile time defaults." /etc/rpm-ostreed.conf'
+ExecCondition=/bin/bash -c 'grep -Fq "Entries in this file show the compile time defaults." /etc/rpm-ostreed.conf'
 ExecStart=/usr/bin/cp /usr/etc/rpm-ostreed.conf /etc/rpm-ostreed.conf
 
 [Install]


### PR DESCRIPTION
This is done only if an upstream packaging bug is present