### PR TITLE
feat: add neverallow rule to AF_ALG policy

### DIFF
--- a/files/scripts/selinux/af_alg/deny_af_alg.cil
+++ b/files/scripts/selinux/af_alg/deny_af_alg.cil
@@ -9,6 +9,9 @@
 ; and exposes a lot of attack surface. In particular, it was responsible for
 ; CVE-2026-31431 ("Copy Fail"), a major privilege escalation vulnerability.
 
-(typeattribute af_alg_restricted)
-(typeattributeset af_alg_restricted (not (kernel_t)))
-(deny af_alg_restricted domain (alg_socket (not (getattr))))
+(typeattribute non_kernel_types)
+(typeattributeset non_kernel_types (not (kernel_t)))
+(typeattribute all_types)
+(typeattributeset all_types (all))
+(deny non_kernel_types all_types (alg_socket (all)))
+(neverallow non_kernel_types all_types (alg_socket (all)))


### PR DESCRIPTION
Refine SELinux policy to block userspace access to AF_ALG sockets:
* Block access for any target type, not just domain types.
* Deny all permissions for `alg_socket` instead of allowing only `getattr`, as this keeps the policy simpler and shouldn't make any difference in practice since we're blocking AF_ALG sockets from being created in the first place.
* Add `neverallow` rule to check at compile-time that no rules allow access. This is similar to what Android does, and essentially acts as a compile-time test of SELinux policy.