### PR TITLE
fix: work around dnf5 bug by leaving lockfile intact

### DIFF
--- a/files/scripts/libdnf5-clear-history.sh
+++ b/files/scripts/libdnf5-clear-history.sh
@@ -5,10 +5,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
+shopt -s nullglob
 
 # dnf transaction history is a source of non-reproducibility between builds.
-# The upstream base images also leave this directory empty.
+# The upstream base images leave this directory entirely empty. We avoid
+# deleting the lockfile because that currently triggers a bug in dnf5:
+# https://github.com/rpm-software-management/dnf5/issues/2709
+#
 # Note: this causes `dnf history list` and similar commands to fail. That isn't
 # a useful command anyway right now, but at some point in the future, if dnf
 # adds support for local layering, we will probably need to remove this.
-find /usr/lib/sysimage/libdnf5 -mindepth 1 -delete
+rm -f /usr/lib/sysimage/libdnf5/{*.toml,transaction_history.sqlite*}


### PR DESCRIPTION
We still delete the dnf metadata and transaction history since those are the sources of non-reproducibility (and this matches what upstream does). Leaving the lockfile alone is a workaround for a dnf5 bug on systems where /usr is read-only; this gets `dnf info`, `dnf search`, and so on working again.