### PR TITLE
feat: MTP support parity on desktop images

### DIFF
--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -46,6 +46,10 @@ install:
     - virt-manager
     - virt-viewer
 
+    # ensure MTP support parity
+    - libmtp
+    - gvfs-mtp
+
 remove:
   packages:
     - firefox


### PR DESCRIPTION
Rationale: the base images omit these sometimes. At the very least Silverblue supports this out of the box, which sets user expectation they'll be able to mount modern Android smartphones via USB on any image. I haven't checked Kinoite, but this likely works out of the box there as well. COSMIC includes `libmtp` but not `gvfs-mtp`. Sericea omits both.