### PR TITLE
feat: Mullvad VPN GUI no longer needs Xwayland

### DIFF
--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -233,7 +233,7 @@ install-vpn:
     # supported VPN providers and the security features they need disabled, separated by spaces
     declare -A vpn_providers=(
         ["ivpn"]="gui_needs_unconfined_userns gui_needs_xwayland"
-        ["mullvad"]="gui_needs_unconfined_userns gui_needs_xwayland"
+        ["mullvad"]="gui_needs_unconfined_userns"
         ["proton"]=""
         ["tailscale"]=""
     )


### PR DESCRIPTION
As of the latest release, the Mullvad VPN GUI uses Wayland by default, meaning Xwayland is no longer required to use it:
https://github.com/mullvad/mullvadvpn-app/releases/tag/2026.1