### PR TITLE
feat: add pre-commit hooks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,33 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: 0c7b6c989466a93942def1f84baf36ddfcd60c83 # v0.15.14
+    hooks:
+      - id: ruff-check
+      - id: ruff-format
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: 9257c6050c0261b8c57e712f632dc4a8010109a9 # v1.25.2
+    hooks:
+      - id: zizmor
+
+  - repo: local
+    hooks:
+      # ty doesn't have an official pre-commit hook yet, so we use a local hook.
+      - id: ty
+        name: ty check
+        description: "Python type checker: https://docs.astral.sh/ty/"
+        entry: ty check
+        language: system
+        types: [python]
+        pass_filenames: false
+
+      # We use a local hook rather than the official ShellCheck pre-commit hook
+      # because the official hook runs as a container image, which won't run on
+      # secureblue in the default system configuration.
+      - id: shellcheck
+        name: ShellCheck
+        description: "Shell script linter: https://www.shellcheck.net/"
+        entry: shellcheck
+        language: system
+        types: [text]
+        types_or: [bash, bats, shell]


### PR DESCRIPTION
Add pre-commit hooks that automatically run Ruff (both the linter and formatter), ty, ShellCheck, and Zizmor. This helps detect code issues before they're made into a PR that CI is run on, which should save developer and reviewer time.

The pre-commit hook versions for Ruff and Zizmor are pinned to commit hashes and configured to be updated by Dependabot. Ty and ShellCheck are set up as local hooks (using binaries on the user's system) since ty doesn't have an official pre-commit hook yet, and ShellCheck's official pre-commit hook runs as an unsigned Docker container image (which is blocked on secureblue in the default system configuration).

Resolves #2168. We use `.pre-commit-config.yaml`, which is compatible with both [prek](https://prek.j178.dev/) and the older [pre-commit](https://pre-commit.com/).

Once this is merged, we should also update the [contributing guide](https://secureblue.dev/contributing) to recommend setting up pre-commit hooks (with either `prek install` or `pre-commit install`).