### PR TITLE
chore(isos): remove bazaar from the ISO rootfs

### DIFF
--- a/.github/workflows/isos/prep_rootfs.sh
+++ b/.github/workflows/isos/prep_rootfs.sh
@@ -13,7 +13,8 @@ IMAGE_REF="ghcr.io/secureblue/$IMAGE_VARIANT_ID"
 
 sed -i '/^install squashfs /d' /usr/lib/modprobe.d/secureblue.conf
 
-dnf remove -y google-noto-fonts-all homebrew
+# https://github.com/ublue-os/bazzite/issues/4126#issuecomment-3980175243
+dnf remove -y google-noto-fonts-all homebrew bazaar
 dnf install -y secureblue-logos
 dnf reinstall -y polkit
 dnf install -y anaconda-live firefox libblockdev-btrfs libblockdev-btrfs libblockdev-lvm libblockdev-dm


### PR DESCRIPTION
Installing flatpaks in the liveenv can cause cache corruption in the resulting image https://github.com/ublue-os/bazzite/issues/4126#issuecomment-3980175243