### PR TITLE
feat: automatically restore SELinux contexts on user fonts

### DIFF
--- a/files/system/desktop/usr/share/user-tmpfiles.d/fonts-fix-secontexts.conf
+++ b/files/system/desktop/usr/share/user-tmpfiles.d/fonts-fix-secontexts.conf
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Ensure user fonts are correctly labeled. This ensures that Trivalent's
+# SELinux policy permits loading the fonts.
+Z %h/.local/share/fonts


### PR DESCRIPTION
Trivalent's SELinux policy only permits loading fonts if they're correctly labeled, but user fonts can often end up mislabeled, for example if the user downloads them to a different location and then moves them into `~/.local/share/fonts`.