### PR TITLE
feat(ujust): Do not force prune podman volumes

### DIFF
--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -56,11 +56,10 @@ update-firmware:
     fwupdmgr get-updates
     fwupdmgr update
 
-# Clean up old up unused podman images, volumes, flatpak packages and rpm-ostree content
+# Clean up old up unused podman images, flatpak packages and rpm-ostree content
 clean-system:
     #!/usr/bin/bash
     podman image prune -af
-    podman volume prune -f
     if command -v flatpak &> /dev/null
     then
         flatpak uninstall --unused

--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -56,10 +56,11 @@ update-firmware:
     fwupdmgr get-updates
     fwupdmgr update
 
-# Clean up old up unused podman images, flatpak packages and rpm-ostree content
+# Clean up old up unused podman images, volumes, flatpak packages and rpm-ostree content
 clean-system:
     #!/usr/bin/bash
     podman image prune -af
+    podman volume prune
     if command -v flatpak &> /dev/null
     then
         flatpak uninstall --unused


### PR DESCRIPTION
This removes the `-f` argument for podman volume prune.

The reason is that it may cause your volumes to be removed: https://github.com/ublue-os/packages/pull/1175

I use both images, so hopefully it's useful for secureblue as well.