### PR TITLE
ci: improve fork development

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -6,7 +6,7 @@ name: Cleanup Old Images
 permissions: {}
 on:
   schedule:
-    - cron: "15 0 * * 0" # 0015 UTC on Sundays
+    - cron: "15 0 * * 0" # 00:15 UTC on Sundays
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run integration tests
         uses: secureblue/bootc-integration-test-action@2236e712456801cd0bd47626733e95a180e38675 # v0.0.10
         with:
-          registry: ghcr.io/secureblue
+          registry: ghcr.io/${{ github.repository_owner }}
           image: silverblue-main-hardened
           token: ${{ secrets.GITHUB_TOKEN }}
           tests: |

--- a/.github/workflows/iso.yml
+++ b/.github/workflows/iso.yml
@@ -67,7 +67,7 @@ jobs:
           IMAGE_NAME: ${{ matrix.image }}
         with:
           arch: x86_64
-          image_name: ${{ env.IMAGE_NAME}}
+          image_name: ${{ env.IMAGE_NAME }}
           image_repo: ghcr.io/secureblue
           image_tag: latest
           version: 43

--- a/.github/workflows/shared-runner-setup/action.yml
+++ b/.github/workflows/shared-runner-setup/action.yml
@@ -56,16 +56,16 @@ runs:
           refs/pull/*) image_tag="pr-${PR_EVENT_NUMBER}-43" ;;
           *) image_tag="br-${GITHUB_REF_NAME}-43" ;;
         esac
-        FULL_IMAGE_REF="ghcr.io/secureblue/${IMAGE_NAME}:${image_tag}"
+        FULL_IMAGE_REF="ghcr.io/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${image_tag}"
         echo "FULL_IMAGE_REF=${FULL_IMAGE_REF}" >> "${GITHUB_OUTPUT}"
 
     - name: Install slsa-verifier
-      if: startsWith(steps.image_data.outputs.BASE_IMAGE, 'ghcr.io/secureblue/')
+      if: startsWith(steps.image_data.outputs.BASE_IMAGE, format('ghcr.io/{0}/', github.repository_owner))
       uses: slsa-framework/slsa-verifier/actions/installer@ea584f4502babc6f60d9bc799dbbb13c1caa9ee6 # v2.7.1
 
     - name: Verify base image provenance
       shell: bash
-      if: startsWith(steps.image_data.outputs.BASE_IMAGE, 'ghcr.io/secureblue/')
+      if: startsWith(steps.image_data.outputs.BASE_IMAGE, format('ghcr.io/{0}/', github.repository_owner))
       env:
         BASE_IMAGE_VERSION: ${{ steps.image_data.outputs.BASE_IMAGE_VERSION }}
         BASE_IMAGE: ${{ steps.image_data.outputs.BASE_IMAGE }}
@@ -81,11 +81,11 @@ runs:
         tar -zxvf go-containerregistry.tar.gz -C /usr/local/bin/ crane
 
         DIGEST=$(crane digest "${BASE_IMAGE}:${BASE_IMAGE_VERSION}")
-        slsa-verifier verify-image --source-uri 'github.com/secureblue/secureblue' "${BASE_IMAGE}:${BASE_IMAGE_VERSION}@${DIGEST}"
+        slsa-verifier verify-image --source-uri 'github.com/${GITHUB_REPOSITORY}' "${BASE_IMAGE}:${BASE_IMAGE_VERSION}@${DIGEST}"
 
     - name: Uninstall slsa-verifier
       shell: bash
-      if: startsWith(steps.image_data.outputs.BASE_IMAGE, 'ghcr.io/secureblue/')
+      if: startsWith(steps.image_data.outputs.BASE_IMAGE, format('ghcr.io/{0}/', github.repository_owner))
       run: |
         # remove slsa-verifier so that it can be successfully reinstalled later by bluebuild
         rm -rf ~/.slsa/
@@ -104,7 +104,7 @@ runs:
         BASE_IMAGE: ${{ steps.image_data.outputs.BASE_IMAGE }}
       run: |
         UPSTREAM_CONTAINER="${BASE_IMAGE}:${BASE_IMAGE_VERSION}"
-        if [[ "$BASE_IMAGE" == ghcr.io/secureblue/* ]]; then
+        if [[ "$BASE_IMAGE" == "ghcr.io/${GITHUB_REPOSITORY_OWNER}/"* ]]; then
           UPSTREAM_PUBKEY='./cosign.pub'
         else
           UPSTREAM_PUBKEY='./files/system/etc/pki/containers/quay.io-fedora-ostree-desktops.pub'

--- a/.github/workflows/shared-runner-setup/action.yml
+++ b/.github/workflows/shared-runner-setup/action.yml
@@ -81,7 +81,7 @@ runs:
         tar -zxvf go-containerregistry.tar.gz -C /usr/local/bin/ crane
 
         DIGEST=$(crane digest "${BASE_IMAGE}:${BASE_IMAGE_VERSION}")
-        slsa-verifier verify-image --source-uri 'github.com/${GITHUB_REPOSITORY}' "${BASE_IMAGE}:${BASE_IMAGE_VERSION}@${DIGEST}"
+        slsa-verifier verify-image --source-uri "github.com/${GITHUB_REPOSITORY}" "${BASE_IMAGE}:${BASE_IMAGE_VERSION}@${DIGEST}"
 
     - name: Uninstall slsa-verifier
       shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 cosign.key
+cosign.private
 *.kate-swp
 .directory
 Containerfile


### PR DESCRIPTION
It's mostly changes on the shared-runner-setup to remove hardcoded repository name, and some nitpicks in other files. This helps development by having less files to change when creating a fork to test.
This PR does not cover provenance.yml and iso.yml. I have tested on my fork but needs double check to make sure it works here.

It would be good if there's a way to globally define the owner user of the repo so they didn't have to change all the occurrences but i don't think it's possible?

I also plan to make a PR for secureblue.dev/contributing presenting a workflow for a easier development.