### PR TITLE
feat: linuxbrew-owned brew installation, install brew-proxy

### DIFF
--- a/files/system/desktop/usr/lib/systemd/system-preset/35-secureblue-desktop.preset
+++ b/files/system/desktop/usr/lib/systemd/system-preset/35-secureblue-desktop.preset
@@ -1,5 +1,11 @@
 enable flatpak-system-update.timer
 
+# Homebrew
+enable brew-proxy-setup.service
+enable brew-update.timer
+enable brew-upgrade.timer
+enable secureblue-brew-proxy-migration.service
+
 # Disable NFS daemons
 disable gssproxy.service
 disable nfs-blkmap.service

--- a/files/system/desktop/usr/lib/systemd/system/secureblue-brew-proxy-migration.service
+++ b/files/system/desktop/usr/lib/systemd/system/secureblue-brew-proxy-migration.service
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[Unit]
+Description=Migration service to new Homebrew setup with brew-proxy
+Wants=multi-user.target
+After=multi-user.target
+ConditionPathExists=!/var/lib/secureblue/secureblue-brew-proxy-migration.stamp
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/secureblue/brew-proxy-migration
+ExecStartPost=touch /var/lib/secureblue/secureblue-brew-proxy-migration.stamp
+
+[Install]
+WantedBy=multi-user.target

--- a/files/system/desktop/usr/lib/systemd/user-preset/35-secureblue-desktop.preset
+++ b/files/system/desktop/usr/lib/systemd/user-preset/35-secureblue-desktop.preset
@@ -8,7 +8,3 @@ enable secureblue-flatpak-setup.timer
 enable secureblue-key-enrollment-verification.timer
 enable secureblue-update-verification.timer
 enable security-update-notification.path
-
-# Homebrew
-enable brew-update.timer
-enable brew-upgrade.timer

--- a/files/system/desktop/usr/libexec/secureblue/brew-proxy-migration
+++ b/files/system/desktop/usr/libexec/secureblue/brew-proxy-migration
@@ -1,0 +1,18 @@
+#!/usr/bin/bash
+
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# Add brewadmin group to /etc/group if not already present.
+# This is a workaround for the issue documented here:
+# https://docs.fedoraproject.org/en-US/atomic-desktops/troubleshooting/#_unable_to_add_user_to_group
+flock /etc/group -c 'grep -q "^brewadmin:" /etc/group || getent group brewadmin >> /etc/group || groupadd -r brewadmin'
+
+# Add user with UID 1000 (if it exists) to brewadmin group. This means that the
+# user who was previously the owner of the Homebrew installation will be allowed
+# to run brew maintenance commands via brew-proxy without authentication.
+user="$(getent passwd 1000 | cut -d: -f1)" || exit 0
+gpasswd -a "${user}" brewadmin

--- a/files/system/desktop/usr/libexec/secureblue/brew_main.py
+++ b/files/system/desktop/usr/libexec/secureblue/brew_main.py
@@ -21,9 +21,9 @@ ToggleMode: Final = utils.ToggleMode
 parse_basic_toggle_args: Final = utils.parse_basic_toggle_args
 
 BREW_HELP: Final[str] = """
-This python script toggles if Homebrew is enabled by enabling or
-disabling its tmpfiles.d configuration, removing or replacing the
-brew.sh profile.d file, and removing the .linuxbrew directory.
+This python script toggles if Homebrew is enabled. When Homebrew is
+disabled, the Homebrew installation in /home/linuxbrew/.linuxbrew is not
+deleted, but just made inaccessible to unprivileged users.
 
 usage:
 ujust set-brew
@@ -45,7 +45,7 @@ ujust set-brew --help
 BREW_TOGGLE_FUNCTION: Final[sandbox.SandboxedFunction] = sandbox.SandboxedFunction(
     "brew.py",
     read_write_paths=["/home/linuxbrew", "/etc/tmpfiles.d", "/etc/profile.d"],
-    capabilities=["CAP_CHOWN", "CAP_DAC_OVERRIDE"],
+    capabilities=["CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FOWNER"],
     allowed_syscalls=["@chown"],
     remove_sandbox_arguments=["--property=ProcSubset="],  # needed for systemd-tmpfiles
 )

--- a/files/system/desktop/usr/libexec/secureblue/inner/brew.py
+++ b/files/system/desktop/usr/libexec/secureblue/inner/brew.py
@@ -15,22 +15,23 @@ import subprocess
 import sys
 from typing import Final
 
+LINUXBREW_HOME: Final[str] = "/home/linuxbrew"
 TMPFILES_OVERRIDE: Final[str] = "/etc/tmpfiles.d/homebrew.conf"
-LINUXBREW_DIR: Final[str] = "/home/linuxbrew/.linuxbrew"
-BREW_CACHE_DIR: Final[str] = "/home/linuxbrew/.cache"
 BREW_PROFILE_FILE: Final[str] = "/etc/profile.d/brew.sh"
 BREW_PROFILE_COMPLETIONS_FILE: Final[str] = "/etc/profile.d/brew-bash-completions.sh"
+BREW_PROXY_SERVICE: Final[str] = "brew-proxy-daemon.service"
 
 
 def enable_brew() -> None:
     """Enable Homebrew."""
     with contextlib.suppress(FileNotFoundError):
         os.remove(TMPFILES_OVERRIDE)
+    subprocess.run(
+        ["/usr/bin/systemd-tmpfiles", "--create", f"--prefix={LINUXBREW_HOME}"], check=True
+    )
     shutil.copy2(f"/usr{BREW_PROFILE_FILE}", BREW_PROFILE_FILE)
     shutil.copy2(f"/usr{BREW_PROFILE_COMPLETIONS_FILE}", BREW_PROFILE_COMPLETIONS_FILE)
-    subprocess.run(
-        ["/usr/bin/systemd-tmpfiles", "--create", "--prefix=/home/linuxbrew"], check=True
-    )
+    subprocess.run(["/usr/bin/systemctl", "unmask", BREW_PROXY_SERVICE], check=True)
 
 
 def disable_brew() -> None:
@@ -38,13 +39,12 @@ def disable_brew() -> None:
     with contextlib.suppress(FileExistsError):
         os.symlink("/dev/null", TMPFILES_OVERRIDE)
     with contextlib.suppress(FileNotFoundError):
-        shutil.rmtree(LINUXBREW_DIR)
-    with contextlib.suppress(FileNotFoundError):
-        shutil.rmtree(BREW_CACHE_DIR)
+        os.chmod(LINUXBREW_HOME, 0o700)
     with contextlib.suppress(FileNotFoundError):
         os.remove(BREW_PROFILE_FILE)
     with contextlib.suppress(FileNotFoundError):
         os.remove(BREW_PROFILE_COMPLETIONS_FILE)
+    subprocess.run(["/usr/bin/systemctl", "mask", "--now", BREW_PROXY_SERVICE], check=True)
 
 
 def main() -> int:

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -718,11 +718,11 @@ def audit_brew_auto_update():
     for unit in ("brew-update", "brew-upgrade"):
         timer = f"{unit}.timer"
         service = f"{unit}.service"
-        if not command_succeeds("systemctl", "--global", "is-enabled", "--quiet", timer):
+        if not command_succeeds("systemctl", "is-enabled", "--quiet", timer):
             status = FAIL
             disabled_timers.append(timer)
             notes.append(Note(_("{0} is not enabled.").format(timer), FAIL))
-        elif command_succeeds("systemctl", "--user", "is-failed", "--quiet", service):
+        elif command_succeeds("systemctl", "is-failed", "--quiet", service):
             status = status.downgrade_to(WARN)
             notes.append(Note(_("{0} has failed to run.").format(service), WARN))
 
@@ -731,7 +731,7 @@ def audit_brew_auto_update():
             (
                 _("Automatic updates for Homebrew are not enabled."),
                 _("To enable them, run:"),
-                f"$ systemctl enable --global --now {' '.join(disabled_timers)}",
+                f"$ systemctl enable --now {' '.join(disabled_timers)}",
             )
         )
 
@@ -762,7 +762,7 @@ def audit_groups():
     yield Report(_("Ensuring user is not a member of the wheel group"), status, recs=rec)
 
     username = getpass.getuser()
-    known_groups = (username, "usbguard", "wheel")
+    known_groups = (username, "brewadmin", "usbguard", "wheel")
     dangerous_groups = ("docker", "libvirt")
     status = PASS
     notes = []
@@ -790,6 +790,17 @@ def audit_groups():
                 note.text,
                 _("This group allows the user to read system and kernel logs."),
                 _("This might make it easier to exploit kernel vulnerabilities."),
+                _("To remove the user from this group, run:"),
+                remove_group_cmd,
+            ]
+            recs.append("\n".join(rec_lines))
+        elif group == "linuxbrew":
+            status = status.downgrade_to(WARN)
+            note = Note(_("The current user is in the group '{0}'.").format(group), WARN)
+            notes.append(note)
+            rec_lines = [
+                note.text,
+                _("This group allows the user to modify the Homebrew installation."),
                 _("To remove the user from this group, run:"),
                 remove_group_cmd,
             ]

--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -20,6 +20,7 @@ install:
     - fzf
     - bazaar
     - homebrew
+    - brew-proxy
     - firewall-config
 
     # yubikey enablement


### PR DESCRIPTION
* Switch to Homebrew installation owned by dedicated "linuxbrew" system user for additional security.
* Install [brew-proxy](https://codeberg.org/HastD/brew-proxy) to facilitate management of the brew installation by authorized users.
* Modify `ujust set-brew` so that it doesn't delete the brew installation when disabling brew, but just makes it inaccessible to unprivileged users.

Prerequisites for this PR to be merged:

* [x] Build brew-proxy in the secureblue copr repo ([done](https://copr.fedorainfracloud.org/coprs/secureblue/packages/package/brew-proxy/))
* [x] secureblue/homebrew#18 needs to be merged first.