### PR TITLE
fix: unblock xpad module

### DIFF
--- a/files/system/usr/lib/modprobe.d/secureblue.conf
+++ b/files/system/usr/lib/modprobe.d/secureblue.conf
@@ -216,7 +216,7 @@ install vimc /bin/false
 # disable vivid
 install vivid /bin/false
 # https://github.com/torvalds/linux/blob/master/drivers/usb/gadget/udc/dummy_hcd.c
-install dummy_hcd /bin/false 
+install dummy_hcd /bin/false
 # https://manpages.ubuntu.com/manpages/bionic/man4/nandsim.4freebsd.html
 # https://github.com/torvalds/linux/blob/master/drivers/mtd/nand/raw/nandsim.c
 install nandsim /bin/false
@@ -321,9 +321,9 @@ install nec7210 /bin/false
 # https://github.com/torvalds/linux/blob/master/drivers/gpib/ni_usb/ni_usb_gpib.c
 install ni_usb_gpib /bin/false
 # # https://github.com/torvalds/linux/blob/master/drivers/gpib/tms9914/tms9914.c
-install tms9914 /bin/false  
+install tms9914 /bin/false
 # https://github.com/torvalds/linux/tree/master/drivers/gpib/tnt4882
-install tnt4882 /bin/false  
+install tnt4882 /bin/false
 
 
 # DVB and TV receivers
@@ -609,8 +609,6 @@ install twidjoy /bin/false
 install walkera0701 /bin/false
 # https://github.com/torvalds/linux/blob/master/drivers/input/joystick/warrior.c
 install warrior /bin/false
-# https://github.com/torvalds/linux/blob/master/drivers/input/joystick/xpad.c
-install xpad /bin/false
 # https://github.com/torvalds/linux/blob/master/drivers/input/joystick/zhenhua.c
 install zhenhua /bin/false
 


### PR DESCRIPTION
All the other joystick input drivers seem to be for legacy devices, but `xpad` includes a bunch of gaming controllers, including a fair number of modern ones that have a reasonable chance of being used on desktop by some users.