### PR TITLE
feat: SELinux policy to deny userspace access to IPSec sockets

### DIFF
--- a/files/scripts/installselinuxpolicies.sh
+++ b/files/scripts/installselinuxpolicies.sh
@@ -15,6 +15,7 @@ policy_modules=(flatpakfull nautilus systemsettings thunar)
 cil_policy_modules=(
     './selinux/af_alg/deny_af_alg.cil'
     './selinux/flatpakfull/grant_systemd_flatpak_exec.cil'
+    './selinux/ipsec/deny_ipsec.cil'
     './selinux/user_namespace/grant_fm_userns.cil'
     './selinux/user_namespace/grant_userns.cil'
     './selinux/user_namespace/harden_container_userns.cil'

--- a/files/scripts/selinux/ipsec/deny_ipsec.cil
+++ b/files/scripts/selinux/ipsec/deny_ipsec.cil
@@ -1,0 +1,25 @@
+; SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+;
+; SPDX-License-Identifier: Apache-2.0 OR MIT
+
+; Denies all userspace processes access to IPSec-related sockets, the userspace
+; interface to IPSec kernel functionality, which is not needed on most desktop
+; systems and was recently responsible for several major privilege escalation
+; exploits.
+
+(typeattribute allow_ipsec_sockets)
+(typeattributeset allow_ipsec_sockets (kernel_t))
+
+(typeattribute deny_ipsec_sockets)
+(typeattributeset deny_ipsec_sockets (not (allow_ipsec_sockets)))
+
+(typeattribute all_types)
+(typeattributeset all_types (all))
+
+; Deny userspace access to NETLINK_XFRM sockets
+(deny deny_ipsec_sockets all_types (netlink_xfrm_socket (all)))
+(neverallow deny_ipsec_sockets all_types (netlink_xfrm_socket (all)))
+
+; Deny userspace access to PF_KEY sockets, used for IPSec key management
+(deny deny_ipsec_sockets all_types (key_socket (all)))
+(neverallow deny_ipsec_sockets all_types (key_socket (all)))


### PR DESCRIPTION
This mitigates IPSec-related kernel vulnerabilities involving components that aren't compiled as kernel modules in the Fedora kernel (and therefore can't be disabled using modprobe overrides).