### PR TITLE
chore: add com.opera.opera-gx to Bazaar blocklist

### DIFF
--- a/files/system/desktop/usr/share/bazaar/blocklist.yaml
+++ b/files/system/desktop/usr/share/bazaar/blocklist.yaml
@@ -13,6 +13,7 @@ blocklists:
       - com.google.ChromeDev
       - com.microsoft.Edge
       - com.opera.Opera
+      - com.opera.opera-gx
       - com.vivaldi.Vivaldi
       - org.chromium.Chromium
 


### PR DESCRIPTION
Not very secure to use Chromium 129 over current 147 either way