### PR TITLE
ci: fix a couple workflow issues

### DIFF
--- a/.github/workflows/shared-runner-setup/action.yml
+++ b/.github/workflows/shared-runner-setup/action.yml
@@ -56,7 +56,7 @@ runs:
           refs/pull/*) image_tag="pr-${PR_EVENT_NUMBER}-43" ;;
           *) image_tag="br-${GITHUB_REF_NAME}-43" ;;
         esac
-        FULL_IMAGE_REF="ghcr.io/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${image_tag}"
+        FULL_IMAGE_REF="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${IMAGE_NAME}:${image_tag}"
         echo "FULL_IMAGE_REF=${FULL_IMAGE_REF}" >> "${GITHUB_OUTPUT}"
 
     - name: Install slsa-verifier

--- a/.github/workflows/update-po.yml
+++ b/.github/workflows/update-po.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   update-po:
     name: Update PO files
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     permissions:
       contents: write  # needed to create branch
       pull-requests: write  # needed to create pull request


### PR DESCRIPTION
* update-po needs to run on a full runner, not `ubuntu-slim`, otherwise `msginit` fails with an error about it being a "language-indifferent environment" (setting env vars doesn't seem to fix this).
* `GITHUB_REPOSITORY_OWNER` needs to be lowercased in the image reference. This doesn't matter for the secureblue repo but can make part of the workflow fail on forks where the repository owner's username isn't all lowercase.