### PR TITLE
fix: typo in set-always-upgrade-on-boot

### DIFF
--- a/files/system/usr/libexec/secureblue/set_always_upgrade_on_boot.py
+++ b/files/system/usr/libexec/secureblue/set_always_upgrade_on_boot.py
@@ -74,7 +74,7 @@ def disable_always_upgrade_on_boot(currently_enabled: bool) -> int:
         return 0
     print_wrapped(f"""
         always-upgrade-on-boot is currently enabled.
-        Disabling it now by creating file '{ALWAYS_UPGRADE_ON_BOOT_STAMPFILE}'.
+        Disabling it now by deleting file '{ALWAYS_UPGRADE_ON_BOOT_STAMPFILE}'.
     """)
     exit_code = sandbox.run(stampfile_function, "delete", ALWAYS_UPGRADE_ON_BOOT_STAMPFILE)
     if exit_code == 0:


### PR DESCRIPTION
Just a nit

Current behaviour:
```
$ ujust --choose
Would you like always-upgrade-on-boot to be enabled? [y/n] n
always-upgrade-on-boot is currently enabled. Disabling it now by
creating file '/var/lib/secureblue/always-upgrade-on-boot.stamp'.
always-upgrade-on-boot disabled.
```

"Disabling it now by creating file" → "Disabling it now by deleting file"