### PR TITLE
fix: do not exit upgrade-on-boot service if --check returns 1

### DIFF
--- a/files/system/desktop/usr/libexec/secureblue/upgrade-on-boot
+++ b/files/system/desktop/usr/libexec/secureblue/upgrade-on-boot
@@ -17,7 +17,7 @@ UPDATE_FAILURE_STRING="Update failed, booting existing deployment..."
 CANCEL_STRING="Press Q to cancel and boot the existing deployment."
 
 plymouth watch-keystroke --keys="qQ" --command "systemctl stop upgrade-on-boot.service" &
-BOOTC_UPGRADE_CHECK_OUTPUT="$(bootc upgrade --check 2>&1)"
+BOOTC_UPGRADE_CHECK_OUTPUT="$(bootc upgrade --check 2>&1)" || true
 
 if grep -q "local rpm-ostree modifications" <<< "$BOOTC_UPGRADE_CHECK_OUTPUT"; then
     echo "Using rpm-ostree"


### PR DESCRIPTION
We want to handle error cases ourselves, for example the case just below this line: "local rpm-ostree modifications"