### PR TITLE
Add lm_sensors to common-packages

### DIFF
--- a/recipes/common/common-packages.yml
+++ b/recipes/common/common-packages.yml
@@ -25,6 +25,7 @@ install:
     - gettext
     - rsync
     - steam-devices
+    - lm_sensors
 
     # signing deps
     - sbsigntools


### PR DESCRIPTION
I think this would be a good addition instead of overlaying. It seems it was previously part of your common image: https://github.com/secureblue/secureblue/pull/1

Is there any reason why it has been removed?

I believe KDE system-monitor use this:

<img width="1441" height="1074" alt="image" src="https://github.com/user-attachments/assets/b39e7609-e54f-4255-b49f-f1c0b92ca609" />

I don't know if any other packages are required?