### PR TITLE
chore: add Nora SNS browser to blocklist

### DIFF
--- a/files/system/desktop/usr/share/bazaar/blocklist.yaml
+++ b/files/system/desktop/usr/share/bazaar/blocklist.yaml
@@ -38,6 +38,7 @@ blocklists:
       # Other browsers.
       ## org.gnome.Epiphany uses WebKitGTK and flatpak-spawn for process-level sandboxing.
       ## Nyxt seems to use WebKitGTK, but without clear sandboxing.
+      - jp.nonbili.nora
       - engineer.atlas.Nyxt
       - org.catacombing.kumo
       - org.netsurf_browser.NetSurf


### PR DESCRIPTION
The Nora SNS browser should be added to the blocklist for Bazar as it contains a full fledged web browser and is intended to be used as one for Social Media.