### PR TITLE
fix: verify ZFS signing key fingerprints

### DIFF
--- a/files/scripts/installzfskmod.sh
+++ b/files/scripts/installzfskmod.sh
@@ -25,10 +25,28 @@ curl -fLsS --retry 5 \
     -O "https://github.com/openzfs/zfs/releases/download/zfs-${ZFS_VERSION}/zfs-${ZFS_VERSION}.tar.gz.asc" \
     -O "https://github.com/openzfs/zfs/releases/download/zfs-${ZFS_VERSION}/zfs-${ZFS_VERSION}.sha256.asc"
 
-echo "Import key"
+echo "Importing ZFS signing keys"
 # https://openzfs.github.io/openzfs-docs/Project%20and%20Community/Signing%20Keys.html
-curl -fLsS --retry 5 "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xD4598027"| gpg --yes --import
-curl -fLsS --retry 5 "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xC6AF658B"| gpg --yes --import
+zfs_keys=(
+    '4F3BA9AB6D1F8D683DC2DFB56AD860EED4598027'
+    'C33DF142657ED1F7C328A2960AB9E991C6AF658B'
+)
+for key in "${zfs_keys[@]}"; do
+    curl -fLsS --retry 5 -o "${key}.asc" "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x${key}"
+    # Verify that the downloaded GPG key has the expected fingerprint before importing it.
+    # Reference for GPG colon-listing format: https://github.com/gpg/gnupg/blob/master/doc/DETAILS
+    if ! gpg --show-keys --with-colons "${key}.asc" \
+        | awk -F: '$1 == "fpr" || $1 == "fp2" { print $10 }' \
+        | grep -Fq "${key}"
+    then
+        echo "FATAL: Downloaded GPG key ${key}.asc does not have expected fingerprint!"
+        echo "Dumping keyfile contents:"
+        cat "${key}.asc"
+        exit 1
+    fi
+    gpg --yes --import "${key}.asc"
+    rm "${key}.asc"
+done
 
 echo "Verifying tar.gz signature"
 if ! gpg --verify "zfs-${ZFS_VERSION}.tar.gz.asc" "zfs-${ZFS_VERSION}.tar.gz"

--- a/tools/check_repo_keys.py
+++ b/tools/check_repo_keys.py
@@ -13,6 +13,7 @@ import json
 import os
 import subprocess
 import sys
+from collections.abc import Generator
 from typing import Final
 
 REPO_DATA_PATH: Final[str] = "tools/rpm-repo-sources.json"
@@ -47,10 +48,18 @@ def local_key_matches_remote_key(key_path: str, key_url: str) -> bool:
     return local_key == remote_key
 
 
+def gpg_key_fingerprints(key_path: str) -> Generator[str]:
+    """Yield fingerprints of GPG key at given path."""
+    # Reference for GPG colon-listing format: https://github.com/gpg/gnupg/blob/master/doc/DETAILS
+    gpg_output = command_stdout("gpg", "--show-keys", "--with-colons", key_path)
+    for line in gpg_output.splitlines():
+        if line.startswith(("fpr:", "fp2:")):
+            yield line.split(":")[9]
+
+
 def local_key_has_fingerprint(key_path: str, fingerprint: str) -> bool:
     """Check whether local GPG key has the specified fingerprint."""
-    gpg_output = command_stdout("gpg", "--show-keys", key_path)
-    return fingerprint in gpg_output
+    return any(fingerprint == fpr for fpr in gpg_key_fingerprints(key_path))
 
 
 def verify_repo_data(repo_path: str, key_path: str, key_url: str, fingerprint: str) -> bool:


### PR DESCRIPTION
Previously the ZFS signing keys were downloaded from the Ubuntu keyserver using a short fingerprint and imported without verifying the expected keys were the ones downloaded. Now we use the full GPG key fingerprints to download the keys, and verify that the downloaded keys have the expected fingerprints before importing them.

Also fix `check_repo_keys.py` to extract GPG fingerprints from the machine-readable GPG colon listing format rather than from a human- readable command output.