### PR TITLE
feat: install Flatseal on KDE images as well

### DIFF
--- a/files/system/desktop/usr/libexec/secureblue/secureblueflatpaksetup
+++ b/files/system/desktop/usr/libexec/secureblue/secureblueflatpaksetup
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 
 # SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
 #
@@ -6,6 +6,7 @@
 
 set -euo pipefail
 
+mkdir -p ~/.cache
 in_progress_indicator=~/.cache/secureblue-flatpak-setup-in-progress
 if [[ ! -f "${in_progress_indicator}" ]]; then
     notify-send -a 'secureblue' -i 'dialog-information' -u normal 'Provisioning core flatpaks, please wait...'
@@ -15,10 +16,7 @@ touch "${in_progress_indicator}"
 flatpak remote-add --if-not-exists --user --subset=verified --title='Flathub Verified' flathub-verified https://dl.flathub.org/repo/flathub.flatpakrepo
 ujust harden-flatpak
 
-image_name=$(awk -F= '$1 == "VARIANT_ID" { print $2; exit }' /etc/os-release)
-if [[ "${image_name}" != *"kinoite"* ]]; then
-    flatpak install --user -y --noninteractive flathub-verified com.github.tchx84.Flatseal
-fi
+flatpak install --user -y --noninteractive flathub-verified com.github.tchx84.Flatseal
 
 notify-send -a 'secureblue' -i 'dialog-information' -u normal 'Flatpak provisioning completed.'
 rm -f "${in_progress_indicator}"


### PR DESCRIPTION
KDE Plasma does have its own settings panel for managing flatpak permissions, but it's buried deep in the settings interface and isn't all that ergonomic, so it's nice to have Flatseal installed out of the box. Plus this means that instructions (from the audit script, in the secureblue FAQ, etc.) can assume the Flatseal is present rather than having to treat Kinoite images separately.