### PR TITLE
feat: add SELinux policy to deny access to AF_ALG sockets

### DIFF
--- a/files/scripts/installselinuxpolicies.sh
+++ b/files/scripts/installselinuxpolicies.sh
@@ -11,11 +11,12 @@ dnf install -y --setopt=install_weak_deps=False policycoreutils-devel
 policy_modules=(flatpakfull nautilus systemsettings thunar)
 
 cil_policy_modules=(
+    './selinux/af_alg/deny_af_alg.cil'
+    './selinux/flatpakfull/grant_systemd_flatpak_exec.cil'
     './selinux/user_namespace/grant_fm_userns.cil'
     './selinux/user_namespace/grant_userns.cil'
-    './selinux/user_namespace/harden_userns.cil'
     './selinux/user_namespace/harden_container_userns.cil'
-    './selinux/flatpakfull/grant_systemd_flatpak_exec.cil'
+    './selinux/user_namespace/harden_userns.cil'
     './selinux/user_namespace/userns_deny_unconfined_relabels.cil'
 )
 

--- a/files/scripts/selinux/af_alg/deny_af_alg.cil
+++ b/files/scripts/selinux/af_alg/deny_af_alg.cil
@@ -1,0 +1,14 @@
+; SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+;
+; SPDX-License-Identifier: Apache-2.0 OR MIT
+
+; Denies all userspace processes access to AF_ALG sockets, which are the
+; userspace interface to the kernel crypto API:
+; https://www.kernel.org/doc/html/latest/crypto/userspace-if.html
+; This API is largely unnecessary given modern userspace cryptographic libraries
+; and exposes a lot of attack surface. In particular, it was responsible for
+; CVE-2026-31431 ("Copy Fail"), a major privilege escalation vulnerability.
+
+(typeattribute af_alg_restricted)
+(typeattributeset af_alg_restricted (not (kernel_t)))
+(deny af_alg_restricted domain (alg_socket (not (getattr))))


### PR DESCRIPTION
AF_ALG sockets are the userspace interface to the kernel crypto API, which exposes a lot of attack surface and was responsible for the recently announced Copy Fail privilege escalation exploit. Seeing as this API isn't used much anyway, we can just deny all userspace processes access to these sockets using SELinux.

Resolves #2180.