### PR TITLE
chore(deps): update BlueBuild modules

### DIFF
--- a/recipes/common/common-modules.yml
+++ b/recipes/common/common-modules.yml
@@ -4,7 +4,7 @@
 
 modules:
     - type: script
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       scripts:
         - addrepos.sh
         - createautostartdir.sh
@@ -16,7 +16,7 @@ modules:
         - pinrpmostree.sh
     - from-file: common/common-packages.yml
     - type: files
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       files:
         - source: system/usr
           destination: /usr
@@ -24,12 +24,12 @@ modules:
           destination: /etc
     - from-file: common/common-scripts.yml
     - type: justfiles
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       validate: true
       include:
         - common
     - type: script
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       scripts:
         - signkernel.sh
       secrets:

--- a/recipes/common/common-packages.yml
+++ b/recipes/common/common-packages.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 type: dnf
-source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
 install:
   install-weak-deps: false
   packages:

--- a/recipes/common/common-scripts.yml
+++ b/recipes/common/common-scripts.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 type: script
-source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
 scripts:
   - manuallyinstalljust.sh
   - hardenlogindefs.sh

--- a/recipes/common/cosmic-modules.yml
+++ b/recipes/common/cosmic-modules.yml
@@ -4,7 +4,7 @@
 
 modules:
     - type: dnf
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       install:
         install-weak-deps: false
         packages:
@@ -18,12 +18,12 @@ modules:
           - fedora-third-party
           - fedora-workstation-repositories
     - type: systemd
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       system:
         enabled:
           - cosmic-greeter
     - type: files
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       files:
         - source: system/cosmic
           destination: /

--- a/recipes/common/desktop-modules.yml
+++ b/recipes/common/desktop-modules.yml
@@ -4,14 +4,14 @@
 
 modules:
     - type: files
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       files:
         - source: system/desktop
           destination: /
     - from-file: common/desktop-packages.yml
     - from-file: common/desktop-scripts.yml
     - type: justfiles
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       validate: true
       include:
         - desktop

--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 type: dnf
-source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
 install:
   install-weak-deps: false
   packages:

--- a/recipes/common/desktop-scripts.yml
+++ b/recipes/common/desktop-scripts.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 type: script
-source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
 scripts:
   - install-trivalent.sh
   - installsubresourcefilter.sh

--- a/recipes/common/final-modules.yml
+++ b/recipes/common/final-modules.yml
@@ -4,7 +4,7 @@
 
 modules:
     - type: script
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       scripts:
         - addimageinfo.sh
         - removeunusedrepos.sh

--- a/recipes/common/kinoite-modules.yml
+++ b/recipes/common/kinoite-modules.yml
@@ -4,7 +4,7 @@
 
 modules:
   - type: dnf
-    source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+    source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
     remove:
       packages:
         - kde-connect
@@ -23,23 +23,23 @@ modules:
         - fedora-workstation-repositories
         - fedora-third-party
   - type: dnf
-    source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+    source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
     install:
       install-weak-deps: false
       packages:
         - krunner-bazaar
   - type: files
-    source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+    source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
     files:
       - source: system/kinoite
         destination: /
   - type: justfiles
-    source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+    source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
     validate: true
     include:
       - kinoite.just
   - type: script
-    source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+    source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
     scripts:
       - setdefaultkdewallpapers.sh
       - systemsettings-standard-malloc.sh

--- a/recipes/common/nvidia-install.yml
+++ b/recipes/common/nvidia-install.yml
@@ -4,12 +4,12 @@
 
 modules:
   - type: justfiles
-    source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+    source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
     validate: true
     include:
       - nvidia
   - type: script
-    source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+    source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
     scripts:
       - installnvidiakmod.sh
     secrets:
@@ -19,14 +19,14 @@ modules:
           type: file
           destination: /tmp/certs/private_key.priv
   - type: script
-    source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+    source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
     scripts:
       - installnvidiapackages.sh
       - removeunusedrepos.sh
       - setearlyloading.sh
       - setdrmvariables.sh
   - type: files
-    source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+    source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
     files:
       - source: system/nvidia
         destination: /

--- a/recipes/common/proprietary-modules.yml
+++ b/recipes/common/proprietary-modules.yml
@@ -4,7 +4,7 @@
 
 modules:
     - type: dnf
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       install:
         install-weak-deps: false
         packages:
@@ -14,7 +14,7 @@ modules:
           - pipewire-libs-extra
 
     - type: dnf
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       replace:
         - from-repo: fedora-multimedia
           skip-unavailable: true
@@ -34,7 +34,7 @@ modules:
             - intel-mediasdk
 
     - type: dnf
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       replace:
         - from-repo: fedora-multimedia
           skip-unavailable: true
@@ -63,6 +63,6 @@ modules:
               new: libswscale
 
     - type: script
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       scripts:
         - removeunusedrepos.sh

--- a/recipes/common/selinux-modules.yml
+++ b/recipes/common/selinux-modules.yml
@@ -4,6 +4,6 @@
 
 modules:
     - type: script
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       scripts:
         - installselinuxpolicies.sh

--- a/recipes/common/sericea-modules.yml
+++ b/recipes/common/sericea-modules.yml
@@ -4,16 +4,16 @@
 
 modules:
   - type: files
-    source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+    source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
     files:
       - source: system/sericea
         destination: /
   - type: script
-    source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+    source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
     scripts:
       - disablewlrportals.sh
   - type: dnf
-    source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+    source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
     remove:
       packages:
         - fedora-flathub-remote

--- a/recipes/common/server-modules.yml
+++ b/recipes/common/server-modules.yml
@@ -4,7 +4,7 @@
 
 modules:
   - type: dnf
-    source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+    source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
     install:
       install-weak-deps: false
       packages:
@@ -14,13 +14,13 @@ modules:
         - policycoreutils-python-utils
 
   - type: files
-    source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+    source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
     files:
       - source: system/server
         destination: /
 
   - type: script
-    source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+    source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
     scripts:
       - excludepcsc.sh
       - setserverdefaultzone.sh

--- a/recipes/common/silverblue-modules.yml
+++ b/recipes/common/silverblue-modules.yml
@@ -4,7 +4,7 @@
 
 modules:
     - type: dnf
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       install:
         install-weak-deps: false
         packages:
@@ -32,20 +32,20 @@ modules:
           - fedora-third-party
           - fedora-workstation-repositories
     - type: gschema-overrides
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       include:
         - zz1-secureblue.gschema.override
     - type: script
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       scripts:
         - removedkmshelper.sh
     - type: files
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       files:
         - source: system/silverblue
           destination: /
     - type: justfiles
-      source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+      source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
       validate: true
       include:
         - silverblue.just

--- a/recipes/common/zfs-modules.yml
+++ b/recipes/common/zfs-modules.yml
@@ -4,7 +4,7 @@
 
 modules:
   - type: script
-    source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+    source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
     scripts:
       - installzfskmod.sh
     secrets:
@@ -14,7 +14,7 @@ modules:
           type: file
           destination: /tmp/certs/private_key.priv
   - type: files
-    source: ghcr.io/blue-build/modules@sha256:23b9c9a2032ac653bf6a73a3b9372c12004211e004eea4269a8d3da9001c2301
+    source: ghcr.io/blue-build/modules@sha256:3d53ecab54b72f4853b02bb7b4f666cc704a32da8733420103dc154ba824ea9b
     files:
       - source: system/zfs
         destination: /


### PR DESCRIPTION
Automatically update BlueBuild modules to the SHA256 hash of the latest build of [blue-build/modules].

The following commits were made to blue-build/modules since the last update:

* `docs(soar): Document the current state of it, after its rewrite` (https://github.com/blue-build/modules/commit/6d6ec2bb857852bb7ceaab6090d07b22756588fc)
* `docs(soar): Fix code comment about bincache` (https://github.com/blue-build/modules/commit/6ad94a2663bebc00a0970f2d49ce26d2bda3cac5)
* `fix(soar): Architecture detection for `soar` installation` (https://github.com/blue-build/modules/commit/70780348e1e45e8fb72d2f9cea2575e8463f2c85)
* `fix(soar): Invalid repo names` (https://github.com/blue-build/modules/commit/e67746ffc1088eea741c581c323f07624afe3094)
* `fix(chezmoi): Correct command for enabling chezmoi services` (https://github.com/blue-build/modules/commit/2ebe6eeffd95922e84f31066e5172e915817e888)
* `fix: Fixes akmods for the new versions of NVIDIA drivers (#554)` (https://github.com/blue-build/modules/commit/6e37d690320db25fa0c6895e55c5614ab5779b14)

[blue-build/modules]: https://github.com/blue-build/modules/pkgs/container/modules
