### PR TITLE
fix: regression in user-motd script

### DIFF
--- a/files/system/etc/profile.d/user-motd.sh
+++ b/files/system/etc/profile.d/user-motd.sh
@@ -8,8 +8,7 @@
 # Prevent doublesourcing
 if [ -z "${USERMOTDSOURCED-}" ]; then
   USERMOTDSOURCED='Y'
-  config_dir=${XDG_CONFIG_HOME:-"$HOME/.config"}
-  if [ -d "$config_dir" ] && ! [ -e "$config_dir/no-show-user-motd" ] && [ -x '/usr/libexec/secureblue-motd' ]; then
+  if [ -d "$HOME" ] && ! [ -e "${XDG_CONFIG_HOME:-"$HOME/.config"}/no-show-user-motd" ] && [ -x '/usr/libexec/secureblue-motd' ]; then
     /usr/libexec/secureblue-motd
   fi
 fi


### PR DESCRIPTION
Commit c3da00c introduced a regression into the user-motd script ([see diff](https://github.com/secureblue/secureblue/commit/c3da00c43894b8994d9293cea96bb7c9fe9e478e#diff-b2d78746f1c870791ce785a2b47225fc5da1b6f14486e9b3f37fb3041eeb22f5R12)) by changing the first if-condition from checking for the presence of the user home folder to checking for the presence of the user home _config_ folder, leading to the motd not being shown on fresh installs where  `~/.config` has not been created yet. (which is the case for at least fresh securecore installations)

This PR restores the original condition logic while keeping the intended change of aforementioned commit.