### PR TITLE
fix: update name of GNOME Shell service

### DIFF
--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -442,7 +442,7 @@ install-vpn:
 
         xwayland_enabled="0"
         if [[ "$DE" == "gnome" ]]; then
-            if ! test -e "/etc/systemd/user/org.gnome.Shell@wayland.service.d/override.conf"; then
+            if ! test -e "/etc/systemd/user/org.gnome.Shell@user.service.d/override.conf"; then
                 xwayland_enabled="1"
             fi
         elif [[ "$DE" == "plasma" ]]; then

--- a/files/system/desktop/usr/libexec/secureblue/set_xwayland.py
+++ b/files/system/desktop/usr/libexec/secureblue/set_xwayland.py
@@ -20,7 +20,7 @@ from utils import (
 )
 
 XWAYLAND_OVERRIDE_FILES: Final[dict[Image, str]] = {
-    Image.SILVERBLUE: "/etc/systemd/user/org.gnome.Shell@wayland.service.d/override.conf",
+    Image.SILVERBLUE: "/etc/systemd/user/org.gnome.Shell@user.service.d/override.conf",
     Image.KINOITE: "/etc/systemd/user/plasma-kwin_wayland.service.d/override.conf",
     Image.SERICEA: "/etc/sway/config.d/99-noxwayland.conf",
 }

--- a/files/system/silverblue/etc/systemd/user/org.gnome.Shell@user.service.d/override.conf
+++ b/files/system/silverblue/etc/systemd/user/org.gnome.Shell@user.service.d/override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/gnome-shell --mode=%i --no-x11

--- a/files/system/silverblue/etc/systemd/user/org.gnome.Shell@wayland.service.d/override.conf
+++ b/files/system/silverblue/etc/systemd/user/org.gnome.Shell@wayland.service.d/override.conf
@@ -1,3 +1,0 @@
-[Service]
-ExecStart=
-ExecStart=/usr/bin/gnome-shell --no-x11

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -789,7 +789,7 @@ def audit_xwayland(state):
     match state["image"]:
         case Image.SILVERBLUE:
             de = _("GNOME")
-            path = "/etc/systemd/user/org.gnome.Shell@wayland.service.d/override.conf"
+            path = "/etc/systemd/user/org.gnome.Shell@user.service.d/override.conf"
         case Image.KINOITE:
             de = _("KDE Plasma")
             path = "/etc/systemd/user/plasma-kwin_wayland.service.d/override.conf"


### PR DESCRIPTION
In GNOME 50, the service name is `org.gnome.Shell@user.service`, not `org.gnome.Shell@wayland.service`. The `Exec=` line in the service file also has `--mode=%i` now, which we should preserve in the override file.