### PR TITLE
ci: run ShellCheck on shell scripts

### DIFF
--- a/.github/workflows/shell-script-lint.yml
+++ b/.github/workflows/shell-script-lint.yml
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Shell script linters
+permissions: {}
+on:
+  pull_request:
+    paths:
+      - 'files/system/**'
+      - '**.sh'
+      - '.shellcheckrc'
+      - '.github/workflows/shell-script-lint.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  shell-script-linters:
+    name: Shell script linters
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install ShellCheck
+        run: |
+          temp_dir="$(mktemp -d)"
+          (
+            cd "${temp_dir}"
+            version='v0.11.0'
+            tarball="shellcheck-${version}.linux.x86_64.tar.gz"
+            curl -fLsS --retry 5 -O "https://github.com/koalaman/shellcheck/releases/download/${version}/${tarball}"
+            sha256sum -c <<<"b7af85e41cc99489dcc21d66c6d5f3685138f06d34651e6d34b42ec6d54fe6f6  ${tarball}"
+            tar -xzf "${tarball}"
+            sudo install -Dt /usr/local/bin "shellcheck-${version}/shellcheck"
+          )
+          rm -rf "${temp_dir}"
+          shellcheck --version
+
+      - name: Install just
+        run: |
+          tmpfile=$(mktemp)
+          cat <<'EOF' > "${tmpfile}"
+          pip==26.1.1 \
+            --hash=sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb
+          rust_just==1.51.0 \
+            --hash=sha256:71fdbd29ad68d67d0ee885ed0eb74f0e906f3e89601b860f69d88bdd4454a869
+          EOF
+
+          python3 -m pip install --require-hashes -r "${tmpfile}"
+
+      - name: Check shell script shebangs
+        run: |
+          git ls-files -z | xargs -0 awk -f tools/check-shell-script-shebangs.awk --
+
+      - name: Run ShellCheck on shell scripts
+        run: |
+          # The previous step checks that all shell scripts start with a shebang.
+          git ls-files -z \
+            | xargs -0 awk 'FNR == 1 && /^#! *(\/usr)?\/bin\/(env )?(ba)?sh *$/ { printf("%s%c", FILENAME, 0) }' \
+            | xargs -0 shellcheck --
+
+      - name: Run ShellCheck on justfile shell scripts
+        run: |
+          tools/shellcheck_justfiles.py

--- a/.github/workflows/shell-script-lint.yml
+++ b/.github/workflows/shell-script-lint.yml
@@ -56,15 +56,29 @@ jobs:
 
           python3 -m pip install --require-hashes -r "${tmpfile}"
 
-      - name: Check shell script shebangs
+      - name: Get list of files to test
+        id: file_list
         run: |
-          git ls-files -z | xargs -0 awk -f tools/check-shell-script-shebangs.awk --
+          tempfile="$(mktemp)"
+          # We need to examine object modes to exclude directories that are the target
+          # of a symbolic link, which get included in the output of `git ls-files` and
+          # would otherwise be passed to awk, triggering a warning.
+          git ls-files -z --format='%(objectmode) %(path)' \
+            | sed -Enz -e '/^120/d' -e 's/^[0-9]+ //p' > "${tempfile}"
+          echo "file_list=${tempfile}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check shell script shebangs
+        env:
+          FILE_LIST: ${{ steps.file_list.outputs.file_list }}
+        run: |
+          xargs -0 -a "${FILE_LIST}" awk -f tools/check-shell-script-shebangs.awk --
 
       - name: Run ShellCheck on shell scripts
+        env:
+          FILE_LIST: ${{ steps.file_list.outputs.file_list }}
         run: |
           # The previous step checks that all shell scripts start with a shebang.
-          git ls-files -z \
-            | xargs -0 awk 'FNR == 1 && /^#! *(\/usr)?\/bin\/(env )?(ba)?sh *$/ { printf("%s%c", FILENAME, 0) }' \
+          xargs -0 -a "${FILE_LIST}" awk 'FNR == 1 && /^#! *(\/usr)?\/bin\/(env )?(ba)?sh *$/ { printf("%s%c", FILENAME, 0) }' \
             | xargs -0 shellcheck --
 
       - name: Run ShellCheck on justfile shell scripts

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Containerfile
 .DS_Store
 __pycache__
 uv.lock
+justfile-tmp-*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,11 @@ repos:
         language: system
         types: [text]
         types_or: [bash, bats, shell]
+
+      - id: shell-script-shebangs
+        name: check script shebangs
+        description: "Check shell script shebang lines are normalized"
+        entry: awk -f tools/check-shell-script-shebangs.awk
+        language: system
+        types: [text]
+        types_or: [bash, bats, shell]

--- a/files/justfiles/common/toggles.just
+++ b/files/justfiles/common/toggles.just
@@ -40,25 +40,25 @@ toggle-cups:
 override-enable-module mod_name:
     #! /bin/run0 /bin/bash
     MOD_NAME="{{ mod_name }}"
-    MOD_FILE="/etc/modprobe.d/99-$MOD_NAME.conf"
-    if [ -e "$MOD_FILE" ]; then
-        echo "$MOD_NAME module is already enabled."
+    MOD_FILE="/etc/modprobe.d/99-${MOD_NAME}.conf"
+    if [[ -e "${MOD_FILE}" ]]; then
+        echo "${MOD_NAME} module is already enabled."
     else
-        sh -c 'echo "install $1 /sbin/modprobe --ignore-install $1" >> "$2"' _ "$MOD_NAME" "$MOD_FILE"
-        chmod 644 "$MOD_FILE"
-        echo "Override created to enable $MOD_NAME module. Reboot to take effect."
+        sh -c 'echo "install $1 /sbin/modprobe --ignore-install $1" >> "$2"' _ "${MOD_NAME}" "${MOD_FILE}"
+        chmod 644 "${MOD_FILE}"
+        echo "Override created to enable ${MOD_NAME} module. Reboot to take effect."
     fi
 
 # reset the override by `just override-enable-module`, i.e. disable the module again (requires restart)
 override-reset-module mod_name:
     #! /bin/run0 /bin/bash
     MOD_NAME="{{ mod_name }}"
-    MOD_FILE="/etc/modprobe.d/99-$MOD_NAME.conf"
-    if [ -e "$MOD_FILE" ]; then
-        rm -f "$MOD_FILE"
-        echo "The override for $MOD_NAME module has been reset. Reboot to take effect."
+    MOD_FILE="/etc/modprobe.d/99-${MOD_NAME}.conf"
+    if [[ -e "${MOD_FILE}" ]]; then
+        rm -f "${MOD_FILE}"
+        echo "The override for ${MOD_NAME} module has been reset. Reboot to take effect."
     else
-        echo "No override found for $MOD_NAME module."
+        echo "No override found for ${MOD_NAME} module."
     fi
 
 # Toggle debug mode (requires restart)
@@ -86,6 +86,7 @@ toggle-debug-mode:
 toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prompt":
     #!/bin/run0 /bin/bash
     set -euo pipefail
+    # shellcheck disable=SC1091
     source /usr/lib/ujust/libformatting.sh
 
     # The below function fetches the minimium and maximium UIDS as configured in /etc/login.defs.
@@ -96,15 +97,15 @@ toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prom
     function user_list_lookup() {
         uid_min="$(grep -Po '^\s*UID_MIN\s+\K\d+' /etc/login.defs)"
         uid_max="$(grep -Po '^\s*UID_MAX\s+\K\d+' /etc/login.defs)"
-        user_string="$(getent passwd | awk -F':' -v max="$uid_max" -v min="$uid_min" 'max >= $3 && $3 >= min {print $1}' | tr '\n' ',' | sed 's/,*$//')"
-        IFS=',' read -ra user_list <<< "$user_string"
+        user_string="$(getent passwd | awk -F':' -v max="${uid_max}" -v min="${uid_min}" 'max >= $3 && $3 >= min {print $1}' | tr '\n' ',' | sed 's/,*$//')"
+        IFS=',' read -ra user_list <<< "${user_string}"
     }
 
-    # $SUDO_USER is the user who started the script instead of whichever authorized it via polkit
-    # or the root home. From there this $USER_HOME uses getent to lookup their home directory to
+    # ${SUDO_USER} is the user who started the script instead of whichever authorized it via polkit
+    # or the root home. From there this ${USER_HOME} uses getent to lookup their home directory to
     # later check if they have an existing .bashrc file.
-    user_home="$(getent passwd "$SUDO_USER" | cut -d: -f6)"
-    if lsattr "$user_home/.bashrc" 2>/dev/null | awk '{print $1}' | grep -q 'i'; then
+    user_home="$(getent passwd "${SUDO_USER}" | cut -d: -f6)"
+    if lsattr "${user_home}/.bashrc" 2>/dev/null | awk '{print $1}' | grep -q 'i'; then
         pending_status="unlocked"
     else
         pending_status="locked"
@@ -114,10 +115,11 @@ toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prom
     # despite execution time.
     current_time="$(date | tr ' ' '_')"
 
-    if [[ "$pending_status" == "locked" ]]; then
+    if [[ "${pending_status}" == "locked" ]]; then
+        # shellcheck disable=SC2154
         echo "${bold}WARNING${unbold} This will change your ~/.bashrc, ~/.bash_profile, ~/.config/bash_completion, ~/.profile, ~/.bash_logout, ~/.bash_login, ~/.bashrc.d/, and ~/.config/environment.d/"
         echo "This is needed to ensure the mitigation (see LD_PRELOAD attacks) is effective."
-        echo "This script will create backups of the old versions in ~/bash_env_files/$current_time."
+        echo "This script will create backups of the old versions in ~/bash_env_files/${current_time}."
     else
         echo "${bold}WARNING${unbold} .bashrc, .bash_profile, and more will be unlocked and made editable by non-root users. This represents a security risk (see LD_PRELOAD attacks)"
     fi
@@ -127,7 +129,7 @@ toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prom
         echo "Do you understand?"
         accept=""
         read -r -p "Type ${bold}YES I UNDERSTAND${unbold} and press ${bold}Enter${unbold} to continue: " accept
-        if [[ "$accept" != "YES I UNDERSTAND" ]]; then
+        if [[ "${accept}" != "YES I UNDERSTAND" ]]; then
             exit
         fi
     elif [[ "{{ skip_approval }}" != "true" ]]; then
@@ -139,14 +141,14 @@ toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prom
     if [[ "{{ apply_for_all_users }}" == "prompt" ]]; then
         user_list_lookup
         echo "This change can be applied to ${bold}all${unbold} users on this system (${user_list[*]})"
-        echo "or only to the user who launched this script ($SUDO_USER)."
+        echo "or only to the user who launched this script (${SUDO_USER})."
         user_choice=""
         read -r -p "Apply this change to ${bold}all${unbold} users? [y/N] " user_choice
-        if [[ "$user_choice" != [yY]* ]]; then
-            user_list=("$SUDO_USER")
+        if [[ "${user_choice}" != [yY]* ]]; then
+            user_list=("${SUDO_USER}")
         fi
     elif [[ "{{ apply_for_all_users }}" == "false" ]]; then
-        user_list=("$SUDO_USER")
+        user_list=("${SUDO_USER}")
     elif [[ "{{ apply_for_all_users }}" == "true" ]]; then
         user_list_lookup
     else
@@ -155,21 +157,21 @@ toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prom
     fi
 
     for user in "${user_list[@]}"; do
-        echo "Applying for user: $user"
-        user_home="$(getent passwd "$user" | awk -F':' '{ print $6}')"
-        [ -d "$user_home" ] || { echo "Variable \$user_home for $user is somehow empty (check your getent passwd entries)"; echo "safely exiting."; exit 1; }
+        echo "Applying for user: ${user}"
+        user_home="$(getent passwd "${user}" | awk -F':' '{ print $6}')"
+        [[ -d "${user_home}" ]] || { echo "Variable \${user_home} for ${user} is somehow empty (check your getent passwd entries)"; echo "safely exiting."; exit 1; }
         xdg_config="$(run0 -i --user="${user}" printenv XDG_CONFIG_HOME || true)"
         user_config="${xdg_config:-"${user_home}/.config"}"
 
         BASH_ENV_FILES=(
-            "$user_home/.bashrc"
-            "$user_home/.bash_profile"
-            "$user_home/.profile"
-            "$user_home/.bash_logout"
-            "$user_home/.bash_login"
-            "$user_home/.bashrc.d/"
-            "$user_config/bash_completion"
-            "$user_config/environment.d/"
+            "${user_home}/.bashrc"
+            "${user_home}/.bash_profile"
+            "${user_home}/.profile"
+            "${user_home}/.bash_logout"
+            "${user_home}/.bash_login"
+            "${user_home}/.bashrc.d/"
+            "${user_config}/bash_completion"
+            "${user_config}/environment.d/"
         )
 
         # Purpose of the below block is to actually lock or unlock the current selected user
@@ -180,54 +182,54 @@ toggle-bash-environment-lockdown skip_approval="false" apply_for_all_users="prom
         #        create default or blank copies (deleting the old versions)
         #        add immutability
 
-        if [[ "$pending_status" == "locked" ]]; then
-            backup_dest="$user_home/bash_env_files/$current_time/"
-            mkdir -p "$backup_dest"
+        if [[ "${pending_status}" == "locked" ]]; then
+            backup_dest="${user_home}/bash_env_files/${current_time}/"
+            mkdir -p "${backup_dest}"
 
             for file in "${BASH_ENV_FILES[@]}"; do
-                # skel_file converts "$user_home/.bashrc" to ".bashrc"
+                # skel_file converts "${user_home}/.bashrc" to ".bashrc"
                 skel_file="${file#"${user_home}/"}"
-                if [ ! -f "$file" ] && [ ! -d "$file" ] && [ -e "$file" ]; then
-                    echo "Special file detected on absolute filepath ($file) from BASH_ENV_FILES. It will not be modified."
-                elif [ -f "$file" ]; then
-                    chattr -i "$file"
-                    rsync -a --mkpath "$file" "$backup_dest$skel_file"
-                    rm "$file"
-                elif [ -d "$file" ]; then
-                    chattr -R -i "$file"
-                    rsync -a --mkpath "$file" "$backup_dest$skel_file"
-                    rm -r "$file"
+                if [[ ! -f "${file}" && ! -d "${file}" && -e "${file}" ]]; then
+                    echo "Special file detected on absolute filepath (${file}) from BASH_ENV_FILES. It will not be modified."
+                elif [[ -f "${file}" ]]; then
+                    chattr -i "${file}"
+                    rsync -a --mkpath "${file}" "${backup_dest}${skel_file}"
+                    rm "${file}"
+                elif [[ -d "${file}" ]]; then
+                    chattr -R -i "${file}"
+                    rsync -a --mkpath "${file}" "${backup_dest}${skel_file}"
+                    rm -r "${file}"
                 fi
 
                 # Now we create new empty/default files and directories
-                if [ "${file: -1}" == "/" ]; then
-                    install -D -d -o "$user" -g "$user" -m 700 "$file"
-                    chattr +i -R "$file"
-                elif [ -f "/etc/skel/$skel_file" ]; then
-                    install -D -o "$user" -g "$user" -m 700 "/etc/skel/$skel_file" "$file"
-                    chattr +i "$file"
+                if [[ "${file: -1}" == "/" ]]; then
+                    install -D -d -o "${user}" -g "${user}" -m 700 "${file}"
+                    chattr +i -R "${file}"
+                elif [[ -f "/etc/skel/${skel_file}" ]]; then
+                    install -D -o "${user}" -g "${user}" -m 700 "/etc/skel/${skel_file}" "${file}"
+                    chattr +i "${file}"
                 else
-                    install -D -o "$user" -g "$user" -m 700 /dev/null "$file"
-                    chattr +i "$file"
+                    install -D -o "${user}" -g "${user}" -m 700 /dev/null "${file}"
+                    chattr +i "${file}"
                 fi
             done
 
-            chmod -R 700 "$user_home/bash_env_files"
-            chown -R "$user:" "$user_home/bash_env_files"
+            chmod -R 700 "${user_home}/bash_env_files"
+            chown -R "${user}:" "${user_home}/bash_env_files"
         else
             for file in "${BASH_ENV_FILES[@]}"; do
-                if [ ! -f "$file" ] && [ ! -d "$file" ] && [ -e "$file" ]; then
-                    echo "Special file detected on absolute filepath ($file) from BASH_ENV_FILES. It will not be modified."
-                elif [ -f "$file" ]; then
-                    chattr -i "$file"
-                elif [ -d "$file" ]; then
-                    chattr -R -i "$file"
+                if [[ ! -f "${file}" && ! -d "${file}" && -e "${file}" ]]; then
+                    echo "Special file detected on absolute filepath (${file}) from BASH_ENV_FILES. It will not be modified."
+                elif [[ -f "${file}" ]]; then
+                    chattr -i "${file}"
+                elif [[ -d "${file}" ]]; then
+                    chattr -R -i "${file}"
                 fi
             done
         fi
     done
 
-    echo "${user_list[@]}" "$pending_status."
+    echo "${user_list[@]}" "${pending_status}."
     echo "${bold}NOTE${unbold}: until a reboot, any process with an open file descriptor will continue to have the access they had before this script was run."
 
 # Toggle MAC Randomization
@@ -235,8 +237,8 @@ toggle-mac-randomization:
     #! /bin/run0 /bin/bash
     RAND_MAC_FILE="/etc/NetworkManager/conf.d/rand_mac.conf"
 
-    if test -e $RAND_MAC_FILE; then
-        rm -f $RAND_MAC_FILE
+    if test -e "${RAND_MAC_FILE}"; then
+        rm -f "${RAND_MAC_FILE}"
         echo "MAC randomization disabled."
         systemctl restart NetworkManager
     else
@@ -245,14 +247,14 @@ toggle-mac-randomization:
         randomization_choice=""
         read -rp "Do you want to use per-connection Wi-Fi MAC address randomization? [y/N] " randomization_choice
 
-        if [[ "$randomization_choice" == [Yy]* ]]; then
+        if [[ "${randomization_choice}" == [Yy]* ]]; then
             randomization_level=random
             echo "Selected state: per-connection"
         else
             randomization_level=stable
             echo "Selected state: per-network (stable)"
         fi
-        cat <<EOL > $RAND_MAC_FILE
+        cat <<EOL > "${RAND_MAC_FILE}"
     [device-mac-randomization]
     # "yes" is already the default for scanning
     wifi.scan-rand-mac-address=yes
@@ -260,9 +262,9 @@ toggle-mac-randomization:
     [connection-mac-randomization]
     # Generate a random MAC for each Network and associate the two permanently.
     ethernet.cloned-mac-address=stable
-    wifi.cloned-mac-address=$randomization_level
+    wifi.cloned-mac-address=${randomization_level}
     EOL
-        chmod 644 $RAND_MAC_FILE
+        chmod 644 "${RAND_MAC_FILE}"
         echo "MAC randomization enabled."
         systemctl restart NetworkManager
     fi

--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -10,9 +10,9 @@ shell := `grep :$(id -u): /etc/passwd | cut -d: -f7`
 # Boot into this device's BIOS/UEFI screen
 bios:
     #!/usr/bin/bash
-    if [ -d /sys/firmware/efi ]; then
+    if [[ -d /sys/firmware/efi ]]; then
         read -rp 'The system will reboot into UEFI firmware settings. Proceed? (y/N) ' proceed
-        if [[ "$proceed" == [Yy]* ]]; then
+        if [[ "${proceed}" == [Yy]* ]]; then
             systemctl reboot --firmware-setup
         fi
     else
@@ -110,8 +110,8 @@ debug-info:
     local_overrides=$(echo -e "\n=== Listing Local Overrides ===\n"; ujust check-local-overrides)
     recent_events=$(echo -e "\n=== Recent System Events ===\n"; journalctl -b -p err..alert --since "1 hour ago")
     failed_services=$(echo -e "\n=== Failed Services ===\n"; systemctl list-units --state=failed)
-    content="$rpm_ostree_status$sysinfo$flatpaks$audit_results$local_overrides$recent_events$failed_services"
-    echo "$content" | fpaste --confirm --private=1
+    content="${rpm_ostree_status}${sysinfo}${flatpaks}${audit_results}${local_overrides}${recent_events}${failed_services}"
+    echo "${content}" | fpaste --confirm --private=1
 
 alias assemble := distrobox-assemble
 
@@ -124,12 +124,13 @@ distrobox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/distrobox/distr
         container_userns_now=""
         read -rp "Would you like to run 'ujust set-container-userns on' now? [Y/n] " container_userns_now
         container_userns_now=${container_userns_now:-y}
-        if [[ "$container_userns_now" == [Yy]* ]]; then
+        if [[ "${container_userns_now}" == [Yy]* ]]; then
             echo "Running 'ujust set-container-userns on'"
             ujust set-container-userns on
         fi
     fi
     # Distroboxes are gathered from distrobox.ini, please add them there
+    # shellcheck disable=SC1091
     source /usr/lib/ujust/ujust.sh
     AssembleList "{{ FILE }}" "{{ ACTION }}" "{{ CONTAINER }}"
 
@@ -142,12 +143,13 @@ toolbox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/toolbox/toolbox.i
         container_userns_now=""
         read -rp "Would you like to run 'ujust set-container-userns on' now? [Y/n] " container_userns_now
         container_userns_now=${container_userns_now:-y}
-        if [[ "$container_userns_now" == [Yy]* ]]; then
+        if [[ "${container_userns_now}" == [Yy]* ]]; then
             echo "Running 'ujust set-container-userns on'"
             ujust set-container-userns on
         fi
     fi
     # Toolboxes are gathered from toolbox.ini, please add them there
+    # shellcheck disable=SC1091
     source /usr/lib/ujust/ujust.sh
     ToolboxAssembleList "{{ FILE }}" "{{ ACTION }}" "{{ CONTAINER }}"
 
@@ -171,10 +173,10 @@ uninstall-docker:
 rebase-secureblue:
     #!/usr/bin/bash
     current_image=$(grep VARIANT= /etc/os-release | cut -d'"' -f2)
-    if [[ "$current_image" == 'CoreOS' ]] || [[ "$current_image" == 'IOT' ]]; then
+    if [[ "${current_image}" == 'CoreOS' ]] || [[ "${current_image}" == 'IOT' ]]; then
         image_name=$(grep VARIANT_ID= /etc/os-release | cut -d'=' -f2 | cut -d'-' -f1)
         read -rp "Do you need ZFS support? [y/N]: " use_zfs
-        [[ "$use_zfs" == [Yy]* ]] && image_name+="-zfs"
+        [[ "${use_zfs}" == [Yy]* ]] && image_name+="-zfs"
     else
         desktop_image_types=(
             "silverblue"
@@ -189,8 +191,8 @@ rebase-secureblue:
             "Cosmic images are considered beta."
         PS3=$'Enter your desktop choice: '
         select image_name in "${desktop_image_types[@]}"; do
-            if [[ -n "$image_name" ]]; then
-                echo "Selected desktop: $image_name"
+            if [[ -n "${image_name}" ]]; then
+                echo "Selected desktop: ${image_name}"
                 break
             else
                 echo "Invalid option, please select a valid number."
@@ -199,68 +201,68 @@ rebase-secureblue:
     fi
     echo "Nvidia's proprietary drivers provide superior performance and official support on Nvidia hardware."
     read -rp "Do you want Nvidia proprietary drivers? [y/N]: " use_nvidia
-    if [[ "$use_nvidia" == [Yy]* ]]; then
+    if [[ "${use_nvidia}" == [Yy]* ]]; then
         image_name+="-nvidia"
         echo "Nvidia's proprietary drivers with open source kernel modules are recommended for Turing or newer cards (GTX 16XX+)."
         read -rp "Do you want Nvidia's proprietary drivers with open source kernel modules? [Y/n]: " use_open
         use_open=${use_open:-y}
-        [[ "$use_open" == [Yy]* ]] && image_name+="-open"
+        [[ "${use_open}" == [Yy]* ]] && image_name+="-open"
     else
         image_name+="-main"
     fi
     image_name+="-hardened"
     full_ref=$(crane digest --full-ref "ghcr.io/secureblue/${image_name}:latest")
     slsa-verifier verify-image --source-uri "github.com/secureblue/secureblue" --source-branch "live" "${full_ref}"
-    rebase_command="rpm-ostree rebase ostree-image-signed:docker://ghcr.io/secureblue/$image_name:latest"
-    printf "Command to execute:\n%s\n\n" "$rebase_command"
+    rebase_command="rpm-ostree rebase ostree-image-signed:docker://ghcr.io/secureblue/${image_name}:latest"
+    printf "Command to execute:\n%s\n\n" "${rebase_command}"
     read -rp "Proceed? [y/N]: " rebase_proceed
-    if [[ "$rebase_proceed" == [Yy]* ]]; then
-        eval "$rebase_command"
+    if [[ "${rebase_proceed}" == [Yy]* ]]; then
+        eval "${rebase_command}"
     fi
 
 # Apply SELinux type "user_home_t" on external drives to allow access from Trivalent
 label-external-drives:
     #!/usr/bin/bash
     set -euo pipefail
-    media_paths=("/run/media/$USER/" "/mnt/")
+    media_paths=("/run/media/${USER}/" "/mnt/")
     selabel="user_home_t"
     supported_fs=("ext2" "ext3" "ext4" "jfs" "xfs" "btrfs") # ref: https://wiki.gentoo.org/wiki/SELinux/FAQ#Can_I_use_SELinux_with_any_file_system.3F
 
     echo "Warning: This will label your drives mounted on paths $(printf '"%s" and ' "${media_paths[@]}" | sed 's/ and $//') such that they are treated as an extension to your home directory. (You can select which ones to label)"
     echo 'If you do not want Trivalent to have access to these drives, do not proceed.'
     read -rp 'Are you sure you want to do this? [y/N] ' warning_proceed
-    if ! [[ "$warning_proceed" == [Yy]* ]]; then
+    if ! [[ "${warning_proceed}" == [Yy]* ]]; then
         echo 'Aborting.'
         exit 0
     fi
 
     for media_path in "${media_paths[@]}"; do
-        if [ -z "$( ls -A "$media_path" 2>&- )" ]; then
+        if [[ -z "$( ls -A "${media_path}" 2>&- )" ]]; then
             echo
-            echo "You don't have any drives mounted in \"$media_path\", skipping..."
+            echo "You don't have any drives mounted in \"${media_path}\", skipping..."
             continue
         fi
 
-        for dir in "$media_path"*/
+        for dir in "${media_path}"*/
         do
             echo
-            if [[ "$(stat -c '%U' "$dir")" != "$USER" ]]; then
-                echo "Drive root folder is not owned by you, skipping drive \"$dir\"..."
+            if [[ "$(stat -c '%U' "${dir}")" != "${USER}" ]]; then
+                echo "Drive root folder is not owned by you, skipping drive \"${dir}\"..."
                 continue
             fi
-            detected_fs="$(df -T "$dir" | awk '{print $2}' | sed -n 2p)"
-            if ! printf "%s\n" "${supported_fs[@]}" | grep -Fxq "$detected_fs"; then
-                echo "SELinux support is unknown for filesystem $detected_fs, skipping drive \"$dir\"..."
+            detected_fs="$(df -T "${dir}" | awk '{print $2}' | sed -n 2p)"
+            if ! printf "%s\n" "${supported_fs[@]}" | grep -Fxq "${detected_fs}"; then
+                echo "SELinux support is unknown for filesystem ${detected_fs}, skipping drive \"${dir}\"..."
                 continue
             fi
-            read -rp "Do you want to label \"$dir\"? [y/N] " proceed
-            if ! [[ "$proceed" == [Yy]* ]]; then
+            read -rp "Do you want to label \"${dir}\"? [y/N] " proceed
+            if ! [[ "${proceed}" == [Yy]* ]]; then
                 echo 'Skipping...'
                 continue
             fi
-            echo "Labeling drive mounted on \"$dir\" with $selabel"
+            echo "Labeling drive mounted on \"${dir}\" with ${selabel}"
             dir=${dir%*/} # remove trailing slash
-            if ! run0 sh -c 'semanage fcontext -a -t "$1" "$2(/.*)?" && restorecon -r "$2"' sh "$selabel" "$dir"; then
+            if ! run0 sh -c 'semanage fcontext -a -t "$1" "$2(/.*)?" && restorecon -r "$2"' sh "${selabel}" "${dir}"; then
                 echo 'Execution failed, aborting.'
                 exit 1
             fi
@@ -293,9 +295,9 @@ install-vpn:
         case "$1" in
             "ivpn")
                 PACKAGE_NAMES="ivpn"
-                REPO_NAME="$PACKAGE_NAMES"
+                REPO_NAME="${PACKAGE_NAMES}"
 
-                if util_checkpackage "$PACKAGE_NAMES" || util_checkpackage "$PACKAGE_NAMES-ui"; then
+                if util_checkpackage "${PACKAGE_NAMES}" || util_checkpackage "${PACKAGE_NAMES}-ui"; then
                     echo 'Error: IVPN is already installed.'
                     echo 'Aborting...'
                     exit 1
@@ -304,8 +306,8 @@ install-vpn:
                 echo 'Installing IVPN...'
                 local proceed2
                 read -rp 'Do you want the IVPN GUI to be installed? [Y/n] ' proceed2
-                if ! [[ "$proceed2" == [nN]* ]]; then
-                    PACKAGE_NAMES="$PACKAGE_NAMES $PACKAGE_NAMES-ui"
+                if ! [[ "${proceed2}" == [nN]* ]]; then
+                    PACKAGE_NAMES="${PACKAGE_NAMES} ${PACKAGE_NAMES}-ui"
                 fi
                 INSTRUCTIONS='Successfully installed IVPN. Please execute the command "systemctl enable --now ivpn-service" after rebooting.'
                 ;;
@@ -314,7 +316,7 @@ install-vpn:
                 PACKAGE_NAMES="mullvad-vpn"
                 REPO_NAME="mullvad"
 
-                if util_checkpackage "$PACKAGE_NAMES"; then
+                if util_checkpackage "${PACKAGE_NAMES}"; then
                     echo 'Error: Mullvad VPN is already installed.'
                     echo 'Aborting...'
                     exit 1
@@ -328,7 +330,7 @@ install-vpn:
                 PACKAGE_NAMES="proton-vpn-gnome-desktop"
                 REPO_NAME="protonvpn-stable"
 
-                if util_checkpackage "$PACKAGE_NAMES"; then
+                if util_checkpackage "${PACKAGE_NAMES}"; then
                     echo 'Error: Proton VPN is already installed.'
                     echo 'Aborting...'
                     exit 1
@@ -342,7 +344,7 @@ install-vpn:
                 PACKAGE_NAMES="tailscale"
                 REPO_NAME="tailscale"
 
-                if util_checkpackage "$PACKAGE_NAMES"; then
+                if util_checkpackage "${PACKAGE_NAMES}"; then
                     echo 'Error: Tailscale VPN is already installed.'
                     echo 'Aborting...'
                     exit 1
@@ -361,12 +363,12 @@ install-vpn:
 
         # The lack of quotes around $2 is intentional.
         # shellcheck disable=SC2086
-        if ! run0 sh -c 'sed -Ei "s/^enabled[[:space:]]*=.*/enabled=1/" "/etc/yum.repos.d/$1.repo" && rpm-ostree install -y $2' sh "$REPO_NAME" "$PACKAGE_NAMES"; then
+        if ! run0 sh -c 'sed -Ei "s/^enabled[[:space:]]*=.*/enabled=1/" "/etc/yum.repos.d/$1.repo" && rpm-ostree install -y $2' sh "${REPO_NAME}" "${PACKAGE_NAMES}"; then
             echo "Error: The installation didn't complete successfully, aborting..."
             exit 1
         fi
 
-        echo "$INSTRUCTIONS"
+        echo "${INSTRUCTIONS}"
     }
 
     function util_checkpackage() {
@@ -378,7 +380,7 @@ install-vpn:
     echo 'Using a VPN is currently incompatible with global DNS or local DNSSEC resolution.'
     echo 'If you are using Unbound, it will be disabled in favour of systemd-resolved.'
     read -rp 'Do you want to continue? [y/N] ' proceed
-    if ! [[ "$proceed" == [yY]* ]]; then
+    if ! [[ "${proceed}" == [yY]* ]]; then
         echo 'Aborting...'
         exit 0
     fi
@@ -386,23 +388,23 @@ install-vpn:
 
     echo 'NOTE: You can also install wireguard profiles from your provider directly into your DE, if you prefer.'
     read -rp 'Do you want to continue with installing a VPN app anyway? [y/N] ' proceed
-    if ! [[ "$proceed" == [yY]* ]]; then
+    if ! [[ "${proceed}" == [yY]* ]]; then
         echo 'Aborting...'
         exit 0
     fi
     echo
     echo 'Please choose your desired provider'
     vpn_choice="$(ugum choose "${!vpn_providers[@]}")"
-    echo "You selected $vpn_choice"
+    echo "You selected ${vpn_choice}"
 
-    vpn_requirements="${vpn_providers[$vpn_choice]}"
+    vpn_requirements="${vpn_providers[${vpn_choice}]}"
     needs_gui="1"
-    if [[ "$vpn_requirements" =~ "gui_needs_" ]]; then
+    if [[ "${vpn_requirements}" =~ "gui_needs_" ]]; then
         echo
         echo 'Notice: This VPN requires additional security features to be disabled in order to use its graphical interface.'
         echo "You can instead use the VPN app's command-line interface, which does not require disabling hardening."
         read -rp 'Do you intend to use the graphical interface? [y/N] ' proceed_gui
-        if [[ "$proceed_gui" == [yY]* ]]; then
+        if [[ "${proceed_gui}" == [yY]* ]]; then
             echo 'Additional hardening features that break the graphical interface will be disabled.'
         else
             echo 'Additional hardening features that break the graphical interface will not be disabled.'
@@ -410,7 +412,7 @@ install-vpn:
         fi
     fi
 
-    if [[ "$vpn_requirements" =~ "always_needs_unconfined_userns" || "$vpn_requirements" =~ "gui_needs_unconfined_userns" && "$needs_gui" == "1" ]]; then
+    if [[ "${vpn_requirements}" =~ "always_needs_unconfined_userns" || "${vpn_requirements}" =~ "gui_needs_unconfined_userns" && "${needs_gui}" == "1" ]]; then
         echo
         if [[ "$(ujust set-unconfined-userns status)" == "enabled" ]] ; then
             echo 'Unconfined domain user namespaces already enabled, skipping...'
@@ -419,7 +421,7 @@ install-vpn:
             echo 'This will execute "ujust set-unconfined-userns on". You can also manually do this later if you skip this step.'
             echo 'Warning: This is a security reduction!'
             read -rp 'Do you want to do this now? [Y/n] ' proceed_userns
-            if ! [[ "$proceed_userns" == [nN]* ]]; then
+            if ! [[ "${proceed_userns}" == [nN]* ]]; then
                 echo 'Enabling unconfined domain user namespaces...'
                 ujust set-unconfined-userns on
                 echo 'Enabled unconfined domain user namespaces.'
@@ -427,44 +429,44 @@ install-vpn:
         fi
     fi
 
-    if [[ "$vpn_requirements" =~ "always_needs_xwayland" || "$vpn_requirements" =~ "gui_needs_xwayland" && "$needs_gui" == "1" ]]; then
+    if [[ "${vpn_requirements}" =~ "always_needs_xwayland" || "${vpn_requirements}" =~ "gui_needs_xwayland" && "${needs_gui}" == "1" ]]; then
         echo
 
         DE="unknown"
         IMAGE="$(rpm-ostree status 2>&- | grep '●')"
-        if echo "$IMAGE" | grep -q 'silverblue'; then
+        if echo "${IMAGE}" | grep -q 'silverblue'; then
             DE="gnome"
-        elif echo "$IMAGE" | grep -q 'kinoite'; then
+        elif echo "${IMAGE}" | grep -q 'kinoite'; then
             DE="plasma"
-        elif echo "$IMAGE" | grep -q 'sericea' || echo "$IMAGE" | grep 'sway'; then
+        elif echo "${IMAGE}" | grep -q 'sericea' || echo "${IMAGE}" | grep 'sway'; then
             DE=sway
         fi
 
         xwayland_enabled="0"
-        if [[ "$DE" == "gnome" ]]; then
+        if [[ "${DE}" == "gnome" ]]; then
             if ! test -e "/etc/systemd/user/org.gnome.Shell@user.service.d/override.conf"; then
                 xwayland_enabled="1"
             fi
-        elif [[ "$DE" == "plasma" ]]; then
+        elif [[ "${DE}" == "plasma" ]]; then
             if ! test -e "/etc/systemd/user/plasma-kwin_wayland.service.d/override.conf"; then
                 xwayland_enabled="1"
             fi
-        elif [[ "$DE" == "sway" ]]; then
+        elif [[ "${DE}" == "sway" ]]; then
             if ! test -e "/etc/sway/config.d/99-noxwayland.conf"; then
                 xwayland_enabled="1"
             fi
         fi
 
-        if [[ "$DE" == "unknown" ]]; then
+        if [[ "${DE}" == "unknown" ]]; then
             echo 'Warning: Unable to identify your desktop environment. Please manually ensure that Xwayland is enabled. Skipping...'
-        elif [[ "$xwayland_enabled" == "1" ]]; then
+        elif [[ "${xwayland_enabled}" == "1" ]]; then
             echo 'Xwayland already enabled, skipping...'
         else
             echo 'This VPN requires Xwayland to be enabled.'
             echo 'This will execute "ujust set-xwayland on". You can also manually do this later if you skip this step.'
             echo 'Warning: This is a security reduction!'
             read -rp 'Do you want to do this now? [Y/n] ' proceed_xwayland
-            if ! [[ "$proceed_xwayland" == [nN]* ]]; then
+            if ! [[ "${proceed_xwayland}" == [nN]* ]]; then
                 echo 'Enabling Xwayland...'
                 ujust set-xwayland on
                 echo 'Enabled Xwayland.'
@@ -478,17 +480,17 @@ install-vpn:
         /usr/libexec/secureblue/dns_selector.py status |
         sed -n 's/^DNS Resolver: //p'
     )
-    if [[ "$resolver" == "systemd-resolved" ]]; then
+    if [[ "${resolver}" == "systemd-resolved" ]]; then
         echo 'DNS resolver is already systemd-resolved. Continuing...'
     else
-        echo "Detected DNS resolver as $resolver".
+        echo "Detected DNS resolver as ${resolver}".
         echo 'Setting DNS resolver to systemd-resolved...'
         /usr/libexec/secureblue/dns_selector.py resolver resolved > /dev/null
     fi
 
     echo
     echo 'Starting installation...'
-    install_vpn "$vpn_choice"
+    install_vpn "${vpn_choice}"
     echo 'Please reboot your device to fully apply the changes.'
 
 # Setup USBGuard
@@ -501,12 +503,12 @@ setup-usbguard:
         mkdir -p /etc/usbguard
         chmod 755 /etc/usbguard
         groupadd usbguard
-        usermod -aG usbguard "$SUDO_USER"
+        usermod -aG usbguard "${SUDO_USER}"
         usbguard generate-policy > /etc/usbguard/rules.conf
         sed -i "/^IPCAllowedGroups=wheel/s/\$/ usbguard/" /etc/usbguard/usbguard-daemon.conf
         restorecon -vR /var/log/usbguard
         systemctl enable --now usbguard.service
-        usbguard add-user "$SUDO_USER"
+        usbguard add-user "${SUDO_USER}"
     '
     if ! rpm-ostree status | grep '●' | grep -Eq 'securecore|iot'; then
         systemctl enable --user --now usbguard-notifier.service

--- a/files/justfiles/desktop/flatpak.just
+++ b/files/justfiles/desktop/flatpak.just
@@ -27,6 +27,7 @@ flatpak-permissions-lockdown:
     kDevicePermissions=("all" "shm" "kvm" "input" "usb")
     kFeaturePermissions=("per-app-dev-shm" "canbus" "bluetooth" "multiarch" "devel")
     kFilesystemPermissions=("home" "host-etc" "host")
+    # shellcheck disable=SC2088
     kDangerousFilesystemPermissions=("~/.bashrc" "~/.bash_profile" "/home" "/var/home" "/var" "/media" "/run/media" "/run" "/mnt")
     kKnownSessionBusNames=("org.xfce.ScreenSaver" "org.mate.ScreenSaver" "org.cinnamon.ScreenSaver" "org.gnome.ScreenSaver" "org.kde.kwalletd6" "org.gnome.Mutter.IdleMonitor.*" "org.gnome.ControlCenter" "org.gnome.Settings" "org.gnome.SettingsDaemon.MediaKeys" "org.gnome.SessionManager" "org.gnome.Shell.Screenshot" "org.kde.kiod5" "org.kde.kwin.Screenshot" "org.kde.JobViewServer" "org.gtk.vfs.*" "org.freedesktop.secrets" "org.kde.kconfig.notify" "org.kde.kpasswdserver" "org.kde.*" "org.kde.StatusNotifierWatcher" "org.kde.kded6" "org.kde.kpasswdserver6" "org.kde.kiod6" "com.canonical.Unity" "org.freedesktop.Notifications" "org.freedesktop.FileManager1" "org.freedesktop.impl.portal.PermissionStore" "org.freedesktop.Flatpak" "com.canonical.AppMenu.Registrar" "org.kde.KGlobalSettings" "org.kde.kded5" "com.canonical.Unity.LauncherEntry" "org.kde.kwalletd5" "org.gnome.SettingsDaemon" "org.a11y.Bus" "com.canonical.indicator.application" "org.freedesktop.ScreenSaver" "ca.desrt.dconf" "org.freedesktop.PowerManagement" "org.gnome.Software" "org.freedesktop.Tracker3.Writeback" "io.missioncenter.MissionCenter.Gatherer")
     kKnownSystemBusNames=("org.bluez" "org.freedesktop.home1" "org.freedesktop.hostname1" "org.freedesktop.import1" "org.freedesktop.locale1" "org.freedesktop.LogControl1" "org.freedesktop.machine1" "org.freedesktop.network1" "org.freedesktop.oom1" "org.freedesktop.portable1" "org.freedesktop.resolve1" "org.freedesktop.sysupdate1" "org.freedesktop.timesync1" "org.freedesktop.timedate1" "org.freedesktop.systemd1" "org.freedesktop.Avahi" "org.freedesktop.Avahi.*" "org.freedesktop.login1" "org.freedesktop.NetworkManager" "org.freedesktop.UPower" "org.freedesktop.UDisks2" "org.freedesktop.fwupd")
@@ -39,72 +40,72 @@ flatpak-permissions-lockdown:
     echo "NOTE 2: This DOES NOT enable hardened_malloc, use the harden-flatpak ujust command."
     echo ""
     read -rp "Would you like to proceed? [y/N] " confirmation
-    if [[ "$confirmation" == [Yy]* ]]; then
+    if [[ "${confirmation}" == [Yy]* ]]; then
         echo "-- Share Permissions --"
         for i in "${kSharePermissions[@]}"; do
-            echo "	Rejecting $i..."
-            $kCommand --unshare="$i"
+            echo "	Rejecting ${i}..."
+            ${kCommand} --unshare="${i}"
         done
         echo ""
         echo "-- Socket Permissions --"
         for i in "${kSocketPermissions[@]}"; do
-            echo "	Rejecting $i..."
-            $kCommand --nosocket="$i"
+            echo "	Rejecting ${i}..."
+            ${kCommand} --nosocket="${i}"
         done
         echo ""
         echo "-- Device Permissions --"
         for i in "${kDevicePermissions[@]}"; do
-            echo "	Rejecting $i..."
-            $kCommand --nodevice="$i"
+            echo "	Rejecting ${i}..."
+            ${kCommand} --nodevice="${i}"
         done
         echo ""
         echo "-- Feature Permissions --"
         for i in "${kFeaturePermissions[@]}"; do
-            echo "	Rejecting $i..."
-            $kCommand --disallow="$i"
+            echo "	Rejecting ${i}..."
+            ${kCommand} --disallow="${i}"
         done
         echo ""
         echo "-- Filesystem Permissions --"
         for i in "${kFilesystemPermissions[@]}"; do
-            echo "	Rejecting $i..."
-            $kCommand --nofilesystem="$i"
+            echo "	Rejecting ${i}..."
+            ${kCommand} --nofilesystem="${i}"
         done
         echo ""
         echo "-- Dangerous Filesystem Permissions --"
         echo "Note: This is a VERY flawed implementation but it does cover a few blatant sandbox escape methods (such as the .bashrc escape or mounted drive access)"
         echo "It is not possible to cover all files since each file can be requested manually and therefore must be rejected manually"
         for i in "${kDangerousFilesystemPermissions[@]}"; do
-            echo "	Rejecting $i..."
-            $kCommand --nofilesystem="$i"
+            echo "	Rejecting ${i}..."
+            ${kCommand} --nofilesystem="${i}"
         done
         echo ""
         echo "NOTE: The next 2 lockdowns are NOT complete and only cover a list of known names, this can be expanded at any time"
         echo "-- Session Bus Name Access --"
         for i in "${kKnownSessionBusNames[@]}"; do
-            echo "	Rejecting $i..."
-            $kCommand --no-talk-name="$i"
+            echo "	Rejecting ${i}..."
+            ${kCommand} --no-talk-name="${i}"
         done
         echo ""
         echo "-- System Bus Name Access --"
         for i in "${kKnownSystemBusNames[@]}"; do
-            echo "	Rejecting $i..."
-            $kCommand --system-no-talk-name="$i"
+            echo "	Rejecting ${i}..."
+            ${kCommand} --system-no-talk-name="${i}"
         done
         echo ""
         echo "-- Persistent Filesystem Grant --"
         echo "Note: This is to unbreak many Flatpaks by allowing the app to store persistent data in their own, isolated home directory without accessing the user's"
         echo "	Granting access to persistent home..."
-        $kCommand --persist=.
+        ${kCommand} --persist=.
         echo ""
         echo "-- Granting Access to Common Permissions --"
         echo "Note: This will grant all apps access to some permissions to ensure most apps work by default, this also encourages the use of these permissions instead of their alternatives"
         echo "	Granting access to Wayland and hardware acceleration..."
-        $kCommand --socket=wayland --device=dri
+        ${kCommand} --socket=wayland --device=dri
         echo ""
         echo "-- Granting Flatseal Access to Bus Names --"
         for i in "${kFlatsealNameAccess[@]}"; do
-            echo "	Granting $i..."
-            $kCommand --talk-name="$i" com.github.tchx84.Flatseal
+            echo "	Granting ${i}..."
+            ${kCommand} --talk-name="${i}" com.github.tchx84.Flatseal
         done
         echo ""
         echo "Done"
@@ -113,7 +114,7 @@ flatpak-permissions-lockdown:
 # Resets Flatpak's global overrides
 flatpak-reset-global-overrides:
     #!/usr/bin/bash
-    GLOBAL_OVERRIDES="$HOME/.local/share/flatpak/overrides/global"
+    GLOBAL_OVERRIDES="${HOME}/.local/share/flatpak/overrides/global"
     echo "This will undo the flatpak-harden command, the flatpak-permissions-lockdown command, as well as any other global overrides (individual app overrides will not be affected)."
-    echo "It will not delete the file, but simply move it from $GLOBAL_OVERRIDES to $GLOBAL_OVERRIDES.save"
-    mv "$GLOBAL_OVERRIDES" "$GLOBAL_OVERRIDES.save"
+    echo "It will not delete the file, but simply move it from ${GLOBAL_OVERRIDES} to ${GLOBAL_OVERRIDES}.save"
+    mv "${GLOBAL_OVERRIDES}" "${GLOBAL_OVERRIDES}.save"

--- a/files/justfiles/desktop/steam.just
+++ b/files/justfiles/desktop/steam.just
@@ -6,13 +6,13 @@
 install-steam:
     #!/usr/bin/bash
     need_reboot=false
-    if [ -z "$(pgrep Xwayland)" ] && [ -z "$(pgrep Xorg)" ] ; then
+    if [[ -z "$(pgrep Xwayland)" && -z "$(pgrep Xorg)" ]]; then
         echo "Steam requires X or Xwayland, which your variant of secureblue has disabled by default." | fold -s
         echo "Please run 'ujust set-xwayland on' to re-enable it."
         enable_xwayland_now=""
         read -rp "Would you like to run 'ujust set-xwayland on' now? [Y/n] " enable_xwayland_now
         enable_xwayland_now=${enable_xwayland_now:-y}
-        if [[ "$enable_xwayland_now" == [Yy]* ]]; then
+        if [[ "${enable_xwayland_now}" == [Yy]* ]]; then
             echo "Running 'ujust set-xwayland on'"
             ujust set-xwayland on
             need_reboot=true
@@ -24,21 +24,21 @@ install-steam:
     echo "    2) Distrobox - Install Steam via the steambox (bazzite-arch) distrobox image (Recommended for SteamVR users)" | fold -s
     while true; do
         read -rp "Selection (1 or 2): " method_selection
-        case "$method_selection" in
+        case "${method_selection}" in
             1|2) break ;;
             *) echo "That is not a valid selection." ;;
         esac
     done
 
     echo "" # blank space
-    case "$method_selection" in
+    case "${method_selection}" in
         1)
             echo "Flatpak method selected."
             if ! flatpak remotes --columns=name | grep -q '^flathub$'; then
                 echo "The Steam flatpak is not verified by Valve and only distributed via the unfiltered Flathub repo." | fold -s
                 read -rp "Would you like to enable the unfiltered Flathub repo now? [Y/n] " flathub_unfiltered
                 flathub_unfiltered=${flathub_unfiltered:-y}
-                if [[ "$flathub_unfiltered" == [Yy]* ]]; then
+                if [[ "${flathub_unfiltered}" == [Yy]* ]]; then
                     echo "Enabling the unfiltered Flathub repo."
                     ujust enable-flathub-unfiltered
                 else
@@ -67,7 +67,7 @@ install-steam:
                 container_userns_now=""
                 read -rp "Would you like to run 'ujust set-container-userns on' now? [Y/n] " container_userns_now
                 container_userns_now=${container_userns_now:-y}
-                if [[ "$container_userns_now" == [Yy]* ]]; then
+                if [[ "${container_userns_now}" == [Yy]* ]]; then
                     echo "Running 'ujust set-container-userns on'"
                     ujust set-container-userns on
                 fi
@@ -94,17 +94,17 @@ install-steam:
         echo "You can enable ptrace support by running 'ujust set-ptrace on'."
         enable_ptrace=""
         read -rp "Would you like to enable ptrace support now? [y/N] " enable_ptrace
-        if [[ "$enable_ptrace" == [Yy]* ]]; then
+        if [[ "${enable_ptrace}" == [Yy]* ]]; then
             ujust set-ptrace on
         fi
     fi
 
-    if [[ "$need_reboot" == true ]]; then
+    if [[ "${need_reboot}" == true ]]; then
         echo "One or more of the changes made necessitates a reboot."
         echo "Steam will not work until you reboot."
         reboot_now=""
         read -rp "Would you like to reboot now? [y/N] " reboot_now
-        if [[ "$reboot_now" == [Yy]* ]]; then
+        if [[ "${reboot_now}" == [Yy]* ]]; then
             echo "Rebooting"
             systemctl reboot
         fi

--- a/files/justfiles/kinoite.just
+++ b/files/justfiles/kinoite.just
@@ -6,12 +6,12 @@
 toggle-ghns:
     #! /bin/run0 /bin/bash
     KDE_GLOBALS_FILE='/etc/xdg/kdeglobals'
-    if test -e "$KDE_GLOBALS_FILE"; then
-        if grep -q '^ghns=false' "$KDE_GLOBALS_FILE"; then
-            sed -i 's/^ghns=false.*/ghns=true/' "$KDE_GLOBALS_FILE"
+    if test -e "${KDE_GLOBALS_FILE}"; then
+        if grep -q '^ghns=false' "${KDE_GLOBALS_FILE}"; then
+            sed -i 's/^ghns=false.*/ghns=true/' "${KDE_GLOBALS_FILE}"
             echo 'GHNS enabled.'
-        elif grep -q '^ghns=true' "$KDE_GLOBALS_FILE"; then
-            sed -i 's/^ghns=true.*/ghns=false/' "$KDE_GLOBALS_FILE"
+        elif grep -q '^ghns=true' "${KDE_GLOBALS_FILE}"; then
+            sed -i 's/^ghns=true.*/ghns=false/' "${KDE_GLOBALS_FILE}"
             echo 'GHNS disabled.'
         else
             echo 'The kdeglobals file is missing the ghns toggle.'

--- a/files/justfiles/silverblue.just
+++ b/files/justfiles/silverblue.just
@@ -6,12 +6,12 @@
 toggle-gnome-jit-js:
     #! /bin/run0 /bin/bash
     ENV_FILE="/etc/profile.d/gnome-disable-jit.sh"
-    if test -e $ENV_FILE; then
-        rm -f $ENV_FILE
+    if test -e "${ENV_FILE}"; then
+        rm -f "${ENV_FILE}"
         echo "JIT JavaScript for Gnome and WebkitGTK has been enabled."
     else
-        cp /usr$ENV_FILE $ENV_FILE
-        chmod 644 $ENV_FILE
+        cp "/usr${ENV_FILE}" "${ENV_FILE}"
+        chmod 644 "${ENV_FILE}"
         echo "JIT JavaScript for Gnome and WebkitGTK has been disabled."
     fi
 

--- a/files/system/desktop/usr/libexec/secureblue/image-deprecation-check
+++ b/files/system/desktop/usr/libexec/secureblue/image-deprecation-check
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 
 # SPDX-FileCopyrightText: Copyright 2025 Universal Blue
 # SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors

--- a/files/system/desktop/usr/libexec/secureblue/image-deprecation-notify
+++ b/files/system/desktop/usr/libexec/secureblue/image-deprecation-notify
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 
 # SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
 #

--- a/files/system/desktop/usr/libexec/secureblue/securebluecheckoutofdate
+++ b/files/system/desktop/usr/libexec/secureblue/securebluecheckoutofdate
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 
 # SPDX-FileCopyrightText: Copyright 2025 Universal Blue
 # SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors

--- a/files/system/desktop/usr/libexec/secureblue/secureblueflatpaksetup
+++ b/files/system/desktop/usr/libexec/secureblue/secureblueflatpaksetup
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 
 # SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
 #

--- a/files/system/desktop/usr/libexec/secureblue/secureblueoutofdatenotify
+++ b/files/system/desktop/usr/libexec/secureblue/secureblueoutofdatenotify
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 
 # SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
 #

--- a/files/system/desktop/usr/libexec/secureblue/securebluesecurebootnotify
+++ b/files/system/desktop/usr/libexec/secureblue/securebluesecurebootnotify
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 
 # SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
 #

--- a/files/system/etc/profile.d/xx-bash-prompt-command.sh
+++ b/files/system/etc/profile.d/xx-bash-prompt-command.sh
@@ -2,5 +2,6 @@
 # Filename needs to be alphabetically later than vte.sh
 if [[ $- == *i* && -n "${BASH_VERSION:-}" ]]; then
     # Print nonzero exit codes in bold red text inside square brackets at beginning of prompt
+    # shellcheck disable=SC2154
     PS1='$(code=${?#0};echo -n "${code:+\[\e[31m\][\[\e[1m\]${code}\[\e[22m\]]\[\e[39m\]}")'"${PS1:-}"
 fi

--- a/files/system/usr/libexec/secureblue/ptrace-migration.sh
+++ b/files/system/usr/libexec/secureblue/ptrace-migration.sh
@@ -8,7 +8,7 @@ set -eu
 
 ptrace_scope=$(grep -oP '^kernel.yama.ptrace_scope\s*=\s*\K[0-9]+' /etc/sysctl.d/61-ptrace-scope.conf 2>/dev/null || echo 3)
 
-case "$ptrace_scope" in
+case "${ptrace_scope}" in
     0|1) ujust set-ptrace on ;;
     2) ujust set-ptrace container ;;
 esac

--- a/files/system/usr/libexec/secureblue/securebluecleanup
+++ b/files/system/usr/libexec/secureblue/securebluecleanup
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 
 # SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
 #

--- a/files/system/usr/share/bash-completion/completions/ujust
+++ b/files/system/usr/share/bash-completion/completions/ujust
@@ -6,6 +6,7 @@
 
 _comp_ujust() {
     local IFS=$' \t\n'
+    # shellcheck disable=SC2034
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
     if [[ "${words[1]-}" == 'with-standard-malloc' ]] && (( cword >= 2 )); then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,5 +61,5 @@ pycodestyle.max-doc-length = 100
 # Don't require audit checks' function signatures to have type hints.
 "files/system/usr/libexec/secureblue/audit_secureblue.py" = ["ANN"]
 
-# Allow partial executable paths in subprocess invocations in this script.
-"tools/update_po.py" = ["S607"]
+# Allow partial executable paths in subprocess invocations in dev tools
+"tools/*.py" = ["S607"]

--- a/tools/check-shell-script-shebangs.awk
+++ b/tools/check-shell-script-shebangs.awk
@@ -1,0 +1,30 @@
+#!/usr/bin/env -S awk -f
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+BEGIN {
+    print "Checking shebang lines of shell scripts..."
+    failure = 0
+}
+
+FNR == 1 && (FILENAME ~ /\.sh$/ || /^#![[:blank:]]*(\/usr)?\/bin\/(env[[:blank:]]+)?(ba)?sh[[:blank:]]*$/) {
+    if ($0 !~ /^#!/) {
+        print FILENAME " is missing a shebang line."
+        failure = 1
+    } else if (FILENAME ~ /^files\/system\// && $0 !~ /^#!(\/usr)?\/bin\/(ba)?sh$/) {
+        print FILENAME " has non-normalized shebang line: \"" $0 "\" (should be absolute)"
+        failure = 1
+    } else if (FILENAME !~ /^files\/system\// && $0 != "#!/usr/bin/env bash") {
+        print FILENAME " has non-normalized shebang line: \"" $0 "\" (should be \"#!/usr/bin/env bash\")"
+        failure = 1
+    }
+}
+
+END {
+    if (failure)
+        exit 1
+    else
+        print "No issues found."
+}

--- a/tools/shellcheck_justfiles.py
+++ b/tools/shellcheck_justfiles.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+
+def command_stdout(*args: str) -> str:
+    """Run a command in the shell and return the contents of stdout."""
+    return subprocess.run(args, check=True, capture_output=True, text=True).stdout.rstrip("\n")
+
+
+def extract_recipe(raw_recipe: str) -> str:
+    """Remove recipe header and dedent script"""
+    recipe = "\n".join(line for line in raw_recipe.splitlines() if line.startswith((" ", "\t")))
+    return textwrap.dedent(recipe + "\n")
+
+
+def normalize_shebang(script: str) -> str:
+    return re.sub(r"^#!\s*(?:(?:/usr)?/bin/run0\s+)?", "#!", script)
+
+
+def is_shell_script(script: str) -> bool:
+    """Test if string looks like a shell script"""
+    matches = re.match(r"#!\s*(?:/usr)?/bin/(?:env\s+)?(?:ba)?sh\s*$", script, flags=re.MULTILINE)
+    return matches is not None
+
+
+script_path = os.path.abspath(os.path.dirname(sys.argv[0]))
+os.chdir(script_path)
+git_root = command_stdout("git", "rev-parse", "--show-toplevel")
+os.chdir(git_root)
+
+justfiles = []
+for root, _, files in os.walk("files/justfiles"):
+    justfiles += (f"{root}/{file}" for file in files)
+
+print("Running ShellCheck on scripts in the following justfiles:")
+print(*justfiles, sep="\n", end="\n\n")
+
+temp_dir = tempfile.mkdtemp(prefix="justfile-tmp-", dir=".")
+recipe_paths = []
+for justfile in justfiles:
+    try:
+        recipes = command_stdout("just", "-f", justfile, "--summary").split()
+    except subprocess.CalledProcessError:
+        print(f"Error parsing justfile '{justfile}'")
+        sys.exit(1)
+    for recipe in recipes:
+        raw_recipe = command_stdout("just", "-f", justfile, "--show", recipe)
+        recipe_script = normalize_shebang(extract_recipe(raw_recipe))
+        if is_shell_script(recipe_script):
+            recipe_fd, recipe_path = tempfile.mkstemp(dir=temp_dir, prefix=f"{recipe}-")
+            with open(recipe_fd, "w", encoding="utf8") as recipe_file:
+                recipe_file.write(recipe_script)
+            recipe_paths.append(recipe_path)
+
+result = subprocess.run(["shellcheck", *sys.argv[1:], "--", *recipe_paths], check=False)
+
+shutil.rmtree(temp_dir)
+
+sys.exit(result.returncode)


### PR DESCRIPTION
...including shell scripts embedded in justfiles. Also:

* Lint shebang lines to ensure that they're consistent (specifically, that runtime scripts use an absolute shebang such as `#!/usr/bin/bash`, while build-time scripts use a relative shebang like `#!/usr/bin/env bash`), and include a pre-commit hook for this check.
* Normalize shebangs to pass the above check.
* Fix style issues flagged by ShellCheck, including in justfiles.