### PR TITLE
fix: Don't export `PS1` enhanced bash prompt to other spawned shells

### DIFF
--- a/files/system/etc/profile.d/xx-bash-prompt-command.sh
+++ b/files/system/etc/profile.d/xx-bash-prompt-command.sh
@@ -2,5 +2,5 @@
 # Filename needs to be alphabetically later than vte.sh
 if [[ $- == *i* && -n "${BASH_VERSION:-}" ]]; then
     # Print nonzero exit codes in bold red text inside square brackets at beginning of prompt
-    export PS1='$(code=${?#0};echo -n "${code:+\[\e[31m\][\[\e[1m\]${code}\[\e[22m\]]\[\e[39m\]}")'"${PS1:-}"
+    PS1='$(code=${?#0};echo -n "${code:+\[\e[31m\][\[\e[1m\]${code}\[\e[22m\]]\[\e[39m\]}")'"${PS1:-}"
 fi


### PR DESCRIPTION
When you launch `sh` from terminal, which inherits `PS1` variable, output looks like garbage:
```
gidro@fedora-gidro:~$ sh
sh: 0: Bad substitution
$(code=${?#0};echo -n "${code:+\[\e[31m\][\[\e[1m\]${code}\[\e[22m\]]\[\e[39m\]}")\[\e]133;D;$?\e\\\e]133;A\e\\\]${PROMPT_START@P}\[\e[0m\]${PROMPT_HIGHLIGHT:+\[\e[${PROMPT_HIGHLIGHT}m\]}${PROMPT_COLOR:+\[\e[${PROMPT_COLOR}m\]}${PROMPT_CONTAINER}${PROMPT_USERHOST:+${PROMPT_USERHOST@P}${PROMPT_SEPARATOR:+\[\e[0m\]${PROMPT_SEPARATOR_COLOR:+\[\e[${PROMPT_SEPARATOR_COLOR}m\]}${PROMPT_SEPARATOR@P}${PROMPT_SEPARATOR_COLOR:+\[\e[0m\]}${PROMPT_HIGHLIGHT:+\[\e[${PROMPT_HIGHLIGHT}m\]}${PROMPT_COLOR:+\[\e[${PROMPT_COLOR}m\]}}}${PROMPT_DIR_COLOR:+\[\e[${PROMPT_DIR_COLOR}m\]}${PROMPT_DIRECTORY@P}${PROMPT_GIT_BRANCH:+${PROMPT_SEPARATOR:+\[\e[0m\]${PROMPT_SEPARATOR_COLOR:+\[\e[${PROMPT_SEPARATOR_COLOR}m\]}${PROMPT_SEPARATOR@P}${PROMPT_SEPARATOR_COLOR:+\[\e[0m\]}${PROMPT_HIGHLIGHT:+\[\e[${PROMPT_HIGHLIGHT}m\]}${PROMPT_COLOR:+\[\e[${PROMPT_COLOR}m\]}${PROMPT_DIR_COLOR:+\[\e[${PROMPT_DIR_COLOR}m\]}}${PROMPT_GIT_COLOR:+\[\e[${PROMPT_GIT_COLOR}m\]}${PROMPT_GIT_BRANCH@P}}\[\e[0m\]${PROMPT_END@P}\$${PROMPT_END:+\[\e[0m\]} \[\e]133;B\e\\\]
```

This fixes it.