### PR TITLE
fix: allow chown syscall in brew setup script

### DIFF
--- a/files/system/desktop/usr/libexec/secureblue/brew_main.py
+++ b/files/system/desktop/usr/libexec/secureblue/brew_main.py
@@ -39,6 +39,7 @@ BREW_TOGGLE_FUNCTION: Final[sandbox.SandboxedFunction] = sandbox.SandboxedFuncti
     "brew.py",
     read_write_paths=["/home/linuxbrew", "/etc/tmpfiles.d", "/etc/profile.d"],
     capabilities=["CAP_CHOWN", "CAP_DAC_OVERRIDE"],
+    allowed_syscalls=["@chown"],
 )
 
 

--- a/files/system/usr/libexec/secureblue/dns_selector.py
+++ b/files/system/usr/libexec/secureblue/dns_selector.py
@@ -35,7 +35,7 @@ dns_function = sandbox.SandboxedFunction(
     "dns.py",
     read_write_paths=["/etc"],
     capabilities=["CAP_SYS_ADMIN", "CAP_DAC_OVERRIDE", "CAP_CHOWN", "CAP_FOWNER"],
-    additional_sandbox_properties=["--property=SystemCallFilter=@chown", "--background="],
+    allowed_syscalls=["@chown"],
 )
 
 


### PR DESCRIPTION
`ujust set-brew on` needs to change ownership of the brew installation from root to the main brew user, so the syscall filter has to allow the `chown` family of syscalls.

Also update DNS selector script to take advantage of improvements to the `SandboxedFunction` class.

This should fix #2098, though I've only tested it on x86-64, not aarch64 (but I don't see any reason for this to be architecture-dependent).