### PR TITLE
fix: remove newline from interruptible_ask

### DIFF
--- a/files/system/usr/libexec/secureblue/utils/__init__.py
+++ b/files/system/usr/libexec/secureblue/utils/__init__.py
@@ -210,7 +210,7 @@ def is_using_vpn() -> bool:
 def interruptible_ask(prompt: str) -> str:
     """Ask for a string input, strip whitespace, and exit gracefully if interrupted."""
     prompt = " ".join(prompt.split())
-    prompt = "\n" + textwrap.fill(prompt) + " "
+    prompt = textwrap.fill(prompt) + " "
     try:
         return input(prompt).strip()
     except (KeyboardInterrupt, EOFError):


### PR DESCRIPTION
In #1592, `interruptible_ask()` (which prints a prompt and takes input) was changed to print a newline before the prompt. While this works in some cases, it makes for a broken-looking UI where this wasn't anticipated.

I think it should be the responsibility of the calling function to insert newlines when needed for readability, not `interruptible_ask()`. Would it be okay if we changed this back? ~~It's currently not used anywhere outside `ujust dns-selector`.~~

<img width="391" height="141" alt="Screenshot From 2026-05-08 17-46-02" src="https://github.com/user-attachments/assets/6913dd18-2ede-480b-9350-d5283484adc6" />
