### PR TITLE
feat(security update notification): Use GUI reboot prompt on DE that supports it

### DIFF
--- a/files/system/desktop/usr/libexec/secureblue/security-update-notification
+++ b/files/system/desktop/usr/libexec/secureblue/security-update-notification
@@ -54,7 +54,21 @@ notify_normal() {
         "Please reboot to run the updated system"
 }
 
+prompt_reboot() {
+    container_image_reference="$(rpm-ostree status --booted --jsonpath='.deployments..container-image-reference')"
+    # Extracts the first 7 characters of the package name as defined
+    # at https://github.com/orgs/secureblue/packages?repo_name=secureblue
+    secureblue_variant_in_use=${container_image_reference:53:7}
+
+    case "${secureblue_variant_in_use}" in
+        "silverb") gnome-session-quit --reboot ;;
+        "kinoite") qdbus org.kde.LogoutPrompt /LogoutPrompt promptReboot ;;
+        *) systemctl reboot ;;
+    esac
+}
+
 if [[ "${trivalent_updated}" == 'true' || "${max_advisory_severity}" == 'critical' ]]; then
+<<<<<<< Updated upstream
     if [[ "$(notify_critical)" == '0' ]]; then
         systemctl reboot
     fi
@@ -62,4 +76,13 @@ elif [[ "${kernel_updated}" == 'true' || "${max_advisory_severity}" == 'importan
     if [[ "$(notify_normal)" == '0' ]]; then
         systemctl reboot
     fi
+=======
+  if [[ "$(notify_critical)" == '0' ]]; then
+    prompt_reboot
+  fi
+elif [[ "${kernel_updated}" == 'true' || "${max_advisory_severity}" == 'important' || "${max_advisory_severity}" == 'unknown' ]]; then
+  if [[ "$(notify_normal)" == '0' ]]; then
+    prompt_reboot
+  fi
+>>>>>>> Stashed changes
 fi

--- a/files/system/desktop/usr/libexec/secureblue/security-update-notification
+++ b/files/system/desktop/usr/libexec/secureblue/security-update-notification
@@ -59,7 +59,7 @@ prompt_reboot() {
 
     case "${secureblue_variant_in_use}" in
         "silverblue") gnome-session-quit --reboot ;;
-        "kinoite") qdbus org.kde.LogoutPrompt /LogoutPrompt promptReboot ;;
+        "kinoite") qdbus-qt6 org.kde.LogoutPrompt /LogoutPrompt promptReboot ;;
         *) systemctl reboot ;;
     esac
 }

--- a/files/system/desktop/usr/libexec/secureblue/security-update-notification
+++ b/files/system/desktop/usr/libexec/secureblue/security-update-notification
@@ -55,13 +55,10 @@ notify_normal() {
 }
 
 prompt_reboot() {
-    container_image_reference="$(rpm-ostree status --booted --jsonpath='.deployments..container-image-reference')"
-    # Extracts the first 7 characters of the package name as defined
-    # at https://github.com/orgs/secureblue/packages?repo_name=secureblue
-    secureblue_variant_in_use=${container_image_reference:53:7}
+    secureblue_variant_in_use="$(grep -oP '^VARIANT_ID=\K\w+' /usr/lib/os-release)"
 
     case "${secureblue_variant_in_use}" in
-        "silverb") gnome-session-quit --reboot ;;
+        "silverblue") gnome-session-quit --reboot ;;
         "kinoite") qdbus org.kde.LogoutPrompt /LogoutPrompt promptReboot ;;
         *) systemctl reboot ;;
     esac

--- a/files/system/desktop/usr/libexec/secureblue/security-update-notification
+++ b/files/system/desktop/usr/libexec/secureblue/security-update-notification
@@ -68,21 +68,11 @@ prompt_reboot() {
 }
 
 if [[ "${trivalent_updated}" == 'true' || "${max_advisory_severity}" == 'critical' ]]; then
-<<<<<<< Updated upstream
     if [[ "$(notify_critical)" == '0' ]]; then
-        systemctl reboot
+        prompt_reboot
     fi
 elif [[ "${kernel_updated}" == 'true' || "${max_advisory_severity}" == 'important' || "${max_advisory_severity}" == 'unknown' ]]; then
     if [[ "$(notify_normal)" == '0' ]]; then
-        systemctl reboot
+        prompt_reboot
     fi
-=======
-  if [[ "$(notify_critical)" == '0' ]]; then
-    prompt_reboot
-  fi
-elif [[ "${kernel_updated}" == 'true' || "${max_advisory_severity}" == 'important' || "${max_advisory_severity}" == 'unknown' ]]; then
-  if [[ "$(notify_normal)" == '0' ]]; then
-    prompt_reboot
-  fi
->>>>>>> Stashed changes
 fi


### PR DESCRIPTION
For GNOME & KDE only: Invoke GUI reboot prompt, rather than running `systemctl reboot` directly, when user clicks on "Reboot" button shown on security update notification.

Benefits: GUI reboot prompt shows inhibitors that blocks reboot, and allows users to cancel reboot operation, avoiding accidental reboots that may lead to data loss. This change allows for better integration with the GUI environment.