### PR TITLE
fix: don't break /etc/os-release symlink

### DIFF
--- a/files/scripts/regenerateinitramfs.sh
+++ b/files/scripts/regenerateinitramfs.sh
@@ -26,7 +26,7 @@ mv "${excluded_preload_file}" "${tmp_preload_file}"
 # version number (which changes daily).
 tmp_release_file=$(mktemp --tmpdir 'os-release-XXXXXXXXXX')
 cp /etc/os-release "${tmp_release_file}"
-sed -Ei -e '/^(OSTREE_)?VERSION=/d' /etc/os-release
+sed -Ei --follow-symlinks -e '/^(OSTREE_)?VERSION=/d' /etc/os-release
 
 qualified_kernel=$(rpm -qa | grep -oP 'kernel-\K\d+\.\d+\.\d+.*')
 


### PR DESCRIPTION
Using `sed -i` without the `--follow-symlinks` option breaks symlinks, but we want `/etc/os-release` to remain a symlink to `/usr/lib/os-release`.

This should fix #2196.