### PR TITLE
fix: use /usr/lib/os-release for ISO variant info

### DIFF
--- a/.github/workflows/isos/prep_rootfs.sh
+++ b/.github/workflows/isos/prep_rootfs.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 IMAGE_TAG="latest"
-IMAGE_VARIANT_ID=$(grep '^VARIANT_ID=' /etc/os-release | cut -d= -f2)
+IMAGE_VARIANT_ID=$(grep '^VARIANT_ID=' /usr/lib/os-release | cut -d= -f2)
 IMAGE_REF="ghcr.io/secureblue/$IMAGE_VARIANT_ID"
 
 sed -i '/^install squashfs /d' /usr/lib/modprobe.d/secureblue.conf


### PR DESCRIPTION
There is a separate bug wherein on Nvidia images, only /usr/lib/os-release is getting the nvidia variant set, and not /etc/os-release. 

New issue to track the bug fix: https://github.com/secureblue/secureblue/issues/2196