### PR TITLE
fix: add qemu user workaround for gnome-boxes flatpak

### DIFF
--- a/files/system/desktop/usr/share/user-tmpfiles.d/qemu-core-dumps.conf
+++ b/files/system/desktop/usr/share/user-tmpfiles.d/qemu-core-dumps.conf
@@ -6,3 +6,6 @@
 # https://github.com/secureblue/secureblue/issues/1054
 d %h/.config/libvirt            0700 - - -
 f %h/.config/libvirt/qemu.conf  0600 - - - max_core = 0\n
+
+d %h/.var/app/org.gnome.Boxes/config/libvirt            0700 - - -
+f %h/.var/app/org.gnome.Boxes/config/libvirt/qemu.conf  0600 - - - max_core = 0\n


### PR DESCRIPTION
Fix #1054 again but for gnome-boxes flatpak