### PR TITLE
feat: Disable iSCSI daemons

### DIFF
--- a/files/scripts/disableiscsidaemons.sh
+++ b/files/scripts/disableiscsidaemons.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+echo "Disabling iSCSI daemons"
+
+systemctl disable iscsid.service 2>/dev/null || true
+systemctl mask iscsid.service 2>/dev/null || true
+
+systemctl disable iscsid.socket 2>/dev/null || true
+systemctl mask iscsid.socket 2>/dev/null || true
+
+systemctl disable iscsiuio.service 2>/dev/null || true
+systemctl mask iscsiuio.service 2>/dev/null || true
+
+systemctl disable iscsid.socket 2>/dev/null || true
+systemctl mask iscsid.socket 2>/dev/null || true

--- a/files/scripts/disableiscsidaemons.sh
+++ b/files/scripts/disableiscsidaemons.sh
@@ -17,5 +17,5 @@ systemctl mask iscsid.socket 2>/dev/null || true
 systemctl disable iscsiuio.service 2>/dev/null || true
 systemctl mask iscsiuio.service 2>/dev/null || true
 
-systemctl disable iscsid.socket 2>/dev/null || true
-systemctl mask iscsid.socket 2>/dev/null || true
+systemctl disable iscsiuio.socket 2>/dev/null || true
+systemctl mask iscsiuio.socket 2>/dev/null || true

--- a/files/system/desktop/usr/lib/systemd/system-preset/35-secureblue-desktop.preset
+++ b/files/system/desktop/usr/lib/systemd/system-preset/35-secureblue-desktop.preset
@@ -49,5 +49,11 @@ disable cups.socket
 # Disable modem manager
 disable ModemManager.service
 
+# Disable iSCSI daemons
+disable iscsid.service
+disable iscsid.socket
+disable iscsiuio.service
+disable iscsiuio.socket
+
 # Enable upgrade-on-boot
 enable upgrade-on-boot.service

--- a/recipes/common/desktop-scripts.yml
+++ b/recipes/common/desktop-scripts.yml
@@ -15,5 +15,6 @@ scripts:
   - disablenfsdaemons.sh
   - disablesssd.sh
   - disableunconfinedrootfulservices.sh
+  - disableiscsidaemons.sh
   - setplymouththemetext.sh
   - setfirewalldefaultzone.sh


### PR DESCRIPTION
This disables the iSCSI daemons that are enabled by default on secureblue; doing so seems to be in line with how NFS daemons are disabled since they provide a similar, niche facility.