### PR TITLE
Quality: Potential race condition in file existence check

### DIFF
--- a/files/system/usr/libexec/secureblue/toggle_user_motd.py
+++ b/files/system/usr/libexec/secureblue/toggle_user_motd.py
@@ -20,9 +20,8 @@ def main() -> int:
         print("MOTD enabled.")
 
     except FileNotFoundError:
-        if not (Path.home() / ".config").is_dir():
-            os.mkdir(Path.home() / ".config")
-        (Path.home() / ".config" / "no-show-user-motd").touch(exist_ok=False)
+        (Path.home() / ".config").mkdir(parents=True, exist_ok=True)
+        (Path.home() / ".config" / "no-show-user-motd").touch(exist_ok=True)
         print("MOTD disabled.")
 
     except OSError as e:


### PR DESCRIPTION
## Summary

Quality: Potential race condition in file existence check

## Problem

**Severity**: `Medium` | **File**: `files/system/usr/libexec/secureblue/toggle_user_motd.py:L20`

In `toggle_user_motd.py`, the code checks if `.config` directory exists and creates it if not, then touches a file. However, between the `is_dir()` check and `mkdir()` call, another process could create the directory, causing a race condition. Similarly, `touch(exist_ok=False)` will raise if the file was created between the remove and touch operations.

## Solution

Use `Path.mkdir(parents=True, exist_ok=True)` to avoid the race condition. Also use `touch(exist_ok=True)` or handle the potential FileExistsError to make the operation idempotent.

## Changes

- `files/system/usr/libexec/secureblue/toggle_user_motd.py` (modified)