### PR TITLE
fix: unblock hid-playstation module

### DIFF
--- a/files/system/usr/lib/modprobe.d/secureblue.conf
+++ b/files/system/usr/lib/modprobe.d/secureblue.conf
@@ -566,8 +566,6 @@ install grip /bin/false
 install grip_mp /bin/false
 # https://github.com/torvalds/linux/blob/master/drivers/input/joystick/guillemot.c
 install guillemot /bin/false
-# https://github.com/torvalds/linux/blob/master/drivers/hid/hid-playstation.c
-install hid-playstation /bin/false
 # https://github.com/torvalds/linux/tree/master/drivers/input/joystick/iforce
 install iforce /bin/false
 install iforce-serio /bin/false


### PR DESCRIPTION
This module includes support for the PS5 controller, which is still widely used and supported.