### PR TITLE
feat: disable kernel modules to mitigate dirtyfrag 

### DIFF
--- a/files/system/usr/lib/modprobe.d/secureblue.conf
+++ b/files/system/usr/lib/modprobe.d/secureblue.conf
@@ -94,3 +94,21 @@ install ath_pci /bin/false
 # block loading cdrom
 install cdrom /bin/false
 install sr_mod /bin/false
+
+# dirtyfrag mitigation: https://github.com/V4bel/dirtyfrag#mitigation
+# RxRPC network protocol: https://www.kernel.org/doc/html/latest/networking/rxrpc.html
+install rxrpc /bin/false
+# esp4 and esp6 provide support for Encapsulating Security Payload, part of IPSec.
+install esp4 /bin/false
+install esp4_offload /bin/false
+install esp6 /bin/false
+install esp6_offload /bin/false
+# xfrm, another part of IPSec involved in related exploits
+install nft_xfrm /bin/false
+install xfrm4_tunnel /bin/false
+install xfrm6_tunnel /bin/false
+install xfrm_algo /bin/false
+install xfrm_interface /bin/false
+install xfrm_ipcomp /bin/false
+install xfrm_iptfs /bin/false
+install xfrm_user /bin/false


### PR DESCRIPTION
This disables the kernel modules that provide support for ESP (Encapsulating Security Payload) and RxRPC, which are involved in the recently disclosed "dirtyfrag" kernel exploit.