### PR TITLE
fix: gap in userns restrictions

### DIFF
--- a/files/scripts/selinux/user_namespace/harden_userns.cil
+++ b/files/scripts/selinux/user_namespace/harden_userns.cil
@@ -3,7 +3,7 @@
 ;; SPDX-License-Identifier: Apache-2.0 OR MIT
 
 (typeattribute userns_privileged_domain)
-(typeattributeset userns_privileged_domain (init_t initrc_t install_t kernel_t))
+(typeattributeset userns_privileged_domain (init_t install_t kernel_t))
 (optional colord_userns_privileged_domain
     (typeattributeset userns_privileged_domain (colord_t))
 )

--- a/files/scripts/selinux/user_namespace/userns_deny_unconfined_relabels.cil
+++ b/files/scripts/selinux/user_namespace/userns_deny_unconfined_relabels.cil
@@ -26,7 +26,11 @@
 )
 
 (typeattribute userns_relabel_allowed)
-(typeattributeset userns_relabel_allowed (init_t initrc_t install_t kernel_t))
+(typeattributeset userns_relabel_allowed (init_t kernel_t))
+(optional install_userns_relabel_allowed
+    (typeattributeset userns_privileged_file_type (install_exec_t))
+    (typeattributeset userns_relabel_allowed (install_t))
+)
 
 (typeattribute userns_relabel_restricted)
 (typeattributeset userns_relabel_restricted (and (domain) (not (userns_relabel_allowed))))


### PR DESCRIPTION
* Remove `initrc_t` from list of userns-privileged domains: it's not needed for system functionality (e.g. installing/updating) and there are lots of domains that transition to `initrc_t`.
* Add `install_exec_t` to list of userns-privileged file types to prevent circumventing userns restrictions.