### PR TITLE
fix: Set FedoraWorkstation as the default firewalld zone in sericea and cosmic images

### DIFF
--- a/files/scripts/setfirewalldefaultzone.sh
+++ b/files/scripts/setfirewalldefaultzone.sh
@@ -6,4 +6,4 @@
 
 set -euo pipefail
 
-sed -i 's/^DefaultZone=public/DefaultZone=FedoraWorkstation/' /etc/firewalld/firewalld.conf
+sed -i 's/^DefaultZone=.*/DefaultZone=FedoraWorkstation/' /etc/firewalld/firewalld.conf

--- a/files/scripts/setfirewalldefaultzone.sh
+++ b/files/scripts/setfirewalldefaultzone.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+sed -i 's/^DefaultZone=public/DefaultZone=FedoraWorkstation/' /etc/firewalld/firewalld.conf

--- a/recipes/common/cosmic-modules.yml
+++ b/recipes/common/cosmic-modules.yml
@@ -27,3 +27,7 @@ modules:
       files:
         - source: system/cosmic
           destination: /
+    - type: script
+      source: ghcr.io/blue-build/modules@sha256:079ae754f5b57e8f2ca5850b33a633b3fe1c37f4be51e7b00e9250a997f4e334
+      scripts:
+          - setfirewalldefaultzone.sh

--- a/recipes/common/cosmic-modules.yml
+++ b/recipes/common/cosmic-modules.yml
@@ -27,7 +27,3 @@ modules:
       files:
         - source: system/cosmic
           destination: /
-    - type: script
-      source: ghcr.io/blue-build/modules@sha256:079ae754f5b57e8f2ca5850b33a633b3fe1c37f4be51e7b00e9250a997f4e334
-      scripts:
-          - setfirewalldefaultzone.sh

--- a/recipes/common/desktop-scripts.yml
+++ b/recipes/common/desktop-scripts.yml
@@ -16,3 +16,4 @@ scripts:
   - disablesssd.sh
   - disableunconfinedrootfulservices.sh
   - setplymouththemetext.sh
+  - setfirewalldefaultzone.sh

--- a/recipes/common/sericea-modules.yml
+++ b/recipes/common/sericea-modules.yml
@@ -12,6 +12,7 @@ modules:
     source: ghcr.io/blue-build/modules@sha256:079ae754f5b57e8f2ca5850b33a633b3fe1c37f4be51e7b00e9250a997f4e334
     scripts:
       - disablewlrportals.sh
+      - setfirewalldefaultzone.sh
   - type: dnf
     source: ghcr.io/blue-build/modules@sha256:079ae754f5b57e8f2ca5850b33a633b3fe1c37f4be51e7b00e9250a997f4e334
     install:

--- a/recipes/common/sericea-modules.yml
+++ b/recipes/common/sericea-modules.yml
@@ -12,7 +12,6 @@ modules:
     source: ghcr.io/blue-build/modules@sha256:079ae754f5b57e8f2ca5850b33a633b3fe1c37f4be51e7b00e9250a997f4e334
     scripts:
       - disablewlrportals.sh
-      - setfirewalldefaultzone.sh
   - type: dnf
     source: ghcr.io/blue-build/modules@sha256:079ae754f5b57e8f2ca5850b33a633b3fe1c37f4be51e7b00e9250a997f4e334
     install:


### PR DESCRIPTION
Closes: #2230 