### PR TITLE
fix: add ujust libformatting to toggle-ptrace-scope.

### DIFF
--- a/files/justfiles/common/toggles.just
+++ b/files/justfiles/common/toggles.just
@@ -106,6 +106,7 @@ alias toggle-ptrace-scope := toggle-anticheat-support
 toggle-anticheat-support:
     #! /bin/run0 /bin/bash
     set -euo pipefail
+    source /usr/lib/ujust/libformatting.sh
     sysctl_ptrace_file='/etc/sysctl.d/61-ptrace-scope.conf'
     umask 022
     # Remove ptrace_scope = 3 from any lexicographically earlier sysctl conf files.


### PR DESCRIPTION
The new toggle-anticheat-support warning when dangerzone is installed results in this error:
```
$ ujust toggle-anticheat-support 
/run/user/1000/just/just-dDfUHO/toggle-anticheat-support: line 121: bold: unbound variable
error: Recipe `toggle-anticheat-support` failed with exit code 1
```
Simple fix, `source /usr/lib/ujust/libformatting.sh` needed to be added.