### PR TITLE
chore: Add Ecosia to the Bazaar blocklist

### DIFF
--- a/files/system/desktop/usr/share/bazaar/blocklist.yaml
+++ b/files/system/desktop/usr/share/bazaar/blocklist.yaml
@@ -4,11 +4,11 @@ blocklists:
       # Verified Chromium-based browsers.
       - com.brave.Browser
       - com.jiosphere.JioSphere
+      - com.opera.opera-gx
       - io.github.ungoogled_software.ungoogled_chromium
+      - org.ecosia.Browser
       - org.kde.falkon
       - ru.yandex.Browser
-      - com.opera.opera-gx
-      - org.ecosia.Browser
 
       # Unverified Chromium-based browsers.
       - com.google.Chrome

--- a/files/system/desktop/usr/share/bazaar/blocklist.yaml
+++ b/files/system/desktop/usr/share/bazaar/blocklist.yaml
@@ -7,13 +7,14 @@ blocklists:
       - io.github.ungoogled_software.ungoogled_chromium
       - org.kde.falkon
       - ru.yandex.Browser
+      - com.opera.opera-gx
+      - org.ecosia.Browser
 
       # Unverified Chromium-based browsers.
       - com.google.Chrome
       - com.google.ChromeDev
       - com.microsoft.Edge
       - com.opera.Opera
-      - com.opera.opera-gx
       - com.vivaldi.Vivaldi
       - org.chromium.Chromium
 


### PR DESCRIPTION
I also moved operagx from the unverified chromium browsers group to the verified chromium browsers group

https://flathub.org/en/apps/com.opera.opera-gx#:~:text=by%20Opera-,opera.com,-Install