### PR TITLE
feat: reduce dependency on negativo

### DIFF
--- a/recipes/common/proprietary-modules.yml
+++ b/recipes/common/proprietary-modules.yml
@@ -8,10 +8,15 @@ modules:
       install:
         install-weak-deps: false
         packages:
-          - libopenjph
-          - heif-pixbuf-loader
           - ffmpegthumbnailer
           - pipewire-libs-extra
+          - intel-gmmlib
+          - intel-mediasdk
+          - libvpl
+          - intel-vpl-gpu-rt
+          - gstreamer1-plugin-libav
+          - libheif
+          - libva
 
     - type: dnf
       source: ghcr.io/blue-build/modules@sha256:079ae754f5b57e8f2ca5850b33a633b3fe1c37f4be51e7b00e9250a997f4e334
@@ -19,19 +24,14 @@ modules:
         - from-repo: fedora-multimedia
           skip-unavailable: true
           packages:
-            - libheif
-            - libva
+            - libva-intel-media-driver
             - mesa-dri-drivers
-            - gstreamer1-plugin-libav
             - mesa-filesystem
             - mesa-libEGL
             - mesa-libGL
             - mesa-libgbm
             - mesa-va-drivers
             - mesa-vulkan-drivers
-            - libva-intel-media-driver
-            - intel-gmmlib
-            - intel-mediasdk
 
     - type: dnf
       source: ghcr.io/blue-build/modules@sha256:079ae754f5b57e8f2ca5850b33a633b3fe1c37f4be51e7b00e9250a997f4e334
@@ -41,10 +41,6 @@ modules:
           packages:
             - old: ffmpeg-free
               new: ffmpeg
-            - old: fdk-aac-free
-              new: libfdk-aac
-            - old: gstreamer1-plugins-ugly-free
-              new: gstreamer1-plugins-ugly
             - old: libavcodec-free
               new: libavcodec
             - old: libavdevice-free

--- a/recipes/common/proprietary-modules.yml
+++ b/recipes/common/proprietary-modules.yml
@@ -10,13 +10,6 @@ modules:
         packages:
           - ffmpegthumbnailer
           - pipewire-libs-extra
-          - intel-gmmlib
-          - intel-mediasdk
-          - libvpl
-          - intel-vpl-gpu-rt
-          - gstreamer1-plugin-libav
-          - libheif
-          - libva
 
     - type: dnf
       source: ghcr.io/blue-build/modules@sha256:079ae754f5b57e8f2ca5850b33a633b3fe1c37f4be51e7b00e9250a997f4e334


### PR DESCRIPTION
- removes libopenjph, which is only used by relatively obscure image types and can be handled by flatpaks
- removing heif-pixbuf-loader in favor of flatpaks as well
- using fedora's intel-mediasdk -> not functionally the same but appears obsolete/replaced by libvpl, could be used via a distrobox
- using fedora's intel-gmmlib -> appears functionally the same
- using fedora's gstreamer1-plugin-libav -> appears functionally the same, wraps libavcodec which we're installing from negativo
- using fedora's gstreamer1-plugins-ugly -> not functionally the same, but impact is likely minimal. flatpaks render the -free version sufficient
- using fedora's libheif -> not functionally the same, impact is likely minimal
- fdk -> affects audio editing operations with AAC, patent encumbered versions can be used in a distrobox or flatpak