### PR TITLE
chore: ensure adb availability across desktop images

### DIFF
--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -50,6 +50,9 @@ install:
     - libmtp
     - gvfs-mtp
 
+    # ensure adb availability
+    - android-tools
+
 remove:
   packages:
     - firefox


### PR DESCRIPTION
2MB package, makes OOTB flashing of Android devices more straightforward