### PR TITLE
fix: clarify kmod toggle boot prompt

### DIFF
--- a/files/system/usr/libexec/secureblue/bluetooth_main.py
+++ b/files/system/usr/libexec/secureblue/bluetooth_main.py
@@ -66,7 +66,7 @@ def main() -> int:
 
     if len(sys.argv) == argc_interactive:
         # Ask interactively.
-        mode = "on" if ask_yes_no("Would you like to load the Bluetooth modules?") else "off"
+        mode = "on" if ask_yes_no("On boot, do you want the Bluetooth modules to load?") else "off"
     elif len(sys.argv) == argc_on_off:
         # Take mode from first argument, i.e. 'on' or 'off'.
         mode = sys.argv[1].casefold()

--- a/files/system/usr/libexec/secureblue/webcam_main.py
+++ b/files/system/usr/libexec/secureblue/webcam_main.py
@@ -66,7 +66,7 @@ def main() -> int:
 
     if len(sys.argv) == argc_interactive:
         # Ask interactively.
-        mode = "on" if ask_yes_no("Would you like to load the Webcam modules?") else "off"
+        mode = "on" if ask_yes_no("On boot, do you want the Webcam modules to load?") else "off"
     elif len(sys.argv) == argc_on_off:
         # Take mode from first argument, i.e. 'on' or 'off'.
         mode = sys.argv[1].casefold()


### PR DESCRIPTION
## Summary
- Clarifies the interactive Webcam and Bluetooth kmod toggle prompts so they describe boot-time module loading behavior instead of sounding like an immediate `modprobe` action.

Fixes #2138

## Testing
- `python3 -m py_compile files/system/usr/libexec/secureblue/webcam_main.py files/system/usr/libexec/secureblue/bluetooth_main.py`
