### PR TITLE
fix: allow bluetooth_t to access AF_ALG sockets

### DIFF
--- a/files/scripts/selinux/af_alg/deny_af_alg.cil
+++ b/files/scripts/selinux/af_alg/deny_af_alg.cil
@@ -2,16 +2,27 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0 OR MIT
 
-; Denies all userspace processes access to AF_ALG sockets, which are the
-; userspace interface to the kernel crypto API:
+; Denies all userspace processes except bluetooth_t access to AF_ALG sockets,
+; which are the userspace interface to the kernel crypto API:
 ; https://www.kernel.org/doc/html/latest/crypto/userspace-if.html
 ; This API is largely unnecessary given modern userspace cryptographic libraries
 ; and exposes a lot of attack surface. In particular, it was responsible for
 ; CVE-2026-31431 ("Copy Fail"), a major privilege escalation vulnerability.
 
-(typeattribute non_kernel_types)
-(typeattributeset non_kernel_types (not (kernel_t)))
+(typeattribute allow_alg_socket)
+(typeattributeset allow_alg_socket (kernel_t))
+
+; bluetooth_t is allowed since BlueZ relies on the kernel crypto API and denying
+; it access breaks some Bluetooth functionality.
+(optional bluetooth_allow_alg_socket
+    (typeattributeset allow_alg_socket (bluetooth_t))
+)
+
+(typeattribute deny_alg_socket)
+(typeattributeset deny_alg_socket (not (allow_alg_socket)))
+
 (typeattribute all_types)
 (typeattributeset all_types (all))
-(deny non_kernel_types all_types (alg_socket (all)))
-(neverallow non_kernel_types all_types (alg_socket (all)))
+
+(deny deny_alg_socket all_types (alg_socket (all)))
+(neverallow deny_alg_socket all_types (alg_socket (all)))


### PR DESCRIPTION
BlueZ relies on the kernel crypto API, and denying it access breaks parts of Bluetooth functionality. Since bluetooth_t is a confined domain, this also shouldn't weaken the policy all that much.