### PR TITLE
feat: prompt to give steam flatpak ptrace

### DIFF
--- a/files/justfiles/desktop/steam.just
+++ b/files/justfiles/desktop/steam.just
@@ -86,13 +86,13 @@ install-steam:
         echo "Reboot before running Steam."
         need_reboot=true
     fi
-    echo "Remember: Steam requires 32-bit support; do not set the 'ia32_emulation=0' kernel argument."
+    echo "Remember: Steam requires 32-bit support; do not set the 'ia32_emulation=0' kernel argument." | fold -s
     echo ""
 
     ptrace_scope=$(</proc/sys/kernel/yama/ptrace_scope)
     if (( "$ptrace_scope" > 1 )); then
-        echo "Games with strict anti-cheats, like Easy Anti-Cheat, require ptrace_scope set to 1."
-        echo "Your current ptrace_scope is ${ptrace_scope}, you can change this later by running 'ujust toggle-anticheat-support'."
+        echo "Games with strict anti-cheats, like Easy Anti-Cheat, require ptrace_scope set to 1." | fold -s
+        echo "Your current ptrace_scope is ${ptrace_scope}, you can change this later by running 'ujust toggle-anticheat-support'." | fold -s
         toggle_anticheat=""
         read -rp "Would you like to set ptrace_scope to 1 now? [y/N] " toggle_anticheat
         if [[ "$toggle_anticheat" == [Yy]* ]]; then
@@ -103,8 +103,8 @@ install-steam:
         fi
     elif (( "$method_selection" == 1 )); then
         # ptrace already 1, using flatpak
-        echo "Games with strict anti-cheats, like Easy Anti-Cheat, require Steam to have access to ptrace."
-        echo "Your ptrace_scope is ${ptrace_scope}, you can change this by running 'ujust toggle-anticheat-support'."
+        echo "Games with strict anti-cheats, like Easy Anti-Cheat, require Steam to have access to ptrace." | fold -s
+        echo "Your ptrace_scope is ${ptrace_scope}, you can change this by running 'ujust toggle-anticheat-support'." | fold -s
         read -rp "Would you like to give Steam access to ptrace now? [y/N] " toggle_anticheat
         if [[ "$toggle_anticheat" == [Yy]* ]]; then
             flatpak override --user --allow=devel com.valvesoftware.Steam

--- a/files/justfiles/desktop/steam.just
+++ b/files/justfiles/desktop/steam.just
@@ -6,6 +6,7 @@
 install-steam:
     #!/usr/bin/bash
     need_reboot=false
+    ptrace_scope=$(</proc/sys/kernel/yama/ptrace_scope)
     if [ -z "$(pgrep Xwayland)" ] && [ -z "$(pgrep Xorg)" ] ; then
         echo "Steam requires X or Xwayland, which your variant of secureblue has disabled by default." | fold -s
         echo "Please run 'ujust set-xwayland on' to re-enable it."
@@ -57,6 +58,20 @@ install-steam:
             echo "Note that to use controllers, you must additionally grant device=input if it is globally denied." | fold -s
             flatpak override --user --share=network --share=ipc --socket=x11 --socket=pulseaudio --allow=multiarch --allow=per-app-dev-shm com.valvesoftware.Steam
             echo ""
+
+            if (( "$ptrace_scope" <= 1 )); then
+                echo "Games with strict anti-cheats, like Easy Anti-Cheat, require Steam to have access to ptrace." | fold -s
+                echo "Your ptrace_scope is ${ptrace_scope}, you can change this by running 'ujust toggle-anticheat-support'." | fold -s
+                read -rp "Would you like to grant Steam the 'allow=devel' permission? [Y/n] " toggle_anticheat
+                toggle_anticheat=${toggle_anticheat:-y}
+                if [[ "$toggle_anticheat" == [Yy]* ]]; then
+                    flatpak override --user --allow=devel com.valvesoftware.Steam
+                fi
+                if [[ "$toggle_anticheat" == [Nn]* ]]; then
+                    flatpak override --user --disallow=devel com.valvesoftware.Steam
+                fi
+                echo "You can change this again later using Flatseal."
+            fi
             ;;
         2)
             echo "Distrobox method selected."
@@ -89,31 +104,17 @@ install-steam:
     echo "Remember: Steam requires 32-bit support; do not set the 'ia32_emulation=0' kernel argument." | fold -s
     echo ""
 
-    ptrace_scope=$(</proc/sys/kernel/yama/ptrace_scope)
     if (( "$ptrace_scope" > 1 )); then
         echo "Games with strict anti-cheats, like Easy Anti-Cheat, require ptrace_scope set to 1." | fold -s
-        echo "Your current ptrace_scope is ${ptrace_scope}, you can change this later by running 'ujust toggle-anticheat-support'." | fold -s
+        echo "Your current ptrace_scope is ${ptrace_scope}, you can change this by running 'ujust toggle-anticheat-support'." | fold -s
         toggle_anticheat=""
         read -rp "Would you like to set ptrace_scope to 1 now? [y/N] " toggle_anticheat
         if [[ "$toggle_anticheat" == [Yy]* ]]; then
             ujust toggle-anticheat-support
             need_reboot=true
-            # assume the user wants steam to have access, cause why else would they say yes
+            # assume the user wants the steam flatpak to have access, cause why else would they say yes
             (( "$method_selection" == 1 )) && flatpak override --user --allow=devel com.valvesoftware.Steam
         fi
-    elif (( "$method_selection" == 1 )); then
-        # ptrace already 1, using flatpak
-        echo "Games with strict anti-cheats, like Easy Anti-Cheat, require Steam to have access to ptrace." | fold -s
-        echo "Your ptrace_scope is ${ptrace_scope}, you can change this by running 'ujust toggle-anticheat-support'." | fold -s
-        read -rp "Would you like to grant Steam the 'allow=devel' permission? [Y/n] " toggle_anticheat
-        toggle_anticheat=${toggle_anticheat:-y}
-        if [[ "$toggle_anticheat" == [Yy]* ]]; then
-            flatpak override --user --allow=devel com.valvesoftware.Steam
-        fi
-        if [[ "$toggle_anticheat" == [Nn]* ]]; then
-            flatpak override --user --disallow=devel com.valvesoftware.Steam
-        fi
-        echo "You can change this again later using Flatseal."
     fi
 
     if [[ "$need_reboot" == true ]]; then

--- a/files/justfiles/desktop/steam.just
+++ b/files/justfiles/desktop/steam.just
@@ -20,7 +20,7 @@ install-steam:
     fi
     method_selection=""
     echo "Please select a method to install Steam:"
-    echo "    1) Flatpak - Install the Steam flatpak from flathub-unverified (Recommended for most users)" | fold -s
+    echo "    1) Flatpak - Install the Steam flatpak from flathub-unverified (Recommended for most users, including Monado/WiVRn users)" | fold -s
     echo "    2) Distrobox - Install Steam via the steambox (bazzite-arch) distrobox image (Recommended for SteamVR users)" | fold -s
     while true; do
         read -rp "Selection (1 or 2): " method_selection
@@ -55,7 +55,6 @@ install-steam:
             echo "Granting Steam necessary permissions for basic functionality, including access to X11 and PulseAudio." | fold -s
             echo "This will override the flatpak-permissions-lockdown command, or any other global overrides." | fold -s
             echo "Note that to use controllers, you must additionally grant device=input if it is globally denied." | fold -s
-            echo "Games with anti-cheats will likely require granting allow=devel alongside running ujust toggle-anticheat-support." | fold -s
             flatpak override --user --share=network --share=ipc --socket=x11 --socket=pulseaudio --allow=multiarch --allow=per-app-dev-shm com.valvesoftware.Steam
             echo ""
             ;;
@@ -88,15 +87,27 @@ install-steam:
         need_reboot=true
     fi
     echo "Remember: Steam requires 32-bit support; do not set the 'ia32_emulation=0' kernel argument."
+    echo ""
 
-    if [[ $(</proc/sys/kernel/yama/ptrace_scope) != 1 ]]; then
-        echo "Some game anti-cheats require ptrace_scope set to 1."
-        echo "You can change your ptrace_scope setting by running 'ujust toggle-anticheat-support'."
+    ptrace_scope=$(</proc/sys/kernel/yama/ptrace_scope)
+    if (( "$ptrace_scope" > 1 )); then
+        echo "Games with strict anti-cheats, like Easy Anti-Cheat, require ptrace_scope set to 1."
+        echo "Your current ptrace_scope is ${ptrace_scope}, you can change this later by running 'ujust toggle-anticheat-support'."
         toggle_anticheat=""
         read -rp "Would you like to set ptrace_scope to 1 now? [y/N] " toggle_anticheat
         if [[ "$toggle_anticheat" == [Yy]* ]]; then
             ujust toggle-anticheat-support
             need_reboot=true
+            # assume the user wants steam to have access, cause why else would they say yes
+            (( "$method_selection" == 1 )) && flatpak override --user --allow=devel com.valvesoftware.Steam
+        fi
+    elif (( "$method_selection" == 1 )); then
+        # ptrace already 1, using flatpak
+        echo "Games with strict anti-cheats, like Easy Anti-Cheat, require Steam to have access to ptrace."
+        echo "Your ptrace_scope is ${ptrace_scope}, you can change this by running 'ujust toggle-anticheat-support'."
+        read -rp "Would you like to give Steam access to ptrace now? [y/N] " toggle_anticheat
+        if [[ "$toggle_anticheat" == [Yy]* ]]; then
+            flatpak override --user --allow=devel com.valvesoftware.Steam
         fi
     fi
 

--- a/files/justfiles/desktop/steam.just
+++ b/files/justfiles/desktop/steam.just
@@ -61,7 +61,7 @@ install-steam:
 
             if (( "$ptrace_scope" <= 1 )); then
                 echo "Games with strict anti-cheats, like Easy Anti-Cheat, require Steam to have access to ptrace." | fold -s
-                echo "Your ptrace_scope is ${ptrace_scope}, you can change this by running 'ujust toggle-anticheat-support'." | fold -s
+                echo "Your ptrace_scope is already ${ptrace_scope}, you can change this by running 'ujust toggle-anticheat-support'." | fold -s
                 read -rp "Would you like to grant Steam the 'allow=devel' permission? [Y/n] " toggle_anticheat
                 toggle_anticheat=${toggle_anticheat:-y}
                 if [[ "$toggle_anticheat" == [Yy]* ]]; then

--- a/files/justfiles/desktop/steam.just
+++ b/files/justfiles/desktop/steam.just
@@ -105,13 +105,19 @@ install-steam:
         # ptrace already 1, using flatpak
         echo "Games with strict anti-cheats, like Easy Anti-Cheat, require Steam to have access to ptrace." | fold -s
         echo "Your ptrace_scope is ${ptrace_scope}, you can change this by running 'ujust toggle-anticheat-support'." | fold -s
-        read -rp "Would you like to give Steam access to ptrace now? [y/N] " toggle_anticheat
+        read -rp "Would you like to grant Steam the 'allow=devel' permission? [Y/n] " toggle_anticheat
+        toggle_anticheat=${toggle_anticheat:-y}
         if [[ "$toggle_anticheat" == [Yy]* ]]; then
             flatpak override --user --allow=devel com.valvesoftware.Steam
         fi
+        if [[ "$toggle_anticheat" == [Nn]* ]]; then
+            flatpak override --user --disallow=devel com.valvesoftware.Steam
+        fi
+        echo "You can change this again later using Flatseal."
     fi
 
     if [[ "$need_reboot" == true ]]; then
+        echo ""
         echo "One or more of the changes made necessitates a reboot."
         echo "Steam will not work until you reboot."
         reboot_now=""


### PR DESCRIPTION
Currently, `ujust install-steam` just tells the user to grant `allow=devel` later. Considering we ask later about loosening ptrace anyway, we might as well grant it then. If the ptrace scope is already satisfactory, then it will just ask if the user wants to grant the permission to Steam. Should address some concerns raised in #1842

As a side thing while I was here, I feel like just saying Distrobox is "recommended for SteamVR users" is a bit too ambiguous. As someone who plays VR and has many friends who do, actually using SteamVR is very uncommon, because it's a buggy janky mess that only really works for Vive or Valve Index owners. The majority of people use either Monado for wired headsets or WiVRn for wireless headsets, and in my experience they work perfectly fine with the flatpak. In fact, WiVRn has an [official flatpak](https://flathub.org/en/apps/io.github.wivrn.wivrn) itself!