### PR TITLE
chore: only suggest brew in motd if it is available

### DIFF
--- a/files/system/usr/libexec/secureblue-motd
+++ b/files/system/usr/libexec/secureblue-motd
@@ -52,8 +52,10 @@ cat << EOF
   ───────────────────────────────┼────────────────────────────────────────────
    ${slight_red} ujust --choose ${reset}              │ List all available commands
    ${slight_red} ujust toggle-user-motd ${reset}      │ Toggle this banner on/off
-   ${slight_red} brew help ${reset}                   │ Manage command line packages
 EOF
+if command -v brew >/dev/null 2>&1; then
+    echo "   ${slight_red} brew help ${reset}                   │ Manage command line packages"
+fi
 if [[ -n "$tip" ]]; then
     echo
     echo -e "  ${tip}"


### PR DESCRIPTION
Avoids suggesting brew on environments where it is not available, e.g. if the user uninstalled it, or on securecore.