### PR TITLE
ci: specify app token permissions

### DIFF
--- a/.github/workflows/update-modules.yml
+++ b/.github/workflows/update-modules.yml
@@ -121,6 +121,8 @@ jobs:
         with:
           client-id: ${{ vars.CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         if: steps.check_commits.conclusion == 'success'

--- a/.github/workflows/update-po.yml
+++ b/.github/workflows/update-po.yml
@@ -43,6 +43,8 @@ jobs:
         with:
           client-id: ${{ vars.CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:


### PR DESCRIPTION
Recommended by Zizmor to ensure app token's permissions aren't broader than intended: https://docs.zizmor.sh/audits/#github-app