### PR TITLE
fix: Revert "feat: remove suid from polkit-agent-helper on non-cosmic imag…

### DIFF
--- a/files/scripts/removesuid.sh
+++ b/files/scripts/removesuid.sh
@@ -10,9 +10,9 @@ set -euo pipefail
 
 whitelist=(
     # Required for nvidia closed driver images
-    # https://github.com/NVIDIA/nvidia-modprobe/issues/12
     "/usr/bin/nvidia-modprobe"
-    
+    # https://gitlab.freedesktop.org/polkit/polkit/-/issues/168
+    "/usr/lib/polkit-1/polkit-agent-helper-1"
     # https://github.com/secureblue/secureblue/issues/119
     # Required for hardened_malloc to be used by suid-root processes
     "/usr/lib64/libhardened_malloc-light.so"
@@ -32,11 +32,6 @@ whitelist=(
     "/usr/lib64/glibc-hwcaps/x86-64-v4/libhardened_malloc.so"
     "/usr/lib64/libno_rlimit_as.so"
 )
-
-# https://github.com/pop-os/cosmic-osd/pull/193
-if [[ "$IMAGE_NAME" == *cosmic* ]]; then
-    whitelist+=("/usr/lib/polkit-1/polkit-agent-helper-1")
-fi
 
 
 is_in_whitelist() {


### PR DESCRIPTION
…es (#2215)"

This reverts commit dccf398257420879819e47565c268a05a14dc080.

This needs more testing on at least Sway images:

<img width="645" height="177" alt="image" src="https://github.com/user-attachments/assets/a18e5727-fc9b-4c62-8265-94d6bd620ac0" />
