### PR TITLE
chore: update BlueBuild CLI to v0.9.33

### DIFF
--- a/.github/workflows/build-one-recipe.yml
+++ b/.github/workflows/build-one-recipe.yml
@@ -218,7 +218,7 @@ jobs:
         env:
           KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
         with:
-          cli_version: v0.9.32
+          cli_version: v0.9.33
           recipe: ${{ inputs.recipe }}
           cosign_private_key: ${{ secrets.SIGNING_SECRET }}
           registry_token: ${{ github.token }}

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -190,7 +190,7 @@ jobs:
         env:
           KERNEL_PRIVKEY: ${{ steps.test_keys.outputs.kernel_privkey }}
         with:
-          cli_version: v0.9.32
+          cli_version: v0.9.33
           recipe: ${{ inputs.recipe }}
           push: false
           registry_token: ${{ github.token }}


### PR DESCRIPTION
Bump BlueBuild CLI version from v0.9.32 to v0.9.33.

Release notes: https://github.com/blue-build/cli/releases/tag/v0.9.33

This should fix the issue where users couldn't install packages using rpm-ostree that were uninstalled during the build process.