### PR TITLE
feat(uki): sealed image builds

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,7 +46,7 @@ body:
     attributes:
       label: Image
       description: Your current image
-      placeholder: 'rpm-ostree status'
+      placeholder: 'rpm-ostree status (or `run0 -i bootc status` on UKI systems)'
     validations:
       required: true
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      pre-commit:
+        applies-to: "version-updates"
+        patterns:
+          - "*"

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -46,6 +46,25 @@ jobs:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
 
+  silverblue-main-sealed:
+    name: Build silverblue main sealed
+    if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
+    needs: silverblue-main
+    permissions:
+      contents: read # Needed to pull the repo for the build
+      actions: read # Needed to read actions and actions logs for provenance generation
+      packages: write # Needed to publish images
+      id-token: write # Needed for token generation for signing
+    uses: ./.github/workflows/build-sealed-image.yml
+    with:
+      image: ${{ needs.silverblue-main.outputs.IMAGE_NAME }}
+      base_tag: ${{ needs.silverblue-main.outputs.IMAGE_TAG }}
+      base_digest: ${{ needs.silverblue-main.outputs.IMAGE_DIGEST }}
+      image_version: ${{ needs.silverblue-main.outputs.IMAGE_VERSION }}
+    secrets:
+      COSIGN_KEY: ${{ secrets.SIGNING_SECRET }}
+      UKI_DB_KEY: ${{ secrets.UKI_DB_KEY }}
+
   kinoite-main:
     name: Build kinoite main
     if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'

--- a/.github/workflows/build-one-recipe.yml
+++ b/.github/workflows/build-one-recipe.yml
@@ -23,6 +23,15 @@ on:
         required: true
       KERNEL_PRIVKEY:
         required: true
+    outputs:
+      IMAGE_DIGEST:
+        value: ${{ jobs.bluebuild.outputs.IMAGE_DIGEST }}
+      IMAGE_NAME:
+        value: ${{ jobs.bluebuild.outputs.IMAGE_NAME }}
+      IMAGE_TAG:
+        value: ${{ jobs.bluebuild.outputs.IMAGE_TAG }}
+      IMAGE_VERSION:
+        value: ${{ jobs.bluebuild.outputs.IMAGE_VERSION }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.recipe }}
@@ -34,8 +43,11 @@ jobs:
     runs-on: ubuntu-24.04
     environment: Build
     outputs:
-      FULL_IMAGE_REF: ${{ steps.runner_setup.outputs.FULL_IMAGE_REF }}
+      FULL_IMAGE_REF: ${{ steps.image_data.outputs.FULL_IMAGE_REF }}
+      IMAGE_NAME: ${{ steps.image_data.outputs.IMAGE_NAME }}
       IMAGE_DIGEST: ${{ steps.image_manifest_metadata.outputs.IMAGE_DIGEST }}
+      IMAGE_TAG: ${{ steps.image_data.outputs.IMAGE_TAG }}
+      IMAGE_VERSION: ${{ steps.image_data.outputs.BASE_IMAGE_VERSION }}
     permissions:
       contents: read # Needed to pull the repo for the build
       packages: write # Needed to publish images
@@ -186,11 +198,64 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Gather image data from recipe
+        id: image_data
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          PR_EVENT_NUMBER: ${{ github.event.number }}
+          RECIPE: ${{ inputs.recipe }}
+        run: |
+          IMAGE_NAME=$(yq -r '."name"' "./recipes/${RECIPE}")
+          echo "IMAGE_NAME=${IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "BASE_IMAGE=$(yq -r '."base-image"' "./recipes/${RECIPE}")" >> "${GITHUB_OUTPUT}"
+          echo "BASE_IMAGE_VERSION=$(yq -r '."image-version"' "./recipes/${RECIPE}")" >> "${GITHUB_OUTPUT}"
+
+          case "$GITHUB_REF" in
+            refs/heads/"$DEFAULT_BRANCH") image_tag='latest' ;;
+            refs/pull/*) image_tag="pr-${PR_EVENT_NUMBER}-44" ;;
+            *) image_tag="br-${GITHUB_REF_NAME}-44" ;;
+          esac
+          echo "IMAGE_TAG=${image_tag}" >> "${GITHUB_OUTPUT}"
+          FULL_IMAGE_REF="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${IMAGE_NAME}:${image_tag}"
+          echo "FULL_IMAGE_REF=${FULL_IMAGE_REF}" >> "${GITHUB_OUTPUT}"
+
       - name: Runner setup
         id: runner_setup
         uses: ./.github/workflows/shared-runner-setup
         with:
-          recipe: ${{ inputs.recipe }}
+          needs_cosign: ${{ steps.image_data.outputs.IMAGE_NAME != 'securecore-main-hardened' && steps.image_data.outputs.IMAGE_NAME != 'iot-main-hardened' }}
+          needs_slsa_crane: ${{ startsWith(steps.image_data.outputs.BASE_IMAGE, format('ghcr.io/{0}/', github.repository_owner)) }}
+
+      - name: Verify base image provenance
+        shell: bash
+        if: startsWith(steps.image_data.outputs.BASE_IMAGE, format('ghcr.io/{0}/', github.repository_owner))
+        env:
+          BASE_IMAGE_VERSION: ${{ steps.image_data.outputs.BASE_IMAGE_VERSION }}
+          BASE_IMAGE: ${{ steps.image_data.outputs.BASE_IMAGE }}
+        run: |
+          DIGEST=$(crane digest "${BASE_IMAGE}:${BASE_IMAGE_VERSION}")
+          slsa-verifier verify-image --source-uri "github.com/${GITHUB_REPOSITORY}" "${BASE_IMAGE}:${BASE_IMAGE_VERSION}@${DIGEST}"
+          # remove slsa-verifier so that it can be successfully reinstalled later by bluebuild
+          rm -rf ~/.slsa/
+
+      - name: Verify base image signature
+        shell: bash
+        if: steps.image_data.outputs.IMAGE_NAME != 'securecore-main-hardened' && steps.image_data.outputs.IMAGE_NAME != 'iot-main-hardened'
+        env:
+          BASE_IMAGE_VERSION: ${{ steps.image_data.outputs.BASE_IMAGE_VERSION }}
+          BASE_IMAGE: ${{ steps.image_data.outputs.BASE_IMAGE }}
+        run: |
+          UPSTREAM_CONTAINER="${BASE_IMAGE}:${BASE_IMAGE_VERSION}"
+          if [[ "$BASE_IMAGE" == "ghcr.io/${GITHUB_REPOSITORY_OWNER}/"* ]]; then
+            UPSTREAM_PUBKEY='./cosign.pub'
+          else
+            UPSTREAM_PUBKEY='./files/system/usr/share/pki/containers/quay.io-fedora-ostree-desktops.pub'
+          fi
+          if ! cosign verify --key "${UPSTREAM_PUBKEY}" "${UPSTREAM_CONTAINER}" | jq; then
+            echo "NOTICE: Verification failed. Please ensure your public key is correct."
+            exit 1
+          fi
 
       - name: Decide whether to clear previous layer plan
         id: clear_plan
@@ -198,7 +263,7 @@ jobs:
         env:
           rechunk: ${{ inputs.rechunk }}
           input_clear_plan: ${{ inputs.clear-plan }}
-          FULL_IMAGE_REF: ${{ steps.runner_setup.outputs.FULL_IMAGE_REF }}
+          FULL_IMAGE_REF: ${{ steps.image_data.outputs.FULL_IMAGE_REF }}
         run: |
           clear_plan='false'
           if [[ "$input_clear_plan" == 'true' ]]; then
@@ -243,7 +308,7 @@ jobs:
         id: image_manifest_metadata
         shell: bash
         env:
-          FULL_IMAGE_REF: ${{ steps.runner_setup.outputs.FULL_IMAGE_REF }}
+          FULL_IMAGE_REF: ${{ steps.image_data.outputs.FULL_IMAGE_REF }}
         run: |
           IMAGE_DIGEST=$(regctl image digest "${FULL_IMAGE_REF}")
           echo "IMAGE_DIGEST=${IMAGE_DIGEST}" >> "${GITHUB_OUTPUT}"
@@ -256,7 +321,7 @@ jobs:
       packages: write # for uploading attestations.
     # Currently this must be referenced by tag, not by hash:
     # https://github.com/slsa-framework/slsa-github-generator?tab=readme-ov-file#referencing-slsa-builders-and-generators
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0 # zizmor: ignore[unpinned-uses]
     with:
       image: ${{ needs.bluebuild.outputs.FULL_IMAGE_REF }}
       digest: ${{ needs.bluebuild.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/build-sealed-image.yml
+++ b/.github/workflows/build-sealed-image.yml
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: build-sealed-image
+
+permissions: {}
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: "Image name (e.g. silverblue-main-hardened)."
+        type: string
+        required: true
+      base_tag:
+        description: "The tag of the base image (e.g. latest)."
+        type: string
+        required: true
+      base_digest:
+        description: "The digest of the base image to seal (e.g. sha256:abc123)."
+        type: string
+        required: true
+      image_version:
+        description: "The Fedora image version used for getting the systemd-boot image, e.g. 44."
+        type: string
+        required: true
+    secrets:
+      COSIGN_KEY:
+        required: true
+      UKI_DB_KEY:
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.image }}
+  cancel-in-progress: true
+
+jobs:
+  build-sealed-image:
+    name: "Build sealed image"
+    runs-on: "ubuntu-26.04"
+    outputs:
+      IMAGE_DIGEST: ${{ steps.push.outputs.digest }}
+    permissions:
+      contents: read # Needed to pull the repo for the build
+      packages: write # Needed to publish images
+    steps:
+      - name: "Harden Runner"
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: "Check out repository"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: "Set up runner"
+        uses: ./.github/workflows/shared-runner-setup
+        with:
+          needs_cosign: true
+          needs_slsa_crane: true
+
+      - name: "Log in to registry"
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        with:
+          registry: "ghcr.io/${{ github.repository_owner }}"
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Get base image digests"
+        id: base_image_digests
+        shell: bash
+        env:
+          IMAGE_VERSION: ${{ inputs.image_version }}
+        run: |
+          SYSTEMD_BOOT_DIGEST=$(crane digest "ghcr.io/${GITHUB_REPOSITORY_OWNER}/systemd-boot:${IMAGE_VERSION}")
+          echo "SYSTEMD_BOOT_DIGEST=${SYSTEMD_BOOT_DIGEST}" >> "${GITHUB_OUTPUT}"
+          UKI_ADDONS_DIGEST=$(crane digest "ghcr.io/${GITHUB_REPOSITORY_OWNER}/uki-addons:latest")
+          echo "UKI_ADDONS_DIGEST=${UKI_ADDONS_DIGEST}" >> "${GITHUB_OUTPUT}"
+
+      - name: "Verify base images"
+        shell: bash
+        env:
+          REPO: "ghcr.io/${{ github.repository_owner }}"
+          BASE_IMAGE: ${{ inputs.image }}
+          BASE_IMAGE_DIGEST: ${{ inputs.base_digest }}
+          SYSTEMD_BOOT_DIGEST: ${{ steps.base_image_digests.outputs.SYSTEMD_BOOT_DIGEST }}
+          UKI_ADDONS_DIGEST: ${{ steps.base_image_digests.outputs.UKI_ADDONS_DIGEST }}
+        run: |
+          slsa-verifier verify-image --source-uri "github.com/${GITHUB_REPOSITORY}" "${REPO}/${BASE_IMAGE}@${BASE_IMAGE_DIGEST}"
+          cosign verify --key ./cosign.pub "${REPO}/${BASE_IMAGE}@${BASE_IMAGE_DIGEST}"
+          slsa-verifier verify-image --source-uri "github.com/${GITHUB_REPOSITORY}" "${REPO}/systemd-boot@${SYSTEMD_BOOT_DIGEST}"
+          cosign verify --key ./cosign.pub "${REPO}/systemd-boot@${SYSTEMD_BOOT_DIGEST}"
+          slsa-verifier verify-image --source-uri "github.com/${GITHUB_REPOSITORY}" "${REPO}/uki-addons@${UKI_ADDONS_DIGEST}"
+          cosign verify --key ./cosign.pub "${REPO}/uki-addons@${UKI_ADDONS_DIGEST}"
+
+      - name: "Generate tags"
+        id: tags
+        run: |
+          set -euxo pipefail
+          date="$(date '+%Y%m%d')"
+          tags="${BASE_TAG}-uki"
+          if [[ "$BASE_TAG" == "latest" ]]; then
+            tags+=" uki ${date}-${IMAGE_VERSION}-uki ${date}-uki ${IMAGE_VERSION}-uki"
+          fi
+          echo "tags=${tags}" >> "$GITHUB_OUTPUT"
+        env:
+          BASE_TAG: ${{ inputs.base_tag }}
+          IMAGE_VERSION: ${{ inputs.image_version }}
+
+      - name: "Get secure boot signing key"
+        run: |
+          mkdir -p /tmp/keys
+          printenv UKI_DB_KEY > /tmp/keys/key
+          cp uki/keys/db/db.pem /tmp/keys/crt
+        env:
+          UKI_DB_KEY: ${{ secrets.UKI_DB_KEY }}
+
+      - name: "Build kernel container"
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
+        with:
+          image: ${{ inputs.image }}-kernel
+          tags: ${{ inputs.base_tag }}-uki
+          containerfiles: uki/Containerfile.kernel
+          oci: true
+          build-args: |
+            BASE=ghcr.io/${{ github.repository_owner }}/${{ inputs.image }}@${{ inputs.base_digest }}
+
+      - name: "Build base container"
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
+        with:
+          image: ${{ inputs.image }}-base
+          tags: ${{ inputs.base_tag }}-uki
+          containerfiles: uki/Containerfile.base
+          oci: true
+          build-args: |
+            BASE=ghcr.io/${{ github.repository_owner }}/${{ inputs.image }}@${{ inputs.base_digest }}
+            SYSTEMDBOOT=ghcr.io/${{ github.repository_owner }}/systemd-boot:${{ inputs.image_version }}
+            UKIADDONS=ghcr.io/${{ github.repository_owner }}/uki-addons:latest
+          extra-args: |
+            --skip-unused-stages=false
+            --security-opt=label=disable
+            --volume /home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}:/run/src
+
+      - name: "Build final container"
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
+        with:
+          image: ${{ inputs.image }}
+          tags: ${{ steps.tags.outputs.tags }}
+          containerfiles: uki/Containerfile.uki
+          oci: true
+          build-args: |
+            BASE=${{ inputs.image }}-base:${{ inputs.base_tag }}-uki
+            KERNEL=${{ inputs.image }}-kernel:${{ inputs.base_tag }}-uki
+            RELEASE=${{ inputs.image_version }}
+          extra-args: |
+            --security-opt=label=disable
+            --volume /home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}:/run/src
+            --secret id=secureboot_key,src=/tmp/keys/key
+            --secret id=secureboot_crt,src=/tmp/keys/crt
+
+      - name: "Clean up secure boot signing key"
+        if: always()
+        run: rm -vrf /tmp/keys
+
+      - name: "Push to registry"
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
+        id: push
+        with:
+          image: ${{ inputs.image }}
+          tags: ${{ steps.tags.outputs.tags }}
+          registry: "ghcr.io/${{ github.repository_owner }}"
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Sign container image"
+        run: |
+          cosign sign -y --key env://COSIGN_KEY "ghcr.io/${GITHUB_REPOSITORY_OWNER}/${IMAGE}@${DIGEST}"
+        env:
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
+          IMAGE: ${{ inputs.image }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+
+  provenance:
+    needs: build-sealed-image
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    # Currently this must be referenced by tag, not by hash:
+    # https://github.com/slsa-framework/slsa-github-generator?tab=readme-ov-file#referencing-slsa-builders-and-generators
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0 # zizmor: ignore[unpinned-uses]
+    with:
+      image: "ghcr.io/${{ github.repository_owner }}/${{ inputs.image }}"
+      digest: ${{ needs.build-sealed-image.outputs.IMAGE_DIGEST }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -174,8 +174,6 @@ jobs:
       - name: Runner setup
         id: runner_setup
         uses: ./.github/workflows/shared-runner-setup
-        with:
-          recipe: ${{ inputs.recipe }}
 
       - name: Set up test keys
         id: test_keys

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.14"
 

--- a/.github/workflows/shared-runner-setup/action.yml
+++ b/.github/workflows/shared-runner-setup/action.yml
@@ -7,14 +7,14 @@ name: shared-runner-setup
 description: Build runner setup
 
 inputs:
-  recipe:
-    type: string
-    required: true
-
-outputs:
-  FULL_IMAGE_REF:
-    description: "Full reference for the image to be built"
-    value: ${{ steps.image_data.outputs.FULL_IMAGE_REF }}
+  needs_cosign:
+    description: "Whether to install cosign, otherwise 'false'."
+    required: false
+    default: 'false'
+  needs_slsa_crane:
+    description: "Whether to install slsa-verifier and crane, otherwise 'false'."
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -25,7 +25,7 @@ runs:
         echo 'set man-db/auto-update false' | sudo debconf-communicate
         sudo dpkg-reconfigure man-db
         sudo rm -f /var/lib/man-db/auto-update
-        sudo sed -i 's/^update_initramfs=.*/update_initramfs=no/' /etc/initramfs-tools/update-initramfs.conf
+        echo "update_initramfs=no" | sudo tee /etc/initramfs-tools/update-initramfs.conf
 
     - name: Drop Ubuntu HTTP mirrors and chrome repo
       shell: bash
@@ -34,42 +34,19 @@ runs:
         sudo sed -i '/^http:\/\//d' /etc/apt/apt-mirrors.txt
         sudo apt-get update
 
-    - name: Install dependencies
-      shell: bash
-      run: |
-        sudo apt install yq
-
-    - name: Gather image data from recipe
-      id: image_data
-      shell: bash
-      env:
-        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        PR_EVENT_NUMBER: ${{ github.event.number }}
-        RECIPE: ${{ inputs.recipe }}
-      run: |
-        IMAGE_NAME=$(yq -r '."name"' "./recipes/${RECIPE}")
-        echo "IMAGE_NAME=${IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
-        echo "BASE_IMAGE=$(yq -r '."base-image"' "./recipes/${RECIPE}")" >> "${GITHUB_OUTPUT}"
-        echo "BASE_IMAGE_VERSION=$(yq -r '."image-version"' "./recipes/${RECIPE}")" >> "${GITHUB_OUTPUT}"
-
-        case "$GITHUB_REF" in
-          refs/heads/"$DEFAULT_BRANCH") image_tag='latest' ;;
-          refs/pull/*) image_tag="pr-${PR_EVENT_NUMBER}-44" ;;
-          *) image_tag="br-${GITHUB_REF_NAME}-44" ;;
-        esac
-        FULL_IMAGE_REF="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${IMAGE_NAME}:${image_tag}"
-        echo "FULL_IMAGE_REF=${FULL_IMAGE_REF}" >> "${GITHUB_OUTPUT}"
+    - name: Install cosign
+      uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+      if: ${{ inputs.needs_cosign == 'true' }}
+      with:
+        cosign-release: 'v2.6.0'
 
     - name: Install slsa-verifier
-      if: startsWith(steps.image_data.outputs.BASE_IMAGE, format('ghcr.io/{0}/', github.repository_owner))
+      if: ${{ inputs.needs_slsa_crane == 'true' }}
       uses: slsa-framework/slsa-verifier/actions/installer@ea584f4502babc6f60d9bc799dbbb13c1caa9ee6 # v2.7.1
 
-    - name: Verify base image provenance
+    - name: Install crane
+      if: ${{ inputs.needs_slsa_crane == 'true' }}
       shell: bash
-      if: startsWith(steps.image_data.outputs.BASE_IMAGE, format('ghcr.io/{0}/', github.repository_owner))
-      env:
-        BASE_IMAGE_VERSION: ${{ steps.image_data.outputs.BASE_IMAGE_VERSION }}
-        BASE_IMAGE: ${{ steps.image_data.outputs.BASE_IMAGE }}
       run: |
         # Install crane
         CRANE_VERSION=v0.20.7
@@ -80,37 +57,3 @@ runs:
             -o 'provenance.intoto.jsonl' "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/multiple.intoto.jsonl"
         slsa-verifier verify-artifact go-containerregistry.tar.gz --provenance-path provenance.intoto.jsonl --source-uri github.com/google/go-containerregistry --source-tag "${CRANE_VERSION}"
         tar -zxvf go-containerregistry.tar.gz -C /usr/local/bin/ crane
-
-        DIGEST=$(crane digest "${BASE_IMAGE}:${BASE_IMAGE_VERSION}")
-        slsa-verifier verify-image --source-uri "github.com/${GITHUB_REPOSITORY}" "${BASE_IMAGE}:${BASE_IMAGE_VERSION}@${DIGEST}"
-
-    - name: Uninstall slsa-verifier
-      shell: bash
-      if: startsWith(steps.image_data.outputs.BASE_IMAGE, format('ghcr.io/{0}/', github.repository_owner))
-      run: |
-        # remove slsa-verifier so that it can be successfully reinstalled later by bluebuild
-        rm -rf ~/.slsa/
-
-    - name: Install cosign
-      uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-      if: steps.image_data.outputs.IMAGE_NAME != 'securecore-main-hardened' && steps.image_data.outputs.IMAGE_NAME != 'iot-main-hardened'
-      with:
-        cosign-release: 'v2.6.0'
-
-    - name: Verify base image
-      shell: bash
-      if: steps.image_data.outputs.IMAGE_NAME != 'securecore-main-hardened' && steps.image_data.outputs.IMAGE_NAME != 'iot-main-hardened'
-      env:
-        BASE_IMAGE_VERSION: ${{ steps.image_data.outputs.BASE_IMAGE_VERSION }}
-        BASE_IMAGE: ${{ steps.image_data.outputs.BASE_IMAGE }}
-      run: |
-        UPSTREAM_CONTAINER="${BASE_IMAGE}:${BASE_IMAGE_VERSION}"
-        if [[ "$BASE_IMAGE" == "ghcr.io/${GITHUB_REPOSITORY_OWNER}/"* ]]; then
-          UPSTREAM_PUBKEY='./cosign.pub'
-        else
-          UPSTREAM_PUBKEY='./files/system/usr/share/pki/containers/quay.io-fedora-ostree-desktops.pub'
-        fi
-        if ! cosign verify --key "${UPSTREAM_PUBKEY}" "${UPSTREAM_CONTAINER}" | jq; then
-          echo "NOTICE: Verification failed. Please ensure your public key is correct."
-          exit 1
-        fi

--- a/.github/workflows/sign-systemd-boot.yml
+++ b/.github/workflows/sign-systemd-boot.yml
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+# SPDX-FileCopyrightText: Timothée Ravier <tim@siosm.fr>
+#
+# SPDX-License-Identifier: Apache-2.0 AND CC0-1.0
+
+name: "Sign systemd-boot"
+
+permissions: {}
+
+env:
+  FEDORA_RELEASE: "44"
+
+on:
+  # This only needs rebuilding for new releases of systemd-boot, e.g. after
+  # every Fedora release, or if the signing key changes. Swapping it might
+  # change the TPM PCR values, which would prompt some users for PINs etc.
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sign:
+    name: "Sign systemd boot"
+    runs-on: "ubuntu-26.04"
+    environment: Build
+    if: github.triggering_actor == 'royaloughtness'
+    permissions:
+      contents: read # Needed to pull the repo for the build
+      packages: write # Needed to publish images
+    outputs:
+      DIGEST: ${{ steps.push.outputs.digest }}
+    steps:
+      - name: "Checkout repo"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: "Runner setup"
+        uses: ./.github/workflows/shared-runner-setup
+        with:
+          needs_cosign: 'true'
+
+      - name: "Log in to registry"
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        with:
+          registry: "ghcr.io/${{ github.repository_owner }}"
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Get secure boot signing key"
+        run: |
+          mkdir -p /tmp/keys
+          printenv UKI_DB_KEY > /tmp/keys/key
+          cp uki/keys/db/db.pem /tmp/keys/crt
+        env:
+          UKI_DB_KEY: ${{ secrets.UKI_DB_KEY }}
+
+      - name: "Build container image"
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
+        with:
+          image: "systemd-boot"
+          tags: ${{ env.FEDORA_RELEASE }}
+          containerfiles: "uki/Containerfile.systemd-boot"
+          oci: true
+          build-args: |
+            RELEASE=${{ env.FEDORA_RELEASE }}
+          extra-args: |
+            --secret=id=secureboot_key,src=/tmp/keys/key
+            --secret=id=secureboot_crt,src=/tmp/keys/crt
+
+      - name: "Clean up secure boot signing key"
+        if: always()
+        run: rm -vrf /tmp/keys
+
+      - name: "Push to registry"
+        id: push
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
+        with:
+          registry: "ghcr.io/${{ github.repository_owner }}"
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          image: "systemd-boot"
+          tags: ${{ env.FEDORA_RELEASE }}
+
+      - name: "Sign container image"
+        run: |
+          cosign sign -y --key env://COSIGN_KEY ghcr.io/${GITHUB_REPOSITORY_OWNER}/systemd-boot@${DIGEST}
+        env:
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_KEY: ${{ secrets.SIGNING_SECRET }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+
+  provenance:
+    needs: sign
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    # Currently this must be referenced by tag, not by hash:
+    # https://github.com/slsa-framework/slsa-github-generator?tab=readme-ov-file#referencing-slsa-builders-and-generators
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0 # zizmor: ignore[unpinned-uses]
+    with:
+      image: "ghcr.io/${{ github.repository_owner }}/systemd-boot"
+      digest: ${{ needs.sign.outputs.DIGEST }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sign-uki-addons.yml
+++ b/.github/workflows/sign-uki-addons.yml
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+# SPDX-FileCopyrightText: Timothée Ravier <tim@siosm.fr>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: "Sign UKI addons"
+
+env:
+  FEDORA_RELEASE: "44"
+
+on:
+  # This only needs changing when the kargs change.
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sign:
+    name: "Sign UKI addons"
+    runs-on: "ubuntu-26.04"
+    environment: Build
+    if: github.triggering_actor == 'royaloughtness'
+    permissions:
+      contents: read # Needed to pull the repo for the build
+      packages: write # Needed to publish images
+    outputs:
+      DIGEST: ${{ steps.push.outputs.digest }}
+    steps:
+      - name: "Check out repository"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: "Set up runner"
+        uses: ./.github/workflows/shared-runner-setup
+        with:
+          needs_cosign: 'true'
+
+      - name: "Log in to registry"
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        with:
+          registry: "ghcr.io/${{ github.repository_owner }}"
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Get secure boot signing key"
+        run: |
+          mkdir -p /tmp/keys
+          printenv UKI_DB_KEY > /tmp/keys/key
+          cp uki/keys/db/db.pem /tmp/keys/crt
+        env:
+          UKI_DB_KEY: ${{ secrets.UKI_DB_KEY }}
+
+      - name: "Build container image"
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
+        with:
+          image: "uki-addons"
+          tags: "latest ${{ github.run_number }}"
+          containerfiles: "uki/Containerfile.addons"
+          oci: true
+          build-args: |
+            RELEASE=${{ env.FEDORA_RELEASE }}
+          extra-args: |
+            --secret=id=secureboot_key,src=/tmp/keys/key
+            --secret=id=secureboot_crt,src=/tmp/keys/crt
+
+      - name: "Clean up secure boot signing key"
+        if: always()
+        run: rm -vrf /tmp/keys
+
+      - name: "Push to registry"
+        id: push
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
+        with:
+          registry: "ghcr.io/${{ github.repository_owner }}"
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          image: "uki-addons"
+          tags: "latest ${{ github.run_number }}"
+
+      - name: "Sign container image"
+        run: |
+          cosign sign -y --key env://COSIGN_KEY ghcr.io/${GITHUB_REPOSITORY_OWNER}/uki-addons@${DIGEST}
+        env:
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_KEY: ${{ secrets.SIGNING_SECRET }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+
+  provenance:
+    needs: sign
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    # Currently this must be referenced by tag, not by hash:
+    # https://github.com/slsa-framework/slsa-github-generator?tab=readme-ov-file#referencing-slsa-builders-and-generators
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0 # zizmor: ignore[unpinned-uses]
+    with:
+      image: "ghcr.io/${{ github.repository_owner }}/uki-addons"
+      digest: ${{ needs.sign.outputs.DIGEST }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -29,6 +29,6 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:
           persona: auditor

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@ cosign.key
 cosign.private
 *.kate-swp
 .directory
-Containerfile
+/Containerfile
 .DS_Store
 __pycache__
 uv.lock
 justfile-tmp-*
+uki/**/*.key
+uki/**/*.esl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,19 +7,19 @@ repos:
         args: ['--markdown-linebreak-ext=md,patch']
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: 9257c6050c0261b8c57e712f632dc4a8010109a9 # v1.25.2
+    rev: e3eebf65325ccc992422292cb7a4baee967cf815 # v1.26.1
     hooks:
       - id: zizmor
         exclude: "^\\.github/workflows/config/linkspector\\.yml$"
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 3b3f7c3f57fe9925356faf5fe6230835138be230 # v0.15.17
+    rev: 77039ccbba72c8aede339c5f8ae29b42aced0a2e # v0.15.18
     hooks:
       - id: ruff-check
       - id: ruff-format
 
   - repo: https://github.com/astral-sh/ty-pre-commit
-    rev: 1c2d685cd524a149bddf350f8c95875a0a3193ac # v0.0.50
+    rev: 05894e7188446033344d151e25e0a5b5d10a956f # v0.0.52
     hooks:
       - id: ty
         args: [--isolated]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,13 @@ repos:
         exclude: "^\\.github/workflows/config/linkspector\\.yml$"
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 77039ccbba72c8aede339c5f8ae29b42aced0a2e # v0.15.18
+    rev: c59bba8fb259db0fec2bbb77ad8ba51ea7341b56 # v0.15.20
     hooks:
       - id: ruff-check
       - id: ruff-format
 
   - repo: https://github.com/astral-sh/ty-pre-commit
-    rev: 05894e7188446033344d151e25e0a5b5d10a956f # v0.0.52
+    rev: 73e808ce6d5bdbf3bf7950ef1a8c0a035c44a2c6 # v0.0.55
     hooks:
       - id: ty
         args: [--isolated]

--- a/docs/example.butane
+++ b/docs/example.butane
@@ -56,7 +56,7 @@ storage:
             echo "Error: Secureblue installation failed." >&2
             exit "$status"
           else
-            sudo cp /usr/etc/containers/policy.json /etc/containers/policy.json
+            sudo cp /usr/share/secureblue/etc/containers/policy.json /etc/containers/policy.json
             sed -i -e '/\/opt\/install_secureblue.sh/d' /var/home/core/.bash_profile
             sudo rm -f /opt/install_secureblue.sh /etc/pki/containers/secureblue-2025.pub
             echo "Automatically rebooting in 5 seconds..."

--- a/files/justfiles/common/toggles.just
+++ b/files/justfiles/common/toggles.just
@@ -31,9 +31,9 @@ override-reset-module mod_name:
 toggle-debug-mode:
     #! /bin/run0 /bin/bash
     if test -e /etc/sysctl.d/99-enable-coredump.conf; then
-        cp /usr/etc/security/limits.d/60-disable-coredump.conf /etc/security/limits.d/60-disable-coredump.conf
-        cp /usr/etc/systemd/system.conf.d/60-disable-coredump.conf /etc/systemd/system.conf.d/60-disable-coredump.conf
-        cp /usr/etc/systemd/user.conf.d/60-disable-coredump.conf /etc/systemd/user.conf.d/60-disable-coredump.conf
+        cp /usr/share/secureblue/etc/security/limits.d/60-disable-coredump.conf /etc/security/limits.d/60-disable-coredump.conf
+        cp /usr/share/secureblue/etc/systemd/system.conf.d/60-disable-coredump.conf /etc/systemd/system.conf.d/60-disable-coredump.conf
+        cp /usr/share/secureblue/etc/systemd/user.conf.d/60-disable-coredump.conf /etc/systemd/user.conf.d/60-disable-coredump.conf
         rm /etc/sysctl.d/99-enable-coredump.conf
         echo "Debug mode disabled."
     else

--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -4,15 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Enroll secureblue's signing key for secure boot - Enter password "secureblue" if prompted
-enroll-secureblue-secure-boot-key:
-    #! /bin/run0 /bin/bash
-    mokutil --timeout -1
-    echo 'The next line will prompt for a MOK password. Input "secureblue".'
-    mokutil --import /usr/share/pki/akmods/certs/akmods-secureblue.der
-    echo 'At next reboot, the mokutil UEFI menu UI will be displayed (*QWERTY* keyboard input and navigation).'
-    echo 'Then, select "Enroll MOK", and input "secureblue" as the password.'
-
 # Clean up old up unused podman images, volumes, flatpak packages and rpm-ostree content
 clean-system:
     #!/usr/bin/bash
@@ -22,7 +13,9 @@ clean-system:
     then
         flatpak uninstall --unused
     fi
-    rpm-ostree cleanup -bm
+    if [[ -f "/usr/bin/rpm-ostree" ]]; then
+        rpm-ostree cleanup -bm
+    fi
 
 # Check for local overrides
 check-local-overrides:
@@ -55,12 +48,17 @@ check-local-overrides:
         --exclude="system.control*" \
         --exclude="cdi" \
         --exclude="default.target" \
-        /usr/etc /etc 2>/dev/null | sed '/Binary\ files\ /d'
+        /usr/share/secureblue/etc /etc 2>/dev/null | sed '/Binary\ files\ /d'
 
 # Debug dump pastebin for issue reporting
 debug-info:
     #!/usr/bin/bash
-    rpm_ostree_status=$(echo -e "=== Rpm-Ostree Status ===\n"; rpm-ostree status --verbose)
+    if [[ -f "/usr/bin/rpm-ostree" ]]; then
+        rpm_ostree_status=$(echo -e "=== Rpm-Ostree Status ===\n"; rpm-ostree status --verbose)
+    else
+        echo "Please authenticate yourself as an administrator to collect debug info."
+        rpm_ostree_status=$(echo -e "=== Bootc Status ===\n"; run0 -i bootc status --verbose)
+    fi
     sysinfo=$(echo -e "\n"; fpaste --sysinfo --printonly)
     flatpaks=$(echo "=== Flatpaks Installed ==="; flatpak list --columns=application,version,options)
     audit_results=$(echo -e "\n=== Audit Results ===\n"; ujust audit-secureblue)
@@ -114,6 +112,10 @@ toolbox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/toolbox/toolbox.i
 install-docker:
     #!/usr/bin/run0 /bin/bash
     set -euo pipefail
+    if [[ ! -f "/usr/bin/rpm-ostree" ]]; then
+        echo "Cannot layer packages on a UKI system. Try Podman, rootless Docker or a systemd-sysext instead."
+        exit 1
+    fi
     sed -i -e '/^\[docker-ce-stable\]$/,/^\[/s/^enabled *= *0.*/enabled=1/' /etc/yum.repos.d/docker-ce.repo
     rpm-ostree refresh-md
     rpm-ostree install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
@@ -122,7 +124,11 @@ install-docker:
 uninstall-docker:
     #!/usr/bin/run0 /bin/bash
     set -euo pipefail
-    cp /usr/etc/yum.repos.d/docker-ce.repo /etc/yum.repos.d/docker-ce.repo
+    if [[ ! -f "/usr/bin/rpm-ostree" ]]; then
+        echo "Cannot unlayer packages on a UKI system."
+        exit 1
+    fi
+    cp /usr/share/secureblue/etc/yum.repos.d/docker-ce.repo /etc/yum.repos.d/docker-ce.repo
     rpm-ostree refresh-md
     rpm-ostree uninstall docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
@@ -168,9 +174,14 @@ rebase-secureblue:
         image_name+="-main"
     fi
     image_name+="-hardened"
-    full_ref=$(crane digest --full-ref "ghcr.io/secureblue/${image_name}:latest")
+    if [[ -f "/usr/bin/rpm-ostree" ]]; then
+        full_ref=$(crane digest --full-ref "ghcr.io/secureblue/${image_name}:latest")
+        rebase_command="rpm-ostree rebase ostree-image-signed:docker://ghcr.io/secureblue/${image_name}:latest"
+    else
+        full_ref=$(crane digest --full-ref "ghcr.io/secureblue/${image_name}:uki")
+        rebase_command="run0 -i bootc switch ghcr.io/secureblue/${image_name}:uki"
+    fi
     slsa-verifier verify-image --source-uri "github.com/secureblue/secureblue" --source-branch "live" "${full_ref}"
-    rebase_command="rpm-ostree rebase ostree-image-signed:docker://ghcr.io/secureblue/${image_name}:latest"
     printf "Command to execute:\n%s\n\n" "${rebase_command}"
     read -rp "Proceed? [y/N]: " rebase_proceed
     if [[ "${rebase_proceed}" == [Yy]* ]]; then
@@ -232,6 +243,11 @@ label-external-drives:
 install-vpn:
     #!/usr/bin/bash
     set -euo pipefail
+
+    if [[ ! -f "/usr/bin/rpm-ostree" ]]; then
+        echo "Cannot layer packages on a UKI system. Try a systemd-sysext instead."
+        exit 1
+    fi
 
     # supported VPN providers and the security features they need disabled, separated by spaces
     declare -A vpn_providers=(
@@ -467,6 +483,6 @@ setup-usbguard:
         systemctl enable --now usbguard.service
         usbguard add-user "${SUDO_USER}"
     '
-    if ! rpm-ostree status | grep '●' | grep -Eq 'securecore|iot'; then
+    if ! grep -Eq '^IMAGE_ID=.*(securecore|iot)' /usr/lib/os-release; then
         systemctl enable --user --now usbguard-notifier.service
     fi

--- a/files/justfiles/common/wrappers.just
+++ b/files/justfiles/common/wrappers.just
@@ -103,3 +103,10 @@ alias set-anticheat-support := set-ptrace
 # Show all messages from last boot
 @logs-last-boot:
     exec /usr/bin/run0 --via-shell journalctl -b -1
+
+# Enroll secure boot key into shim or firmware.
+[positional-arguments]
+@enroll-secure-boot-keys *args:
+    exec /usr/bin/python3 /usr/libexec/secureblue/enroll_secure_boot_keys.py "$@"
+
+alias enroll-secureblue-secure-boot-key := enroll-secure-boot-keys

--- a/files/justfiles/desktop/steam.just
+++ b/files/justfiles/desktop/steam.just
@@ -5,6 +5,11 @@
 # Install Steam via choice of 2 methods
 install-steam:
     #!/usr/bin/bash
+    if [[ ! -f "/usr/bin/rpm-ostree" ]]; then
+        echo "This script does not support UKI systems yet."
+        exit 1
+    fi
+
     need_reboot=false
     if [[ -z "$(pgrep Xwayland)" && -z "$(pgrep Xorg)" ]]; then
         echo "Steam requires X or Xwayland, which your variant of secureblue has disabled by default." | fold -s

--- a/files/po/audit_secureblue.pot
+++ b/files/po/audit_secureblue.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-22 00:29+0000\n"
+"POT-Creation-Date: 2026-07-06 02:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -767,69 +767,64 @@ msgstr ""
 msgid "Note: some results omitted due to configuration file or '{0}' argument."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:140
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:101
 msgid "permission"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:145
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:106
 #, python-brace-format
 msgid "{0} has {1}"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:150
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:111
 msgid "This may also be used as a sandbox escape vector."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:156
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:117
 #, python-brace-format
 msgid "The following flatpak app(s) have {0}:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:160
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:398
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:498
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:121
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:336
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:133
 msgid "To remove this permission from an app, use Flatseal or run:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:162
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:340
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:400
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:479
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:500
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:123
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:278
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:338
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:107
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:135
 #, python-brace-format
 msgid "(replacing \"{0}\" with the flatpak app ID)"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:190
-#, python-brace-format
-msgid "This grants access to {0}."
-msgstr ""
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:196
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:131
 msgid "network access"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:201
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:136
 msgid "inter-process communications access"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:202
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:137
 msgid "This is only necessary for better X11 performance."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:208
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:143
 msgid "X11 access"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:209
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:144
 msgid "X11 apps can monitor and modify each other's graphics and inputs."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:215
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:150
 msgid "access to the PulseAudio socket"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:216
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:151
 msgid ""
 "\n"
 "            This grants access to all audio input and output streams.\n"
@@ -837,158 +832,163 @@ msgid ""
 "        "
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:221
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:156
 msgid "access to the D-Bus session bus"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:222
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:157
 msgid "access to the D-Bus system bus"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:223
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:158
 msgid "access to the SSH agent"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:228
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:163
 msgid "access to all devices"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:229
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:164
 msgid "This includes input devices, GPUs, raw USB, and virtualization."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:231
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:166
 #, python-brace-format
 msgid "If GPU access is required, allow {0} instead."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:237
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:172
 msgid "access to input devices"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:238
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:173
 msgid "This is required for game controllers."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:240
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:175
 msgid "access to kernel-based virtualization"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:245
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:180
 msgid "access to shared memory."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:252
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:187
 msgid "raw access to USB devices."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:255
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:190
 msgid "bluetooth access"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:256
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:191
 msgid "ptrace access"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:303
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:241
 #, python-brace-format
 msgid "{0} can acquire arbitrary permissions."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:306
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:244
 msgid "However, this is required for its functionality."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:323
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:328
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:261
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:266
 #, python-brace-format
 msgid "{0} is requesting {1}"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:334
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:272
 #, python-brace-format
 msgid "{0} is not requesting {1}"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:336
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:274
 #, python-brace-format
 msgid "The following flatpak app(s) are not requesting {0}:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:338
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:276
 msgid "To enable it for an app, run:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:387
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:325
 #, python-brace-format
 msgid "{0} can talk to {1} on the session bus."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:388
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:326
 #, python-brace-format
 msgid "The following flatpak app(s) can talk to {0} on the session bus:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:391
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:329
 #, python-brace-format
 msgid "{0} can talk to {1} on the system bus."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:392
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:330
 #, python-brace-format
 msgid "The following flatpak app(s) can talk to {0} on the system bus:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:397
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:497
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:335
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:132
 msgid "This grants the ability to acquire arbitrary permissions."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:441
-msgid "all system files"
-msgstr ""
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:442
-msgid "all user files"
-msgstr ""
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:443
-msgid "other applications' configuration files"
-msgstr ""
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:444
-msgid "other applications' cache files"
-msgstr ""
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:445
-msgid "other applications' data files"
-msgstr ""
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:471
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:99
 #, python-brace-format
 msgid "{0} is missing {1} permission"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:474
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:102
 #, python-brace-format
 msgid "The following flatpak app(s) are missing {0} permission:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:476
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:104
 msgid "This is required to load hardened_malloc."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:477
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:105
 msgid "To add this permission to an app, use Flatseal or run:"
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:493
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:128
 #, python-brace-format
 msgid "{0} can modify flatpak permissions."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:495
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:130
 msgid "The following flatpak app(s) can modify flatpak permissions:"
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:165
+#, python-brace-format
+msgid "This grants access to {0}."
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:171
+msgid "all system files"
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:172
+msgid "all user files"
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:173
+msgid "other applications' configuration files"
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:174
+msgid "other applications' cache files"
+msgstr ""
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:175
+msgid "other applications' data files"
 msgstr ""
 
 #: files/system/usr/libexec/secureblue/audit_utils/__init__.py:38

--- a/files/po/de/audit_secureblue.po
+++ b/files/po/de/audit_secureblue.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-22 00:29+0000\n"
+"POT-Creation-Date: 2026-07-06 02:05+0000\n"
 "PO-Revision-Date: 2025-08-05 13:32+0200\n"
 "Last-Translator: MatsG23 <60609373+MatsG23@users.noreply.github.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -792,72 +792,67 @@ msgstr "Bericht"
 msgid "Note: some results omitted due to configuration file or '{0}' argument."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:140
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:101
 msgid "permission"
 msgstr "Berechtigung"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:145
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:106
 #, python-brace-format
 msgid "{0} has {1}"
 msgstr "{0} hat {1}"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:150
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:111
 msgid "This may also be used as a sandbox escape vector."
 msgstr ""
 "Dies kann auch als Angriffsvektor für einen Sandbox Escape verwendet werden."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:156
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:117
 #, python-brace-format
 msgid "The following flatpak app(s) have {0}:"
 msgstr "Folgende Flatpak-Anwendungen haben {0}:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:160
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:398
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:498
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:121
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:336
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:133
 msgid "To remove this permission from an app, use Flatseal or run:"
 msgstr ""
 "Um diese Berechtigung von einer Anwendung zu entfernen, verwende Flatseal "
 "oder führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:162
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:340
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:400
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:479
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:500
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:123
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:278
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:338
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:107
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:135
 #, python-brace-format
 msgid "(replacing \"{0}\" with the flatpak app ID)"
 msgstr "(ersetze \"{0}\" mit der ID der Flatpak-Anwendung)"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:190
-#, python-brace-format
-msgid "This grants access to {0}."
-msgstr "Dies gewährt Zugriff auf {0}."
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:196
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:131
 msgid "network access"
 msgstr "Netzwerkzugriff"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:201
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:136
 msgid "inter-process communications access"
 msgstr "Zugriff auf Interprozesskommunikation"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:202
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:137
 msgid "This is only necessary for better X11 performance."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:208
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:143
 msgid "X11 access"
 msgstr "Zugriff auf X11"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:209
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:144
 msgid "X11 apps can monitor and modify each other's graphics and inputs."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:215
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:150
 msgid "access to the PulseAudio socket"
 msgstr "Zugriff auf den PulseAudio Socket"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:216
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:151
 msgid ""
 "\n"
 "            This grants access to all audio input and output streams.\n"
@@ -865,181 +860,186 @@ msgid ""
 "        "
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:221
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:156
 msgid "access to the D-Bus session bus"
 msgstr "Zugriff auf den D-Bus Session Bus"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:222
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:157
 msgid "access to the D-Bus system bus"
 msgstr "Zugriff auf den D-Bus System Bus"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:223
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:158
 msgid "access to the SSH agent"
 msgstr "Zugriff auf den SSH Agent"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:228
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:163
 #, fuzzy
 msgid "access to all devices"
 msgstr "Dies gewährt Zugriff auf Eingabegeräte."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:229
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:164
 #, fuzzy
 msgid "This includes input devices, GPUs, raw USB, and virtualization."
 msgstr ""
 "Dies gewährt Zugriff auf Eingabegeräte, GPUs, direkten USB-Zugriff und "
 "Virtualisierung."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:231
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:166
 #, python-brace-format
 msgid "If GPU access is required, allow {0} instead."
 msgstr "Falls GPU-Zugriff benötigt wird, erlaube stattdessen {0}."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:237
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:172
 #, fuzzy
 msgid "access to input devices"
 msgstr "Dies gewährt Zugriff auf Eingabegeräte."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:238
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:173
 #, fuzzy
 msgid "This is required for game controllers."
 msgstr "Dies ist erforderlich um hardened_malloc zu laden."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:240
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:175
 #, fuzzy
 msgid "access to kernel-based virtualization"
 msgstr "Dies gewährt Zugriff auf kernelbasierte Virtualisierung."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:245
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:180
 #, fuzzy
 msgid "access to shared memory."
 msgstr "Dies gewährt Zugriff auf geteilten Speicher."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:252
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:187
 #, fuzzy
 msgid "raw access to USB devices."
 msgstr "Dies gewährt Zugriff auf Eingabegeräte."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:255
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:190
 msgid "bluetooth access"
 msgstr "Zugriff auf Bluetooth"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:256
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:191
 msgid "ptrace access"
 msgstr "Zugriff auf ptrace"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:303
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:241
 #, python-brace-format
 msgid "{0} can acquire arbitrary permissions."
 msgstr "{0} kann beliebige Berechtigungen erlangen."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:306
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:244
 msgid "However, this is required for its functionality."
 msgstr "Dies ist jedoch für die Funktionalität erforderlich."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:323
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:328
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:261
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:266
 #, python-brace-format
 msgid "{0} is requesting {1}"
 msgstr "{0} fragt {1} an"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:334
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:272
 #, python-brace-format
 msgid "{0} is not requesting {1}"
 msgstr "{0} fragt nicht {1} an"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:336
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:274
 #, python-brace-format
 msgid "The following flatpak app(s) are not requesting {0}:"
 msgstr "Folgende Flatpak-Anwendungen fragen {0} nicht an:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:338
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:276
 msgid "To enable it for an app, run:"
 msgstr "Um es für eine Anwendung zu aktivieren, führe aus:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:387
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:325
 #, fuzzy, python-brace-format
 msgid "{0} can talk to {1} on the session bus."
 msgstr ""
 "Folgende Flatpak-Anwendungen können mit {0} auf dem Session Bus "
 "kommunizieren:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:388
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:326
 #, python-brace-format
 msgid "The following flatpak app(s) can talk to {0} on the session bus:"
 msgstr ""
 "Folgende Flatpak-Anwendungen können mit {0} auf dem Session Bus "
 "kommunizieren:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:391
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:329
 #, fuzzy, python-brace-format
 msgid "{0} can talk to {1} on the system bus."
 msgstr ""
 "Folgende Flatpak-Anwendungen können mit {0} auf dem Session Bus "
 "kommunizieren:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:392
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:330
 #, fuzzy, python-brace-format
 msgid "The following flatpak app(s) can talk to {0} on the system bus:"
 msgstr ""
 "Folgende Flatpak-Anwendungen können mit {0} auf dem Session Bus "
 "kommunizieren:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:397
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:497
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:335
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:132
 msgid "This grants the ability to acquire arbitrary permissions."
 msgstr ""
 "Dies ermöglicht es fer Anwendung, beliebige Berechtigungen zu erlangen."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:441
-msgid "all system files"
-msgstr "alle Systemdateien"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:442
-msgid "all user files"
-msgstr "alle Benutzerdateien"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:443
-msgid "other applications' configuration files"
-msgstr "Konfigurationsdateien anderer Anwendungen"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:444
-msgid "other applications' cache files"
-msgstr "Cachedateien anderer Anwendungen"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:445
-msgid "other applications' data files"
-msgstr "Speicherdateien anderer Anwendungen"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:471
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:99
 #, python-brace-format
 msgid "{0} is missing {1} permission"
 msgstr "{0} fehlt die {1} Berechtigung"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:474
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:102
 #, python-brace-format
 msgid "The following flatpak app(s) are missing {0} permission:"
 msgstr "Folgenden Flatpak-Anwendungen fehlt die {0} Berechtigung:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:476
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:104
 msgid "This is required to load hardened_malloc."
 msgstr "Dies ist erforderlich um hardened_malloc zu laden."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:477
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:105
 msgid "To add this permission to an app, use Flatseal or run:"
 msgstr ""
 "Um einer App diese Berechtigung zu gewähren, verwende Flatseal oder führe "
 "aus:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:493
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:128
 #, fuzzy, python-brace-format
 msgid "{0} can modify flatpak permissions."
 msgstr "{0} kann beliebige Berechtigungen erlangen."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:495
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:130
 #, fuzzy
 msgid "The following flatpak app(s) can modify flatpak permissions:"
 msgstr ""
 "Folgende Flatpak-Anwendungen können Flatpak-Überschreibungen vornehmen:"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:165
+#, python-brace-format
+msgid "This grants access to {0}."
+msgstr "Dies gewährt Zugriff auf {0}."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:171
+msgid "all system files"
+msgstr "alle Systemdateien"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:172
+msgid "all user files"
+msgstr "alle Benutzerdateien"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:173
+msgid "other applications' configuration files"
+msgstr "Konfigurationsdateien anderer Anwendungen"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:174
+msgid "other applications' cache files"
+msgstr "Cachedateien anderer Anwendungen"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:175
+msgid "other applications' data files"
+msgstr "Speicherdateien anderer Anwendungen"
 
 #: files/system/usr/libexec/secureblue/audit_utils/__init__.py:38
 msgid "*** WARNING: Running audit script as root is not recommended. ***"

--- a/files/po/en/audit_secureblue.po
+++ b/files/po/en/audit_secureblue.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-22 00:29+0000\n"
-"PO-Revision-Date: 2026-06-22 00:29+0000\n"
+"POT-Creation-Date: 2026-07-06 02:05+0000\n"
+"PO-Revision-Date: 2026-07-06 02:05+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en_US\n"
@@ -779,69 +779,64 @@ msgid "Note: some results omitted due to configuration file or '{0}' argument."
 msgstr ""
 "Note: some results omitted due to configuration file or '{0}' argument."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:140
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:101
 msgid "permission"
 msgstr "permission"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:145
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:106
 #, python-brace-format
 msgid "{0} has {1}"
 msgstr "{0} has {1}"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:150
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:111
 msgid "This may also be used as a sandbox escape vector."
 msgstr "This may also be used as a sandbox escape vector."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:156
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:117
 #, python-brace-format
 msgid "The following flatpak app(s) have {0}:"
 msgstr "The following flatpak app(s) have {0}:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:160
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:398
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:498
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:121
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:336
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:133
 msgid "To remove this permission from an app, use Flatseal or run:"
 msgstr "To remove this permission from an app, use Flatseal or run:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:162
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:340
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:400
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:479
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:500
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:123
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:278
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:338
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:107
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:135
 #, python-brace-format
 msgid "(replacing \"{0}\" with the flatpak app ID)"
 msgstr "(replacing \"{0}\" with the flatpak app ID)"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:190
-#, python-brace-format
-msgid "This grants access to {0}."
-msgstr "This grants access to {0}."
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:196
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:131
 msgid "network access"
 msgstr "network access"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:201
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:136
 msgid "inter-process communications access"
 msgstr "inter-process communications access"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:202
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:137
 msgid "This is only necessary for better X11 performance."
 msgstr "This is only necessary for better X11 performance."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:208
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:143
 msgid "X11 access"
 msgstr "X11 access"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:209
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:144
 msgid "X11 apps can monitor and modify each other's graphics and inputs."
 msgstr "X11 apps can monitor and modify each other's graphics and inputs."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:215
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:150
 msgid "access to the PulseAudio socket"
 msgstr "access to the PulseAudio socket"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:216
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:151
 msgid ""
 "\n"
 "            This grants access to all audio input and output streams.\n"
@@ -853,159 +848,164 @@ msgstr ""
 "            However, this is necessary for most apps to play sound.\n"
 "        "
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:221
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:156
 msgid "access to the D-Bus session bus"
 msgstr "access to the D-Bus session bus"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:222
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:157
 msgid "access to the D-Bus system bus"
 msgstr "access to the D-Bus system bus"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:223
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:158
 msgid "access to the SSH agent"
 msgstr "access to the SSH agent"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:228
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:163
 msgid "access to all devices"
 msgstr "access to all devices"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:229
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:164
 msgid "This includes input devices, GPUs, raw USB, and virtualization."
 msgstr "This includes input devices, GPUs, raw USB, and virtualization."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:231
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:166
 #, python-brace-format
 msgid "If GPU access is required, allow {0} instead."
 msgstr "If GPU access is required, allow {0} instead."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:237
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:172
 msgid "access to input devices"
 msgstr "access to input devices"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:238
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:173
 msgid "This is required for game controllers."
 msgstr "This is required for game controllers."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:240
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:175
 msgid "access to kernel-based virtualization"
 msgstr "access to kernel-based virtualization"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:245
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:180
 msgid "access to shared memory."
 msgstr "access to shared memory."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:252
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:187
 msgid "raw access to USB devices."
 msgstr "raw access to USB devices."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:255
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:190
 msgid "bluetooth access"
 msgstr "bluetooth access"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:256
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:191
 msgid "ptrace access"
 msgstr "ptrace access"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:303
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:241
 #, python-brace-format
 msgid "{0} can acquire arbitrary permissions."
 msgstr "{0} can acquire arbitrary permissions."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:306
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:244
 msgid "However, this is required for its functionality."
 msgstr "However, this is required for its functionality."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:323
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:328
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:261
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:266
 #, python-brace-format
 msgid "{0} is requesting {1}"
 msgstr "{0} is requesting {1}"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:334
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:272
 #, python-brace-format
 msgid "{0} is not requesting {1}"
 msgstr "{0} is not requesting {1}"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:336
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:274
 #, python-brace-format
 msgid "The following flatpak app(s) are not requesting {0}:"
 msgstr "The following flatpak app(s) are not requesting {0}:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:338
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:276
 msgid "To enable it for an app, run:"
 msgstr "To enable it for an app, run:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:387
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:325
 #, python-brace-format
 msgid "{0} can talk to {1} on the session bus."
 msgstr "{0} can talk to {1} on the session bus."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:388
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:326
 #, python-brace-format
 msgid "The following flatpak app(s) can talk to {0} on the session bus:"
 msgstr "The following flatpak app(s) can talk to {0} on the session bus:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:391
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:329
 #, python-brace-format
 msgid "{0} can talk to {1} on the system bus."
 msgstr "{0} can talk to {1} on the system bus."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:392
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:330
 #, python-brace-format
 msgid "The following flatpak app(s) can talk to {0} on the system bus:"
 msgstr "The following flatpak app(s) can talk to {0} on the system bus:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:397
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:497
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:335
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:132
 msgid "This grants the ability to acquire arbitrary permissions."
 msgstr "This grants the ability to acquire arbitrary permissions."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:441
-msgid "all system files"
-msgstr "all system files"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:442
-msgid "all user files"
-msgstr "all user files"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:443
-msgid "other applications' configuration files"
-msgstr "other applications' configuration files"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:444
-msgid "other applications' cache files"
-msgstr "other applications' cache files"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:445
-msgid "other applications' data files"
-msgstr "other applications' data files"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:471
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:99
 #, python-brace-format
 msgid "{0} is missing {1} permission"
 msgstr "{0} is missing {1} permission"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:474
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:102
 #, python-brace-format
 msgid "The following flatpak app(s) are missing {0} permission:"
 msgstr "The following flatpak app(s) are missing {0} permission:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:476
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:104
 msgid "This is required to load hardened_malloc."
 msgstr "This is required to load hardened_malloc."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:477
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:105
 msgid "To add this permission to an app, use Flatseal or run:"
 msgstr "To add this permission to an app, use Flatseal or run:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:493
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:128
 #, python-brace-format
 msgid "{0} can modify flatpak permissions."
 msgstr "{0} can modify flatpak permissions."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:495
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:130
 msgid "The following flatpak app(s) can modify flatpak permissions:"
 msgstr "The following flatpak app(s) can modify flatpak permissions:"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:165
+#, python-brace-format
+msgid "This grants access to {0}."
+msgstr "This grants access to {0}."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:171
+msgid "all system files"
+msgstr "all system files"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:172
+msgid "all user files"
+msgstr "all user files"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:173
+msgid "other applications' configuration files"
+msgstr "other applications' configuration files"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:174
+msgid "other applications' cache files"
+msgstr "other applications' cache files"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:175
+msgid "other applications' data files"
+msgstr "other applications' data files"
 
 #: files/system/usr/libexec/secureblue/audit_utils/__init__.py:38
 msgid "*** WARNING: Running audit script as root is not recommended. ***"

--- a/files/po/es/audit_secureblue.po
+++ b/files/po/es/audit_secureblue.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-22 00:29+0000\n"
+"POT-Creation-Date: 2026-07-06 02:05+0000\n"
 "PO-Revision-Date: 2025-09-22 23:20-0400\n"
 "Last-Translator: Cup-png <232283931+Cup-png@users.noreply.github.com>\n"
 "Language-Team: none\n"
@@ -802,69 +802,64 @@ msgstr "Verificación"
 msgid "Note: some results omitted due to configuration file or '{0}' argument."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:140
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:101
 msgid "permission"
 msgstr "permiso"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:145
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:106
 #, python-brace-format
 msgid "{0} has {1}"
 msgstr "{0} tiene {1}"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:150
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:111
 msgid "This may also be used as a sandbox escape vector."
 msgstr "Este puede ser usado como vector de escape del sandbox."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:156
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:117
 #, python-brace-format
 msgid "The following flatpak app(s) have {0}:"
 msgstr "Los siguientes flatpaks tienen {0}:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:160
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:398
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:498
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:121
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:336
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:133
 msgid "To remove this permission from an app, use Flatseal or run:"
 msgstr "Para eliminar este permiso de una aplicación, use Flatseal o ejecute:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:162
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:340
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:400
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:479
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:500
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:123
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:278
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:338
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:107
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:135
 #, python-brace-format
 msgid "(replacing \"{0}\" with the flatpak app ID)"
 msgstr "(reemplazando \"{0}\" con la ID de aplicación flatpak)"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:190
-#, python-brace-format
-msgid "This grants access to {0}."
-msgstr "Esto otorga acceso a {0}."
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:196
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:131
 msgid "network access"
 msgstr "acceso a la red"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:201
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:136
 msgid "inter-process communications access"
 msgstr "acceso a la comunicación entre procesos"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:202
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:137
 msgid "This is only necessary for better X11 performance."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:208
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:143
 msgid "X11 access"
 msgstr "acceso a X11"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:209
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:144
 msgid "X11 apps can monitor and modify each other's graphics and inputs."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:215
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:150
 msgid "access to the PulseAudio socket"
 msgstr "acceso al socket de PulseAudio"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:216
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:151
 msgid ""
 "\n"
 "            This grants access to all audio input and output streams.\n"
@@ -872,172 +867,177 @@ msgid ""
 "        "
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:221
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:156
 msgid "access to the D-Bus session bus"
 msgstr "acceso al bus de sesión D-Bus"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:222
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:157
 msgid "access to the D-Bus system bus"
 msgstr "acceso al bus del sistema D-Bus"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:223
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:158
 msgid "access to the SSH agent"
 msgstr "acceso al protocolo SSH agent"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:228
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:163
 #, fuzzy
 msgid "access to all devices"
 msgstr "Esto otorga acceso a periféricos."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:229
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:164
 #, fuzzy
 msgid "This includes input devices, GPUs, raw USB, and virtualization."
 msgstr "Esto otorga acceso a periféricos, GPUs, USB raw, y virtualización."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:231
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:166
 #, python-brace-format
 msgid "If GPU access is required, allow {0} instead."
 msgstr "Si se requiere acceso a la GPU, permita {0} en su lugar."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:237
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:172
 #, fuzzy
 msgid "access to input devices"
 msgstr "Esto otorga acceso a periféricos."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:238
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:173
 #, fuzzy
 msgid "This is required for game controllers."
 msgstr "Esto se requiere para cargar hardened_malloc."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:240
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:175
 #, fuzzy
 msgid "access to kernel-based virtualization"
 msgstr "Esto otorga acceso a virtualización basada en el kernel."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:245
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:180
 #, fuzzy
 msgid "access to shared memory."
 msgstr "Esto otorga acceso a memoria compartida."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:252
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:187
 #, fuzzy
 msgid "raw access to USB devices."
 msgstr "Esto otorga acceso a periféricos."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:255
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:190
 msgid "bluetooth access"
 msgstr "acceso a bluetooth"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:256
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:191
 msgid "ptrace access"
 msgstr "acceso a ptrace"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:303
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:241
 #, python-brace-format
 msgid "{0} can acquire arbitrary permissions."
 msgstr "{0} puede adquirir permisos arbitrarios."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:306
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:244
 msgid "However, this is required for its functionality."
 msgstr "Sin embargo, esto es necesario para su funcionamiento."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:323
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:328
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:261
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:266
 #, python-brace-format
 msgid "{0} is requesting {1}"
 msgstr "{0} está pidiendo {1}"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:334
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:272
 #, python-brace-format
 msgid "{0} is not requesting {1}"
 msgstr "{0} no está pidiendo {1}"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:336
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:274
 #, python-brace-format
 msgid "The following flatpak app(s) are not requesting {0}:"
 msgstr "Los siguientes flatpaks no están pidiendo {0}:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:338
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:276
 msgid "To enable it for an app, run:"
 msgstr "Para habilitarlo para una aplicación, ejecute:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:387
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:325
 #, fuzzy, python-brace-format
 msgid "{0} can talk to {1} on the session bus."
 msgstr ""
 "Los siguientes flatpaks pueden comunicarse con {0} en el bus de sesión:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:388
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:326
 #, python-brace-format
 msgid "The following flatpak app(s) can talk to {0} on the session bus:"
 msgstr ""
 "Los siguientes flatpaks pueden comunicarse con {0} en el bus de sesión:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:391
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:329
 #, fuzzy, python-brace-format
 msgid "{0} can talk to {1} on the system bus."
 msgstr ""
 "Los siguientes flatpaks pueden comunicarse con {0} en el bus de sesión:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:392
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:330
 #, python-brace-format
 msgid "The following flatpak app(s) can talk to {0} on the system bus:"
 msgstr ""
 "Los siguientes flatpaks pueden comunicarse con {0} en el bus de sesión:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:397
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:497
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:335
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:132
 msgid "This grants the ability to acquire arbitrary permissions."
 msgstr "Esto otorga la habilidad de adquirir permisos arbitrarios."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:441
-msgid "all system files"
-msgstr "todos los archivos del sistema"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:442
-msgid "all user files"
-msgstr "todos los archivos del usuario"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:443
-msgid "other applications' configuration files"
-msgstr "archivos de configuración de otras aplicaciones"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:444
-msgid "other applications' cache files"
-msgstr "archivos de cache de otras aplicaciones"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:445
-msgid "other applications' data files"
-msgstr "archivos de datos de otras aplicaciones"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:471
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:99
 #, python-brace-format
 msgid "{0} is missing {1} permission"
 msgstr "{0} tiene permiso {1} faltante"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:474
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:102
 #, python-brace-format
 msgid "The following flatpak app(s) are missing {0} permission:"
 msgstr "Los siguientes flatpaks tienen permiso {0} faltante:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:476
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:104
 msgid "This is required to load hardened_malloc."
 msgstr "Esto se requiere para cargar hardened_malloc."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:477
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:105
 msgid "To add this permission to an app, use Flatseal or run:"
 msgstr "Para añadir este permiso a una aplicación, use Flatseal o ejecute:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:493
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:128
 #, fuzzy, python-brace-format
 msgid "{0} can modify flatpak permissions."
 msgstr "{0} puede adquirir permisos arbitrarios."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:495
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:130
 #, fuzzy
 msgid "The following flatpak app(s) can modify flatpak permissions:"
 msgstr ""
 "Los siguientes flatpaks pueden modificar los permisos de otros flatpaks:"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:165
+#, python-brace-format
+msgid "This grants access to {0}."
+msgstr "Esto otorga acceso a {0}."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:171
+msgid "all system files"
+msgstr "todos los archivos del sistema"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:172
+msgid "all user files"
+msgstr "todos los archivos del usuario"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:173
+msgid "other applications' configuration files"
+msgstr "archivos de configuración de otras aplicaciones"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:174
+msgid "other applications' cache files"
+msgstr "archivos de cache de otras aplicaciones"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:175
+msgid "other applications' data files"
+msgstr "archivos de datos de otras aplicaciones"
 
 #: files/system/usr/libexec/secureblue/audit_utils/__init__.py:38
 msgid "*** WARNING: Running audit script as root is not recommended. ***"

--- a/files/po/pl/audit_secureblue.po
+++ b/files/po/pl/audit_secureblue.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-22 00:29+0000\n"
+"POT-Creation-Date: 2026-07-06 02:05+0000\n"
 "PO-Revision-Date: 2025-12-22 00:06+0000\n"
 "Last-Translator: tpaau <tpaau-17db@tutamail.com>\n"
 "Language-Team: none\n"
@@ -804,69 +804,64 @@ msgstr "Audyt"
 msgid "Note: some results omitted due to configuration file or '{0}' argument."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:140
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:101
 msgid "permission"
 msgstr "uprawnienie"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:145
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:106
 #, python-brace-format
 msgid "{0} has {1}"
 msgstr "Aplikacja {0} ma uprawnienie \"{1}\""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:150
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:111
 msgid "This may also be used as a sandbox escape vector."
 msgstr "Może to też zostać użyte do ucieczki z sandboxa."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:156
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:117
 #, python-brace-format
 msgid "The following flatpak app(s) have {0}:"
 msgstr "Następujące aplikacje Flatpak mają uprawnienie \"{0}\":"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:160
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:398
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:498
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:121
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:336
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:133
 msgid "To remove this permission from an app, use Flatseal or run:"
 msgstr "Aby odebrać to uprawnienie, użyj programu Flatseal lub uruchom:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:162
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:340
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:400
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:479
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:500
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:123
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:278
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:338
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:107
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:135
 #, python-brace-format
 msgid "(replacing \"{0}\" with the flatpak app ID)"
 msgstr "(zastąp \"{0}\" identyfikatorem aplikacji Flatpak)"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:190
-#, python-brace-format
-msgid "This grants access to {0}."
-msgstr "Umożliwia to na dostęp do \"{0}\"."
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:196
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:131
 msgid "network access"
 msgstr "dostęp do sieci"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:201
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:136
 msgid "inter-process communications access"
 msgstr "dostęp do komunikacji międzyprocesowej"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:202
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:137
 msgid "This is only necessary for better X11 performance."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:208
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:143
 msgid "X11 access"
 msgstr "dostęp do X11"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:209
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:144
 msgid "X11 apps can monitor and modify each other's graphics and inputs."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:215
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:150
 msgid "access to the PulseAudio socket"
 msgstr "dostęp do gniazda PulseAudio"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:216
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:151
 msgid ""
 "\n"
 "            This grants access to all audio input and output streams.\n"
@@ -874,174 +869,179 @@ msgid ""
 "        "
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:221
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:156
 msgid "access to the D-Bus session bus"
 msgstr "dostęp do magistrali sesji D-Bus"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:222
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:157
 msgid "access to the D-Bus system bus"
 msgstr "dostęp do magistrali systemowej D-Bus"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:223
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:158
 msgid "access to the SSH agent"
 msgstr "dostęp do agenta SSH"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:228
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:163
 #, fuzzy
 msgid "access to all devices"
 msgstr "Pozwala to na dostęp do urządzeń wejścia."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:229
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:164
 #, fuzzy
 msgid "This includes input devices, GPUs, raw USB, and virtualization."
 msgstr ""
 "Pozwala to na dostęp do urządzeń wejścia, kart graficznych, surowych "
 "urządzeń USB, oraz wirtualizacji."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:231
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:166
 #, python-brace-format
 msgid "If GPU access is required, allow {0} instead."
 msgstr ""
 "Jeżeli aplikacja jedynie wymaga dostępu do kart graficznych, zamiast tego "
 "zezwól na \"{0}\"."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:237
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:172
 #, fuzzy
 msgid "access to input devices"
 msgstr "Pozwala to na dostęp do urządzeń wejścia."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:238
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:173
 #, fuzzy
 msgid "This is required for game controllers."
 msgstr "Jest to wymagane do załadowania hardened_malloc."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:240
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:175
 #, fuzzy
 msgid "access to kernel-based virtualization"
 msgstr "Pozwala to na wirtualizację bazującą na jądrze."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:245
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:180
 #, fuzzy
 msgid "access to shared memory."
 msgstr "Pozwala to na dostęp do współdzielonej pamięci."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:252
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:187
 #, fuzzy
 msgid "raw access to USB devices."
 msgstr "Pozwala to na dostęp do urządzeń wejścia."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:255
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:190
 msgid "bluetooth access"
 msgstr "dostęp do bluetooth"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:256
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:191
 msgid "ptrace access"
 msgstr "dostęp do ptrace"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:303
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:241
 #, python-brace-format
 msgid "{0} can acquire arbitrary permissions."
 msgstr "{0} może uzyskać dowolne uprawnienia."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:306
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:244
 msgid "However, this is required for its functionality."
 msgstr "Jest to jednak wymagane do poprawnego działania."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:323
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:328
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:261
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:266
 #, python-brace-format
 msgid "{0} is requesting {1}"
 msgstr "{1} jest włączony dla {0}"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:334
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:272
 #, python-brace-format
 msgid "{0} is not requesting {1}"
 msgstr "{1} nie jest włączony dla {0}"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:336
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:274
 #, python-brace-format
 msgid "The following flatpak app(s) are not requesting {0}:"
 msgstr "{0} nie jest włączony dla następujących aplikacji:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:338
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:276
 msgid "To enable it for an app, run:"
 msgstr "Aby włączyć, uruchom:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:387
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:325
 #, fuzzy, python-brace-format
 msgid "{0} can talk to {1} on the session bus."
 msgstr "Następujące aplikacje mogą komunikować się z {0} na magistrali sesji:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:388
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:326
 #, python-brace-format
 msgid "The following flatpak app(s) can talk to {0} on the session bus:"
 msgstr "Następujące aplikacje mogą komunikować się z {0} na magistrali sesji:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:391
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:329
 #, fuzzy, python-brace-format
 msgid "{0} can talk to {1} on the system bus."
 msgstr ""
 "Następujące aplikacje mogą komunikować się z {0} na magistrali systemowej:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:392
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:330
 #, python-brace-format
 msgid "The following flatpak app(s) can talk to {0} on the system bus:"
 msgstr ""
 "Następujące aplikacje mogą komunikować się z {0} na magistrali systemowej:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:397
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:497
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:335
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:132
 msgid "This grants the ability to acquire arbitrary permissions."
 msgstr "Umożliwia to zyskiwanie dowolnych uprawnień."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:441
-msgid "all system files"
-msgstr "wszystkie pliki systemowe"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:442
-msgid "all user files"
-msgstr "wszystkie pliki użytkownika"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:443
-msgid "other applications' configuration files"
-msgstr "pliki konfiguracyjne innych aplikacji"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:444
-msgid "other applications' cache files"
-msgstr "pliki cache innych aplikacji"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:445
-msgid "other applications' data files"
-msgstr "pliki danych innych aplikacji"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:471
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:99
 #, python-brace-format
 msgid "{0} is missing {1} permission"
 msgstr "{0} potrzebuje uprawnienia \"{1}\""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:474
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:102
 #, python-brace-format
 msgid "The following flatpak app(s) are missing {0} permission:"
 msgstr "Następujące aplikacje potrzebują uprawnienia \"{0}\":"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:476
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:104
 msgid "This is required to load hardened_malloc."
 msgstr "Jest to wymagane do załadowania hardened_malloc."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:477
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:105
 msgid "To add this permission to an app, use Flatseal or run:"
 msgstr ""
 "Aby udzielić aplikacji to uprawnienie, użyj programu Flatseal lub uruchom:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:493
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:128
 #, fuzzy, python-brace-format
 msgid "{0} can modify flatpak permissions."
 msgstr "{0} może uzyskać dowolne uprawnienia."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:495
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:130
 #, fuzzy
 msgid "The following flatpak app(s) can modify flatpak permissions:"
 msgstr "Następujące aplikacje mogą modyfikować uprawnienia aplikacji Flatpak:"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:165
+#, python-brace-format
+msgid "This grants access to {0}."
+msgstr "Umożliwia to na dostęp do \"{0}\"."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:171
+msgid "all system files"
+msgstr "wszystkie pliki systemowe"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:172
+msgid "all user files"
+msgstr "wszystkie pliki użytkownika"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:173
+msgid "other applications' configuration files"
+msgstr "pliki konfiguracyjne innych aplikacji"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:174
+msgid "other applications' cache files"
+msgstr "pliki cache innych aplikacji"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:175
+msgid "other applications' data files"
+msgstr "pliki danych innych aplikacji"
 
 #: files/system/usr/libexec/secureblue/audit_utils/__init__.py:38
 msgid "*** WARNING: Running audit script as root is not recommended. ***"

--- a/files/po/po-source-files.json
+++ b/files/po/po-source-files.json
@@ -3,7 +3,8 @@
         "files/system/usr/libexec/secureblue/audit_secureblue.py",
         "files/system/usr/libexec/secureblue/auditor/__init__.py",
         "files/system/usr/libexec/secureblue/audit_flatpak/__init__.py",
+        "files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py",
         "files/system/usr/libexec/secureblue/audit_utils/__init__.py",
-        "files/system/usr/libexec/secureblue/utils/__init__.py"
+        "files/system/usr/libexec/secureblue/audit_utils/containers.py"
     ]
 }

--- a/files/po/pt/audit_secureblue.po
+++ b/files/po/pt/audit_secureblue.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-22 00:29+0000\n"
+"POT-Creation-Date: 2026-07-06 02:05+0000\n"
 "PO-Revision-Date: 2025-12-01 14:26-0300\n"
 "Last-Translator: EsseLowNitro <103858681+EsseLowNitro@users.noreply.github."
 "com>\n"
@@ -801,69 +801,64 @@ msgstr "Fiscalização"
 msgid "Note: some results omitted due to configuration file or '{0}' argument."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:140
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:101
 msgid "permission"
 msgstr "permissão"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:145
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:106
 #, python-brace-format
 msgid "{0} has {1}"
 msgstr "{0} tem {1}"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:150
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:111
 msgid "This may also be used as a sandbox escape vector."
 msgstr "Isso também pode ser usado como método de escape de sandbox."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:156
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:117
 #, python-brace-format
 msgid "The following flatpak app(s) have {0}:"
 msgstr "O(s) seguinte(s) flatpak(s) possuem {0}:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:160
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:398
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:498
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:121
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:336
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:133
 msgid "To remove this permission from an app, use Flatseal or run:"
 msgstr "Para remover essa permissão desse flatpak, use Flatseal ou rode:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:162
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:340
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:400
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:479
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:500
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:123
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:278
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:338
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:107
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:135
 #, python-brace-format
 msgid "(replacing \"{0}\" with the flatpak app ID)"
 msgstr "(trocando \"{0}\" pelo ID do flatpak)"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:190
-#, python-brace-format
-msgid "This grants access to {0}."
-msgstr "Isso permite-o acesso à {0}."
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:196
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:131
 msgid "network access"
 msgstr "acesso à rede"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:201
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:136
 msgid "inter-process communications access"
 msgstr "acesso à comunicação entre processos"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:202
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:137
 msgid "This is only necessary for better X11 performance."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:208
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:143
 msgid "X11 access"
 msgstr "acesso ao X11"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:209
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:144
 msgid "X11 apps can monitor and modify each other's graphics and inputs."
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:215
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:150
 msgid "access to the PulseAudio socket"
 msgstr "acesso ao soquete PulseAudio"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:216
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:151
 msgid ""
 "\n"
 "            This grants access to all audio input and output streams.\n"
@@ -871,177 +866,182 @@ msgid ""
 "        "
 msgstr ""
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:221
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:156
 msgid "access to the D-Bus session bus"
 msgstr "acesso ao barramento D-Bus de sessão"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:222
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:157
 msgid "access to the D-Bus system bus"
 msgstr "acesso ao barramento D-Bus de sistema"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:223
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:158
 msgid "access to the SSH agent"
 msgstr "acesso ao agente SSH"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:228
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:163
 #, fuzzy
 msgid "access to all devices"
 msgstr "Isso permite acesso à dispositivos de entrada."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:229
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:164
 #, fuzzy
 msgid "This includes input devices, GPUs, raw USB, and virtualization."
 msgstr ""
 "Isso permite acesso a dispositivos de entrada, placas de vídeo, USB direto, "
 "e virtualização."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:231
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:166
 #, python-brace-format
 msgid "If GPU access is required, allow {0} instead."
 msgstr ""
 "Se acesso apenas à placa de vídeo for necessário, permita apenas {0} ao "
 "invés disso."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:237
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:172
 #, fuzzy
 msgid "access to input devices"
 msgstr "Isso permite acesso à dispositivos de entrada."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:238
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:173
 #, fuzzy
 msgid "This is required for game controllers."
 msgstr "Essa permissão é necessária para que o flatpak use hardened_malloc."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:240
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:175
 #, fuzzy
 msgid "access to kernel-based virtualization"
 msgstr "Isso permite acesso à virtualização providenciada pelo kernel (KVM)."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:245
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:180
 #, fuzzy
 msgid "access to shared memory."
 msgstr "Isso permite acesso a memória compartilhada."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:252
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:187
 #, fuzzy
 msgid "raw access to USB devices."
 msgstr "Isso permite acesso à dispositivos de entrada."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:255
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:190
 msgid "bluetooth access"
 msgstr "acesso ao Bluetooth"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:256
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:191
 msgid "ptrace access"
 msgstr "acesso ao ptrace"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:303
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:241
 #, python-brace-format
 msgid "{0} can acquire arbitrary permissions."
 msgstr "{0} pode adquirir permissões arbitrárias."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:306
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:244
 msgid "However, this is required for its functionality."
 msgstr "Porém, isso é necessário para sua funcionalidade."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:323
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:328
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:261
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:266
 #, python-brace-format
 msgid "{0} is requesting {1}"
 msgstr "{0} pede {1}"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:334
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:272
 #, python-brace-format
 msgid "{0} is not requesting {1}"
 msgstr "{0} não pede {1}"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:336
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:274
 #, python-brace-format
 msgid "The following flatpak app(s) are not requesting {0}:"
 msgstr "O(s) seguinte(s) flatpak(s) não pede(m) {0}:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:338
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:276
 msgid "To enable it for an app, run:"
 msgstr "Para ativá-lo para um flatpak, rode:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:387
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:325
 #, fuzzy, python-brace-format
 msgid "{0} can talk to {1} on the session bus."
 msgstr ""
 "O(s) seguinte(s) flatpak(s) podem falar com {0} pelo barramento de sessão:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:388
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:326
 #, python-brace-format
 msgid "The following flatpak app(s) can talk to {0} on the session bus:"
 msgstr ""
 "O(s) seguinte(s) flatpak(s) podem falar com {0} pelo barramento de sessão:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:391
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:329
 #, fuzzy, python-brace-format
 msgid "{0} can talk to {1} on the system bus."
 msgstr ""
 "O(s) seguinte(s) flatpak(s) podem falar com {0} pelo barramento de sistema:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:392
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:330
 #, fuzzy, python-brace-format
 msgid "The following flatpak app(s) can talk to {0} on the system bus:"
 msgstr ""
 "O(s) seguinte(s) flatpak(s) podem falar com {0} pelo barramento de sistema:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:397
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:497
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:335
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:132
 msgid "This grants the ability to acquire arbitrary permissions."
 msgstr "Isso o(s) permite(m) adquirir permissões arbitrárias."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:441
-msgid "all system files"
-msgstr "todos os arquivos de sistema"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:442
-msgid "all user files"
-msgstr "todos os arquivos do usuário"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:443
-msgid "other applications' configuration files"
-msgstr "arquivos de configuração de outros apps"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:444
-msgid "other applications' cache files"
-msgstr "arquivos de cache de outros apps"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:445
-msgid "other applications' data files"
-msgstr "arquivos de dados de outros apps"
-
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:471
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:99
 #, python-brace-format
 msgid "{0} is missing {1} permission"
 msgstr "Falta a permissão {1} à {0}"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:474
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:102
 #, python-brace-format
 msgid "The following flatpak app(s) are missing {0} permission:"
 msgstr "Ao(s) seguinte(s) flatpak(s) falta a permissão {0}:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:476
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:104
 msgid "This is required to load hardened_malloc."
 msgstr "Essa permissão é necessária para que o flatpak use hardened_malloc."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:477
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:105
 msgid "To add this permission to an app, use Flatseal or run:"
 msgstr "Para adicionar essa permissão a um app, use Flatseal ou rode:"
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:493
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:128
 #, fuzzy, python-brace-format
 msgid "{0} can modify flatpak permissions."
 msgstr "{0} pode adquirir permissões arbitrárias."
 
-#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:495
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:130
 #, fuzzy
 msgid "The following flatpak app(s) can modify flatpak permissions:"
 msgstr ""
 "O(s) seguinte(s) flatpak(s) podem mudar substituiçoes de configuração "
 "flatpak:"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:165
+#, python-brace-format
+msgid "This grants access to {0}."
+msgstr "Isso permite-o acesso à {0}."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:171
+msgid "all system files"
+msgstr "todos os arquivos de sistema"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:172
+msgid "all user files"
+msgstr "todos os arquivos do usuário"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:173
+msgid "other applications' configuration files"
+msgstr "arquivos de configuração de outros apps"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:174
+msgid "other applications' cache files"
+msgstr "arquivos de cache de outros apps"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py:175
+msgid "other applications' data files"
+msgstr "arquivos de dados de outros apps"
 
 #: files/system/usr/libexec/secureblue/audit_utils/__init__.py:38
 msgid "*** WARNING: Running audit script as root is not recommended. ***"

--- a/files/scripts/backupetc.sh
+++ b/files/scripts/backupetc.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# /usr/etc/ is an implementation detail of bootc, but we still need a reliable
+# baseline of /etc/ for our runtime tooling. bootc does not support having both
+# /etc/ and /usr/etc/ populated in an image (undefined behaviour), so instead we
+# explicitly make a backup in /usr/share/secureblue/etc/.
+
+cp -a /etc /usr/share/secureblue/

--- a/files/system/desktop/usr/lib/systemd/user/secureblue-key-enrollment-verification.service
+++ b/files/system/desktop/usr/lib/systemd/user/secureblue-key-enrollment-verification.service
@@ -7,6 +7,5 @@ ConditionPathIsDirectory=/var/home/%u
 
 [Service]
 Type=oneshot
-ExecCondition=/bin/bash -c 'mokutil --list-enrolled --short >/dev/null 2>&1'
-ExecCondition=/bin/bash -c '! mokutil --list-enrolled --short | grep -Fq "secureblue secureboot key"'
+ExecCondition=/bin/bash -c 'ujust enroll-secure-boot-keys status | grep -Fq "Status: not enrolled"'
 ExecStart=/usr/libexec/secureblue/securebluesecurebootnotify

--- a/files/system/desktop/usr/libexec/secureblue/inner/brew.py
+++ b/files/system/desktop/usr/libexec/secureblue/inner/brew.py
@@ -35,8 +35,10 @@ def enable_brew() -> None:
     subprocess.run(
         ["/usr/bin/systemd-tmpfiles", "--create", f"--prefix={LINUXBREW_HOME}"], check=True
     )
-    shutil.copy2(f"/usr{BREW_PROFILE_FILE}", BREW_PROFILE_FILE)
-    shutil.copy2(f"/usr{BREW_PROFILE_COMPLETIONS_FILE}", BREW_PROFILE_COMPLETIONS_FILE)
+    shutil.copy2(f"/usr/share/secureblue{BREW_PROFILE_FILE}", BREW_PROFILE_FILE)
+    shutil.copy2(
+        f"/usr/share/secureblue{BREW_PROFILE_COMPLETIONS_FILE}", BREW_PROFILE_COMPLETIONS_FILE
+    )
     subprocess.run(["/usr/bin/systemctl", "unmask", "--", *BREW_SYSTEMD_UNITS], check=True)
 
 

--- a/files/system/desktop/usr/libexec/secureblue/securebluecheckoutofdate
+++ b/files/system/desktop/usr/libexec/secureblue/securebluecheckoutofdate
@@ -7,9 +7,14 @@
 
 set -euo pipefail
 
-RPM_OSTREE_STATUS=$(rpm-ostree status --json --booted)
+if [[ -f "/usr/bin/rpm-ostree" ]]; then
+    RPM_OSTREE_STATUS=$(rpm-ostree status --json --booted)
+    IMAGE_DATE=$(echo "${RPM_OSTREE_STATUS}" | jq -r '.deployments[0].timestamp')
+else
+    IMAGE_DATE=$(jq -r '.status.booted.image.timestamp' /run/bootc/status.json)
+    IMAGE_DATE=$(date -d "${IMAGE_DATE}" '+%s')
+fi
 
-IMAGE_DATE=$(echo "${RPM_OSTREE_STATUS}" | jq -r '.deployments[0].timestamp')
 CURRENT_SECONDS=$(date +%s)
 DIFFERENCE=$((CURRENT_SECONDS - IMAGE_DATE))
 WEEK=604800 # 1 week

--- a/files/system/desktop/usr/libexec/secureblue/securebluesecurebootnotify
+++ b/files/system/desktop/usr/libexec/secureblue/securebluesecurebootnotify
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-selection=$(notify-send -A 'info=More Information' -a 'secureblue' -i 'dialog-warning' 'Secureboot key is not enrolled!' 'Run <i>ujust enroll-secureblue-secure-boot-key</i> to resolve this issue.' -u critical)
+selection=$(notify-send -A 'info=More Information' -a 'secureblue' -i 'dialog-warning' 'Secure Boot key is not enrolled!' 'Run <i>ujust enroll-secure-boot-keys</i> to resolve this issue.' -u critical)
 
 if [[ ${selection} == "info" ]]; then
     trivalent "https://secureblue.dev/faq#new-key"

--- a/files/system/desktop/usr/libexec/secureblue/security-update-notification
+++ b/files/system/desktop/usr/libexec/secureblue/security-update-notification
@@ -6,6 +6,19 @@
 
 set -euo pipefail
 
+# If there's been a bootc/composefs upgrade, then unconditionally notify.
+# We don't have an equivalent to the rpm-ostree database.
+if [[ ! -f "/usr/bin/rpm-ostree" ]]; then
+    if jq -e '.status.staged != null' /run/bootc/status.json > /dev/null; then
+        notify-send --urgency=critical \
+            --app-name="secureblue" \
+            --action="Reboot" \
+            "An update is ready" \
+            "Please reboot to run the updated system."
+    fi
+    exit 0
+fi
+
 cached_update_json="$(rpm-ostree status --json | jq -c '."cached-update"')"
 if [[ "${cached_update_json}" == 'null' ]]; then
     exit 0

--- a/files/system/desktop/usr/libexec/secureblue/set_xwayland.py
+++ b/files/system/desktop/usr/libexec/secureblue/set_xwayland.py
@@ -19,7 +19,6 @@ else:
 CommandUsageError: Final = utils.CommandUsageError
 Image: Final = utils.Image
 ToggleMode: Final = utils.ToggleMode
-booted_image_ref: Final = utils.booted_image_ref
 logout: Final = utils.logout
 parse_basic_toggle_args: Final = utils.parse_basic_toggle_args
 
@@ -63,7 +62,7 @@ def run(mode: ToggleMode) -> int:
         print(HELP_MESSAGE)
         return 0
 
-    image = Image.from_image_ref(booted_image_ref())
+    image = Image.from_running()
     if image not in XWAYLAND_OVERRIDE_FILES:
         print("The booted image does not support toggling Xwayland.")
         return 1
@@ -96,7 +95,7 @@ def run(mode: ToggleMode) -> int:
                         "/usr/bin/cp",
                         "-p",
                         "--",
-                        f"/usr{override_file}",
+                        f"/usr/share/secureblue{override_file}",
                         override_file,
                     ],
                     check=True,

--- a/files/system/usr/lib/modprobe.d/secureblue.conf
+++ b/files/system/usr/lib/modprobe.d/secureblue.conf
@@ -626,7 +626,7 @@ install pvrusb2 /bin/false
 # https://www.linuxtv.org/wiki/index.php/Philips_SAA7146
 # https://github.com/torvalds/linux/blob/master/drivers/media/pci/saa7146/hexium_orion.c
 install saa7146 /bin/false
-install saa7146_vv /bin/falsee
+install saa7146_vv /bin/false
 install hexium_gemini /bin/false
 install hexium_orion /bin/false
 # http://www.szmjd.com/Attachments/product/201501/54c5e68c78140.pdf

--- a/files/system/usr/lib/systemd/system/bootc-status.service
+++ b/files/system/usr/lib/systemd/system/bootc-status.service
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This service is a workaround for `bootc status` requiring root: see
+# <https://github.com/bootc-dev/bootc/issues/409>.
+
+[Unit]
+Description=Write bootc status to file
+Documentation=man:bootc(8)
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/bootc status --format json
+StandardOutput=truncate:/run/bootc/status.json
+
+[Install]
+WantedBy=multi-user.target

--- a/files/system/usr/lib/systemd/system/bootc-upgrade.service
+++ b/files/system/usr/lib/systemd/system/bootc-upgrade.service
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[Unit]
+Description=Upgrade bootc image
+Documentation=man:bootc(8)
+After=network-online.target nss-lookup.target
+Wants=network-online.target
+StartLimitIntervalSec=24h
+StartLimitBurst=3
+OnSuccess=bootc-status.service
+
+[Service]
+Type=oneshot
+ExecCondition=/bin/bash -c '[[ "$(busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Metered | cut -c 3-)" =~ ^(2|4)$ ]]'
+ExecStartPre=/usr/libexec/secureblue/verify-provenance.sh
+ExecStart=/usr/bin/bootc upgrade --quiet
+ExecStop=/bin/sh -c 'umask 022 && mkdir -p /var/lib/secureblue && date -Iseconds > /var/lib/secureblue/rpm-ostreed-automatic-completed.stamp'
+RestartSec=1h
+Restart=on-failure

--- a/files/system/usr/lib/systemd/system/bootc-upgrade.timer
+++ b/files/system/usr/lib/systemd/system/bootc-upgrade.timer
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[Unit]
+Description=Upgrade bootc image
+Documentation=man:bootc(8)
+After=network-online.target
+Wants=network-online.target
+
+[Timer]
+OnBootSec=1h
+OnUnitInactiveSec=8h
+RandomizedDelaySec=10m
+OnCalendar=*-*-* 4:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/files/system/usr/lib/tmpfiles.d/bootc.conf
+++ b/files/system/usr/lib/tmpfiles.d/bootc.conf
@@ -1,0 +1,1 @@
+d /run/bootc 0755 root root -

--- a/files/system/usr/libexec/luks-disable-fido2-unlock.sh
+++ b/files/system/usr/libexec/luks-disable-fido2-unlock.sh
@@ -5,7 +5,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set -eou pipefail
+set -euo pipefail
+
+if [[ ! -f "/usr/bin/rpm-ostree" ]]; then
+    echo "This script does not support UKI systems yet."
+    exit 1
+fi
 
 [[ "${UID}" -eq 0 ]] || { echo "This script must be run as root."; exit 1;}
 

--- a/files/system/usr/libexec/luks-disable-tpm2-autounlock.sh
+++ b/files/system/usr/libexec/luks-disable-tpm2-autounlock.sh
@@ -8,6 +8,11 @@
 ## disable unlock LUKS2 encrypted root on Fedora/Silverblue/maybe others
 set -euo pipefail
 
+if [[ ! -f "/usr/bin/rpm-ostree" ]]; then
+    echo "This script does not support UKI systems yet."
+    exit 1
+fi
+
 [[ "${UID}" -eq 0 ]] || { echo "This script must be run as root."; exit 1;}
 
 echo "This script utilizes systemd-cryptenroll for removing tpm2 unlock."

--- a/files/system/usr/libexec/luks-enable-fido2-unlock.sh
+++ b/files/system/usr/libexec/luks-enable-fido2-unlock.sh
@@ -5,7 +5,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set -eou pipefail
+set -euo pipefail
+
+if [[ ! -f "/usr/bin/rpm-ostree" ]]; then
+    echo "This script does not support UKI systems yet."
+    exit 1
+fi
 
 [[ "${UID}" -eq 0 ]] || { echo "This script must be run as root."; exit 1;}
 

--- a/files/system/usr/libexec/luks-enable-tpm2-autounlock.sh
+++ b/files/system/usr/libexec/luks-enable-tpm2-autounlock.sh
@@ -6,7 +6,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ## setup unlock LUKS2 encrypted root on Fedora/Silverblue/maybe others
-set -eou pipefail
+set -euo pipefail
+
+if [[ ! -f "/usr/bin/rpm-ostree" ]]; then
+    echo "This script does not support UKI systems yet."
+    exit 1
+fi
 
 
 [[ "${UID}" -eq 0 ]] || { echo "This script must be run as root."; exit 1;}

--- a/files/system/usr/libexec/secureblue-motd
+++ b/files/system/usr/libexec/secureblue-motd
@@ -7,39 +7,50 @@
 
 set -euo pipefail
 
-rpm_ostree_status=$(rpm-ostree status --json --booted)
-full_image_ref=$(jq -cr '.deployments[0]."container-image-reference"' <<<"${rpm_ostree_status}")
-image_ref_name=${full_image_ref##*/}
-if [[ "${image_ref_name}" == *hardened:* ]]; then
-    image_tag=${image_ref_name##*:}
-else
-    image_tag=''
-fi
-
-image_date=$(jq -cr '.deployments[0].timestamp' <<<"${rpm_ostree_status}")
-current_seconds=$(date +%s)
-difference=$((current_seconds - image_date))
-week=$((7 * 24 * 60 * 60))
-
-is_deprecated=$(jq -cr --arg 'image' "${image_ref_name}" '.imageTypes | any(inside($image))' /usr/libexec/deprecated-images.json)
-
 reset=$'\e[0m'
 bold=$'\e[1m'
 slight_red=$'\e[48;2;48;48;48m\e[38;2;245;86;71m'
 link=$'\e[38;2;23;118;122m'
 header=$'\e[1;38;5;228m\e[48;5;63m'
 
+if [[ ! -f "/usr/bin/rpm-ostree" ]]; then
+    full_image_ref=$(jq -r '.status.booted.image.image.image' /run/bootc/status.json)
+    image_ref_name=${full_image_ref##*/}
+    image_date=$(jq -r '.status.booted.image.timestamp' /run/bootc/status.json)
+    image_date=$(date -d "${image_date}" '+%s')
+    is_deprecated='false'
+else
+    rpm_ostree_status=$(rpm-ostree status --json --booted)
+    full_image_ref=$(jq -cr '.deployments[0]."container-image-reference"' <<<"${rpm_ostree_status}")
+    image_ref_name=${full_image_ref##*/}
+    image_date=$(jq -cr '.deployments[0].timestamp' <<<"${rpm_ostree_status}")
+    is_deprecated=$(jq -cr --arg 'image' "${image_ref_name}" '.imageTypes | any(inside($image))' /usr/libexec/deprecated-images.json)
+fi
+
+if [[ "${image_ref_name}" == *hardened:* ]]; then
+    image_tag=${image_ref_name##*:}
+else
+    image_tag=''
+fi
+
+current_seconds=$(date +%s)
+difference=$((current_seconds - image_date))
+week=$((7 * 24 * 60 * 60))
+
+# We only display one tag at a time, determined from most to least urgent.
 tip=''
 if [[ "${is_deprecated}" == 'true' ]]; then
     tip="${bold}You are on a deprecated image, rebase: ${reset}${link}https://github.com/secureblue/secureblue/blob/live/files/system/usr/libexec/deprecated-images.json.md${reset}"
-elif mokutil --list-enrolled --short >/dev/null 2>&1 && ! mokutil --list-enrolled --short | grep -Fq 'secureblue secureboot key'; then
-    tip="${bold}Secure Boot key is not enrolled! Run ${reset}${slight_red} ujust enroll-secureblue-secure-boot-key ${reset}${bold} to resolve this issue. More information: ${reset}${link}https://secureblue.dev/faq#new-key${reset}"
+elif ujust enroll-secure-boot-keys status | grep -Fq "Status: not enrolled"; then
+    tip="${bold}Secure Boot key is not enrolled! Run ${reset}${slight_red} ujust enroll-secure-boot-keys ${reset}${bold} to resolve this issue. More information: ${reset}${link}https://secureblue.dev/faq#new-key${reset}"
 elif [[ -z "${image_tag}" ]]; then
     tip="${bold}You are missing an image tag, which is unsupported by secureblue. Rebase to the ${reset}${slight_red} latest ${reset}${bold} tag to ensure you continue to receive updates.${reset}"
-elif [[ "${image_tag}" != "latest" ]]; then
+elif [[ "${image_tag}" != "latest" && "${image_tag}" != "uki" && "${image_tag}" != "latest-uki" ]]; then
     tip="${bold}You are on a specific tag, which is unsupported by secureblue. Rebase to the ${reset}${slight_red} latest ${reset}${bold} tag to ensure you continue to receive updates.${reset}"
 elif (( difference >= week )); then
     tip="${bold}Your current image is over 1 week old, run ${reset}${slight_red} ujust update-system ${reset}${reset}"
+elif [[ "${image_tag}" == "uki" || "${image_tag}" == "latest-uki" ]]; then
+    tip="${bold}UKI images are currently experimental.${reset}"
 fi
 
 cat << EOF

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -46,14 +46,15 @@ from auditor import (
     global_audit,
 )
 from utils import (
+    BootcBackend,
     Image,
-    booted_image_ref,
     command_stdout,
     command_succeeds,
     get_config_dir,
     is_module_loaded,
     is_using_vpn,
     loaded_kernel_modules,
+    ostree_booted_image_ref,
     parse_config,
     print_err,
 )
@@ -77,7 +78,7 @@ def audit_kargs():
     notes = []
     rec = None
 
-    kargs_current = frozenset(command_stdout("rpm-ostree", "kargs").split())
+    kargs_current = frozenset(Path("/proc/cmdline").read_text(encoding="utf-8").split())
     kargs_expected = kargs_hardening_common.DEFAULT_KARGS
     for karg in kargs_expected:
         if karg not in kargs_current:
@@ -154,8 +155,14 @@ def audit_sysctl():
 @audit
 def audit_signed_image(state):
     """Check that the secureblue image is signed."""
-    image_ref = booted_image_ref()
-    state["image"] = Image.from_image_ref(image_ref)
+
+    state["image"] = Image.from_running()
+    if BootcBackend.from_running() == BootcBackend.COMPOSEFS:
+        # bootc doesn't give specific info on this; it's best handled as part of
+        # audit_container_policy() which is also used by bootc.
+        return
+
+    image_ref = ostree_booted_image_ref()
     if image_ref.startswith("ostree-image-signed:"):
         status = PASS
         rec = None
@@ -213,7 +220,7 @@ def audit_container_policy():
     status = PASS
     notes = []
     system_policy_file = "/etc/containers/policy.json"
-    if not filecmp.cmp(f"/usr{system_policy_file}", system_policy_file):
+    if not filecmp.cmp(f"/usr/share/secureblue{system_policy_file}", system_policy_file):
         status = status.downgrade_to(INFO)
         notes.append(Note(_("The file {0} has been modified.").format(system_policy_file), INFO))
 
@@ -548,28 +555,39 @@ def audit_mac_randomization():
 
 
 @audit
-def audit_rpm_ostree_timer():
-    """Ensure rpm-ostree automatic updates are enabled."""
+def audit_update_timer():
+    """Ensure automatic updates are enabled."""
     status = PASS
     notes = []
     recs = []
 
-    if not command_succeeds("systemctl", "is-enabled", "--quiet", "rpm-ostreed-automatic.timer"):
+    is_ostree = BootcBackend.from_running() == BootcBackend.OSTREE
+    timer_unit = "rpm-ostreed-automatic.timer" if is_ostree else "bootc-upgrade.timer"
+    service_unit = "rpm-ostreed-automatic.service" if is_ostree else "bootc-upgrade.service"
+
+    # Check for upgrade timer or service failures.
+    if not command_succeeds("systemctl", "is-enabled", "--quiet", timer_unit):
         status = FAIL
-        note_text = _("{0} is disabled.").format("rpm-ostreed-automatic.timer")
+        note_text = _("{0} is disabled.").format(timer_unit)
         notes.append(Note(note_text, FAIL))
         rec_lines = [
             note_text,
             _("To enable it, run:"),
-            "$ systemctl enable --now rpm-ostreed-automatic.timer",
+            f"$ systemctl enable --now {timer_unit}",
         ]
         recs.append("\n".join(rec_lines))
-    elif command_succeeds("systemctl", "is-failed", "--quiet", "rpm-ostreed-automatic.service"):
+    elif command_succeeds("systemctl", "is-failed", "--quiet", service_unit):
         status = status.downgrade_to(WARN)
-        notes.append(
-            Note(_("{0} has failed to run.").format("rpm-ostreed-automatic.service"), WARN)
-        )
+        notes.append(Note(_("{0} has failed to run.").format(service_unit), WARN))
 
+    # For bootc/composefs systems, this is enough.
+    if not is_ostree:
+        yield Report(
+            _("Ensuring automatic system updates are enabled"), status, notes=notes, recs=recs
+        )
+        return
+
+    # On OSTree systems, also check the rpm-ostree config to see if updates are disabled.
     bad_rpm_ostreed_conf = False
     try:
         config = configparser.ConfigParser()
@@ -586,7 +604,7 @@ def audit_rpm_ostree_timer():
         rec_lines = [
             note_text,
             _("To fix this, run:"),
-            "$ run0 -i cp /usr/etc/rpm-ostreed.conf /etc/rpm-ostreed.conf",
+            "$ run0 -i cp /usr/share/secureblue/etc/rpm-ostreed.conf /etc/rpm-ostreed.conf",
         ]
         recs.append("\n".join(rec_lines))
 
@@ -979,7 +997,7 @@ def audit_environment_file():
         rec_lines = [
             _("The file {0} has been modified.").format(env_file),
             _("To reset it, run:"),
-            f"$ run0 -i cp -p /usr{env_file} {env_file}",
+            f"$ run0 -i cp -p /usr/share/secureblue{env_file} {env_file}",
         ]
         rec = "\n".join(rec_lines)
     yield Report(_("Ensuring no environment file overrides"), status, notes=note, recs=rec)
@@ -1048,7 +1066,7 @@ def audit_ld_preload():
         rec_lines = [
             _("The file {0} has been modified or deleted.").format(ld_so_preload),
             _("To reset it and enable hardened_malloc for system processes, run:"),
-            f"$ run0 -i cp -p /usr{ld_so_preload} {ld_so_preload}",
+            f"$ run0 -i cp -p /usr/share/secureblue{ld_so_preload} {ld_so_preload}",
         ]
         rec = "\n".join(rec_lines)
     yield Report(

--- a/files/system/usr/libexec/secureblue/enroll_secure_boot_keys.py
+++ b/files/system/usr/libexec/secureblue/enroll_secure_boot_keys.py
@@ -1,0 +1,152 @@
+#!/usr/bin/python3
+
+"""Enrolls secure boot keys into shim or the firmware - `ujust enroll-secure-boot-keys`."""
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from pathlib import Path
+
+import sandbox
+from shared.secure_boot import (
+    EFI_NS_GLOBAL,
+    EFI_NS_SHIM,
+    EFIVARS,
+    Bootloader,
+    EnrollEfiKeys,
+    EnrollMokKey,
+    is_cert_in_signature_list,
+    is_efi_system,
+    is_secure_boot_enabled,
+    is_setup_mode_enabled,
+    is_shim_system,
+    serialize,
+)
+
+AKMODS_DER_PATH = "/usr/share/pki/akmods/certs/akmods-secureblue.der"
+DB_AUTH_PATH = "/usr/share/secureblue/uki/keys/db.auth"
+DB_DER_PATH = "/usr/share/secureblue/uki/keys/db.der"
+KEK_AUTH_PATH = "/usr/share/secureblue/uki/keys/KEK.auth"
+PK_AUTH_PATH = "/usr/share/secureblue/uki/keys/PK.auth"
+PK_DER_PATH = "/usr/share/secureblue/uki/keys/PK.der"
+
+worker = sandbox.SandboxedFunction(
+    "secure_boot.py", read_write_paths=[EFIVARS.as_posix()], capabilities=["CAP_LINUX_IMMUTABLE"]
+)
+
+
+def required_mok_cert() -> str:
+    """Returns the MOK certificate that should be installed on the running system."""
+    return AKMODS_DER_PATH if Bootloader.from_running() == Bootloader.GRUB2 else DB_DER_PATH
+
+
+def is_mok_installed() -> bool:
+    """Returns whether the secureblue MOK is installed."""
+    return is_cert_in_signature_list(
+        Path(required_mok_cert()), EFIVARS / f"MokListRT-{EFI_NS_SHIM}"
+    )
+
+
+def is_pk_installed() -> bool:
+    """Returns whether the secureblue Platform Key is installed."""
+    try:
+        return is_cert_in_signature_list(Path(PK_DER_PATH), EFIVARS / f"PK-{EFI_NS_GLOBAL}")
+    except FileNotFoundError:
+        # Can be normal in Setup Mode.
+        return False
+
+
+def print_status(is_shim: bool) -> None:
+    """Prints the Secure Boot key enrollment status."""
+
+    if not is_efi_system():
+        print("Status: unavailable")
+        return
+
+    key_installed = is_mok_installed() if is_shim else is_pk_installed()
+    print("Status: enrolled" if key_installed else "Status: not enrolled")
+
+
+def install_pk() -> int:
+    """Installs the Platform Key. Returns error/success exit code."""
+
+    if is_pk_installed():
+        print("The secureblue Platform Key is already enrolled.")
+        if not is_secure_boot_enabled():
+            print("Secure Boot is not enabled. Please do this in `ujust bios`.")
+        return 0
+
+    if not is_setup_mode_enabled():
+        print(
+            "The firmware is not in Setup Mode.\n"
+            "Please remove the existing Platform Key in `ujust bios`."
+        )
+        return 1
+
+    request = EnrollEfiKeys(db_auth=DB_AUTH_PATH, kek_auth=KEK_AUTH_PATH, pk_auth=PK_AUTH_PATH)
+    exit_code = worker.run(stdin=serialize(request))
+
+    if exit_code:
+        print(f"Worker failed (exit {exit_code})", file=sys.stderr)
+        return exit_code
+
+    if is_pk_installed():
+        print("The secureblue Platform Key was successfully enrolled.")
+        return 0
+
+    print("Unable to install the secureblue Platform Key. Reboot and try again.")
+    return 1
+
+
+def install_mok() -> int:
+    """Install the MOK. Returns error/success exit code."""
+
+    if is_mok_installed():
+        print("The secureblue MOK is already enrolled.")
+        return 0
+
+    if not is_secure_boot_enabled():
+        print("Secure Boot is not enabled. Please do this in `ujust bios`.")
+
+    request = EnrollMokKey(der=required_mok_cert(), password="secureblue")  # noqa: S106
+    exit_code = worker.run(stdin=serialize(request))
+
+    if exit_code:
+        print(f"Worker failed (exit {exit_code})", file=sys.stderr)
+        return exit_code
+
+    print(
+        "The secureblue MOK has been queued for enrollment.\n"
+        "Please reboot and enter the password 'secureblue' when prompted."
+    )
+    return 0
+
+
+def main() -> int:
+    """Enroll MOK or Platform Key depending on bootc backend."""
+
+    is_shim = is_shim_system()
+
+    if len(sys.argv) > 1 and sys.argv[1] == "status":
+        print_status(is_shim)
+        return 0
+
+    # User wants to enroll a key.
+    if not is_efi_system():
+        print(
+            "Secure Boot is not available on your system.\n"
+            "If you have a dual-mode system, switch it from BIOS to UEFI mode and try again."
+        )
+        return 1
+
+    # We're running on a UEFI system.
+    if is_shim:
+        return install_mok()
+
+    return install_pk()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/files/system/usr/libexec/secureblue/inner/secure_boot.py
+++ b/files/system/usr/libexec/secureblue/inner/secure_boot.py
@@ -1,0 +1,188 @@
+#!/usr/bin/python3
+
+"""Enrolls secure boot keys into shim or the firmware. Should be run as root."""
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+from shared.secure_boot import (
+    EFI_GUID_SIZE,
+    EFI_NS_GLOBAL,
+    EFI_NS_SECURITY,
+    EFI_NS_SHIM,
+    EFI_TYPE_X509,
+    EFI_UINT32_SIZE,
+    EFIVARS,
+    EnrollEfiKeys,
+    EnrollMokKey,
+    deserialize,
+)
+
+# UEFI variable attributes.
+EFI_ATTR_NON_VOLATILE = 0x00000001  # EFI_VARIABLE_NON_VOLATILE
+EFI_ATTR_BOOTSERVICE = 0x00000002  # EFI_VARIABLE_BOOTSERVICE_ACCESS
+EFI_ATTR_RUNTIME = 0x00000004  # EFI_VARIABLE_RUNTIME_ACCESS
+EFI_ATTR_TIME_BASED_AUTH_WRITE = 0x00000020  # EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS
+
+SYSTEMD_BOOT_NEW = Path("/usr/lib/systemd/boot/efi/systemd-bootx64.efi")
+BOOTLOADER_ESP_BOOT = Path("/boot/EFI/BOOT/BOOTX64.EFI")
+BOOTLOADER_ESP_SYSTEMD = Path("/boot/EFI/systemd/systemd-bootx64.efi")
+
+
+def _write_efi_bytes(variable: str, ns_guid: str, attributes: int, payload: bytes) -> None:
+    """Writes a UEFI variable with an attribute."""
+
+    path = EFIVARS / f"{variable}-{ns_guid}"
+
+    # The kernel exposes efivars with the attributes as a 4-byte LE uint at the start.
+    data = struct.pack("<I", attributes) + payload
+
+    # Existing efivars are marked immutable, so that needs to be explicitly cleared.
+    if path.exists():
+        subprocess.run(["/usr/bin/chattr", "-i", path.as_posix()], check=True)
+
+    os.umask(0o022)  # Otherwise the outer function can't verify the PK.
+    path.write_bytes(data)
+
+    subprocess.run(["/usr/bin/chattr", "+i", path.as_posix()], check=True)
+
+
+def enroll_efi_keys(*, db_auth: Path, kek_auth: Path, pk_auth: Path) -> None:
+    """Enroll db, KEK, and PK directly into UEFI firmware.
+
+    Args:
+        db_auth: The db.auth file in EFI_VARIABLE_AUTHENTICATION_2 format.
+        kek_auth: The KEK.auth file in EFI_VARIABLE_AUTHENTICATION_2 format.
+        pk_auth: The PK.auth file in EFI_VARIABLE_AUTHENTICATION_2 format.
+    """
+
+    # These are standard and taken from systemd-boot loader.conf.
+    attributes = (
+        EFI_ATTR_NON_VOLATILE
+        | EFI_ATTR_RUNTIME
+        | EFI_ATTR_BOOTSERVICE
+        | EFI_ATTR_TIME_BASED_AUTH_WRITE
+    )
+
+    for variable, ns_guid, auth_file in (
+        ("db", EFI_NS_SECURITY, db_auth),
+        ("KEK", EFI_NS_GLOBAL, kek_auth),
+        ("PK", EFI_NS_GLOBAL, pk_auth),  # Enrolling a PK exits Setup Mode, so this goes last.
+    ):
+        _write_efi_bytes(variable, ns_guid, attributes, auth_file.read_bytes())
+
+
+def update_systemd_boot() -> None:
+    """Updates systemd-boot in the ESP to the version shipped with secureblue. Invalidates PCR."""
+
+    new_systemd = hashlib.file_digest(SYSTEMD_BOOT_NEW.open("rb"), "sha256").hexdigest()
+    esp_boot = hashlib.file_digest(BOOTLOADER_ESP_BOOT.open("rb"), "sha256").hexdigest()
+    esp_systemd = hashlib.file_digest(BOOTLOADER_ESP_SYSTEMD.open("rb"), "sha256").hexdigest()
+    if new_systemd != esp_systemd:
+        shutil.copy(SYSTEMD_BOOT_NEW, BOOTLOADER_ESP_SYSTEMD)
+        # If BOOTX64.EFI is not a copy of systemd-bootx64.efi (e.g. dual-booting)
+        # then we don't want to overwrite it.
+        if esp_boot == esp_systemd:
+            shutil.copy(SYSTEMD_BOOT_NEW, BOOTLOADER_ESP_BOOT)
+
+
+def _mok_auth_hash(list_data: bytes, password: str) -> bytes:
+    """Returns the 32-byte verifier for MokAuth. See mokutil `generate_auth()`.
+
+    Args:
+        list_data: The EFI_SIGNATURE_LIST being enrolled.
+        password: Password the user must enter at the MOK screen to confirm enrollment.
+
+    Returns:
+        The SHA256 digest of `list_data` followed by the password.
+    """
+    digest = hashlib.sha256()
+    digest.update(list_data)
+    digest.update(password.encode("utf-16-le"))
+    return digest.digest()
+
+
+def enroll_mok_key(der: Path, *, password: str) -> None:
+    """Stage a DER certificate for MOK enrollment on next boot.
+
+    Args:
+        der: Path to the DER-encoded certificate file.
+        password: Password the user must enter at the MOK screen to confirm enrollment.
+    """
+    der_bytes = der.read_bytes()
+
+    # MokNew takes an EFI_SIGNATURE_LIST. See EDK2 source:
+    #
+    # typedef struct {
+    #   EFI_GUID    SignatureType;
+    #   UINT32      SignatureListSize;
+    #   UINT32      SignatureHeaderSize;
+    #   UINT32      SignatureSize;
+    #   /// UINT8           SignatureHeader[SignatureHeaderSize];
+    #   /// EFI_SIGNATURE_DATA Signatures[][SignatureSize];
+    # } EFI_SIGNATURE_LIST;
+    #
+    # typedef struct {
+    #   EFI_GUID    SignatureOwner;
+    #   UINT8       SignatureData[1];
+    # } EFI_SIGNATURE_DATA;
+
+    signature_type = uuid.UUID(EFI_TYPE_X509).bytes_le
+    signature_size = EFI_GUID_SIZE + len(der_bytes)
+    signature_list_size = EFI_GUID_SIZE + (EFI_UINT32_SIZE * 3) + signature_size
+    signature_header_size = 0
+
+    # We don't need a SignatureOwner for MOK.
+    signature_owner = b"\x00" * EFI_GUID_SIZE
+
+    mok_new_payload = (
+        signature_type
+        + struct.pack("<III", signature_list_size, signature_header_size, signature_size)
+        + signature_owner
+        + der_bytes
+    )
+
+    attrs = EFI_ATTR_NON_VOLATILE | EFI_ATTR_BOOTSERVICE | EFI_ATTR_RUNTIME
+    mok_auth_payload = _mok_auth_hash(mok_new_payload, password)
+
+    _write_efi_bytes("MokNew", EFI_NS_SHIM, attrs, mok_new_payload)
+    _write_efi_bytes("MokAuth", EFI_NS_SHIM, attrs, mok_auth_payload)
+
+    # To avoid boot failures if there's been a key rotation, we make sure
+    # systemd-boot is up to date with any new signature or version.
+    update_systemd_boot()
+
+
+def main() -> int:
+    """Execute the requested function."""
+
+    request = deserialize(sys.stdin.read())
+
+    match request:
+        case EnrollEfiKeys():
+            enroll_efi_keys(
+                db_auth=Path(request.db_auth),
+                kek_auth=Path(request.kek_auth),
+                pk_auth=Path(request.pk_auth),
+            )
+            return 0
+        case EnrollMokKey():
+            enroll_mok_key(der=Path(request.der), password=request.password)
+            return 0
+        case _:
+            print(f"Unhandled action: {request}", file=sys.stderr)
+            return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/files/system/usr/libexec/secureblue/install_dangerzone.py
+++ b/files/system/usr/libexec/secureblue/install_dangerzone.py
@@ -13,7 +13,7 @@ import sys
 from typing import Final
 
 import sandbox
-from utils import ask_yes_no, print_wrapped
+from utils import BootcBackend, ask_yes_no, print_wrapped
 
 WARNING_MESSAGE: Final[str] = """
 Warning: Dangerzone (https://dangerzone.rocks/) requires enabling both container-domain
@@ -25,6 +25,10 @@ and to use ptrace to inspect child processes in containers.
 
 def main() -> int:
     """Main script entrypoint."""
+    if BootcBackend.from_running() == BootcBackend.COMPOSEFS:
+        print("This script does not support UKI systems yet.")
+        return 1
+
     print_wrapped(WARNING_MESSAGE)
     if not ask_yes_no("Continue installing Dangerzone?"):
         print("Canceling installation.")

--- a/files/system/usr/libexec/secureblue/sandbox/__init__.py
+++ b/files/system/usr/libexec/secureblue/sandbox/__init__.py
@@ -55,6 +55,7 @@ RUN0_BASE_ARGUMENTS: Final[list[str]] = [
     f"--property=SystemCallFilter={' '.join(SYSCALLS_TO_ALLOW)}",
     f"--property=SystemCallFilter=~{' '.join(SYSCALLS_TO_DENY)}",
     "--property=SystemCallErrorNumber=EPERM",
+    "--setenv=PYTHONPATH=/usr/libexec/secureblue",
 ]
 
 
@@ -159,20 +160,25 @@ class SandboxedFunction:
 
         return args
 
-    def run(self, *args: str) -> int:
+    def run(self, *args: str, stdin: str | None = None) -> int:
         """Run the sandboxed function.
 
         Args:
             *args (str): Positional arguments to pass to the sandboxed function.
+            stdin (str | None): Text to pipe to the sandboxed function's stdin.
+                Only valid for non-interactive functions.
         Returns:
             int: The exit status code of the function.
         """
 
-        return run(self, *args)
+        return run(self, *args, stdin=stdin)
 
 
-def run(sandboxed_function: SandboxedFunction, *args: str) -> int:
+def run(sandboxed_function: SandboxedFunction, *args: str, stdin: str | None = None) -> int:
     """Execute a sandboxed function."""
+
+    if sandboxed_function.subprocess_interactive and stdin is not None:
+        raise ValueError("Cannot specify 'stdin' when 'subprocess_interactive' is set to True.")
 
     command = [
         "/usr/bin/run0",
@@ -184,11 +190,17 @@ def run(sandboxed_function: SandboxedFunction, *args: str) -> int:
         *args,
     ]
 
-    if sandboxed_function.subprocess_interactive:
+    if stdin is not None:
+        result = subprocess.run(
+            command, check=False, input=stdin, stdout=sys.stdout, stderr=sys.stderr, text=True
+        )
+    elif sandboxed_function.subprocess_interactive:
         result = subprocess.run(
             command, check=False, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr
         )
     else:
-        result = subprocess.run(command, check=False, stdin=subprocess.DEVNULL)
+        result = subprocess.run(
+            command, check=False, stdin=subprocess.DEVNULL, stdout=sys.stdout, stderr=sys.stderr
+        )
 
     return result.returncode

--- a/files/system/usr/libexec/secureblue/securebluecleanup
+++ b/files/system/usr/libexec/secureblue/securebluecleanup
@@ -7,17 +7,17 @@
 set -euo pipefail
 
 # Remove vestigial authselect overrides from Anaconda
-cp /usr/etc/authselect/system-auth /etc/authselect/system-auth
-cp /usr/etc/authselect/fingerprint-auth /etc/authselect/fingerprint-auth
-cp /usr/etc/authselect/dconf-db /etc/authselect/dconf-db
-cp /usr/etc/authselect/authselect.conf /etc/authselect/authselect.conf
+cp /usr/share/secureblue/etc/authselect/system-auth /etc/authselect/system-auth
+cp /usr/share/secureblue/etc/authselect/fingerprint-auth /etc/authselect/fingerprint-auth
+cp /usr/share/secureblue/etc/authselect/dconf-db /etc/authselect/dconf-db
+cp /usr/share/secureblue/etc/authselect/authselect.conf /etc/authselect/authselect.conf
 
 # Remove firewalld zone override from Anaconda
-cp /usr/etc/firewalld/zones/FedoraWorkstation.xml /etc/firewalld/zones/FedoraWorkstation.xml || true
-cp /usr/etc/firewalld/zones/FedoraServer.xml /etc/firewalld/zones/FedoraServer.xml || true
+cp /usr/share/secureblue/etc/firewalld/zones/FedoraWorkstation.xml /etc/firewalld/zones/FedoraWorkstation.xml || true
+cp /usr/share/secureblue/etc/firewalld/zones/FedoraServer.xml /etc/firewalld/zones/FedoraServer.xml || true
 
 # Undo chronyd timeserver configuration from Anaconda, which is empty sometimes.
-cp /usr/etc/chrony.conf /etc/chrony.conf
+cp /usr/share/secureblue/etc/chrony.conf /etc/chrony.conf
 
 if command -v flatpak &> /dev/null
 then

--- a/files/system/usr/libexec/secureblue/shared/secure_boot.py
+++ b/files/system/usr/libexec/secureblue/shared/secure_boot.py
@@ -1,0 +1,195 @@
+#!/usr/bin/python3
+
+"""Shared data objects for `ujust enroll-secure-boot-keys`."""
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import dataclasses
+import enum
+import json
+import struct
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+EFIVARS = Path("/sys/firmware/efi/efivars")
+
+# UEFI variable namespaces. These are mostly relevant as the predictable suffix
+# after an efivar, like /sys/firmware/efi/efivars/{VARIABLE}-{NAMESPACE_GUID}.
+# See S3.3: <https://uefi.org/sites/default/files/resources/UEFI_Spec_2_10_Aug29.pdf>
+EFI_NS_GLOBAL = "8be4df61-93ca-11d2-aa0d-00e098032b8c"  # EFI_GLOBAL_VARIABLE
+EFI_NS_SECURITY = "d719b2cb-3d3a-4596-a3bc-dad00e67656f"  # EFI_IMAGE_SECURITY_DATABASE_GUID
+# https://github.com/rhboot/shim/blob/c17fdb2ff23c9e28615782ac9ae268ed6a8f71f4/lib/guid.c
+EFI_NS_SHIM = "605dab50-e046-4300-abb6-3dd810dd8b23"  # SHIM_LOCK_GUID
+EFI_NS_SYSTEMD = "4a67b082-0a4c-41cf-b6c7-440b29bb8c4f"  # systemd vendor GUID
+
+# UEFI types.
+EFI_TYPE_X509 = "a5c059a1-94e4-4aa7-87b5-ab155c2bf072"  # EFI_CERT_X509_GUID
+
+# UEFI binary layout sizes (bytes).
+EFI_UINT32_SIZE = 4
+EFI_GUID_SIZE = 16
+
+
+@dataclass
+class EnrollEfiKeys:
+    """Shared data object for calling `enroll_efi_keys(db_auth, kek_auth, pk_auth)`."""
+
+    action: Literal["enroll_efi_keys"] = "enroll_efi_keys"
+    db_auth: str = ""
+    kek_auth: str = ""
+    pk_auth: str = ""
+
+
+@dataclass
+class EnrollMokKey:
+    """Shared data object for calling `enroll_mok_key(der, password)`."""
+
+    action: Literal["enroll_mok_key"] = "enroll_mok_key"
+    der: str = ""
+    password: str = ""
+
+
+_TYPES: dict[str, type] = {
+    "enroll_efi_keys": EnrollEfiKeys,
+    "enroll_mok_key": EnrollMokKey,
+}
+
+
+def read_efivar(name: str, ns_guid: str) -> bytes:
+    """Returns the raw contents of a UEFI variable."""
+
+    path = EFIVARS / f"{name}-{ns_guid}"
+    data = path.read_bytes()
+
+    # Strip the attributes uint to get the data.
+    return data[EFI_UINT32_SIZE:]
+
+
+def read_efivar_str(name: str, ns_guid: str) -> str:
+    """Returns the string contents of a UEFI variable."""
+    return read_efivar(name, ns_guid).decode("utf-16-le").rstrip("\x00")
+
+
+def is_cert_in_signature_list(der: Path, efivar: Path) -> bool:
+    """Return whether the DER certificate is present in the given EFI_SIGNATURE_LIST.
+
+    Raises:
+        FileNotFoundError: Either the certificate or efivar could not be found.
+    """
+
+    der_bytes = der.read_bytes()
+    sig_list = efivar.read_bytes()[EFI_UINT32_SIZE:]  # Strip attributes.
+    x509_guid = uuid.UUID(EFI_TYPE_X509).bytes_le
+
+    # See EDK2 source:
+    #
+    # typedef struct {
+    #   EFI_GUID    SignatureType;
+    #   UINT32      SignatureListSize;
+    #   UINT32      SignatureHeaderSize;
+    #   UINT32      SignatureSize;
+    #   /// UINT8           SignatureHeader[SignatureHeaderSize];
+    #   /// EFI_SIGNATURE_DATA Signatures[][SignatureSize];
+    # } EFI_SIGNATURE_LIST;
+    #
+    # typedef struct {
+    #   EFI_GUID    SignatureOwner;
+    #   UINT8       SignatureData[1];
+    # } EFI_SIGNATURE_DATA;
+
+    sig_list_header_size = EFI_GUID_SIZE + (EFI_UINT32_SIZE * 3)
+    list_offset = 0
+
+    while list_offset + sig_list_header_size <= len(sig_list):
+        sig_type = sig_list[list_offset : list_offset + EFI_GUID_SIZE]
+        sig_list_size, sig_header_size, sig_size = struct.unpack_from(
+            "<III", sig_list, list_offset + EFI_GUID_SIZE
+        )
+
+        if sig_list_size == 0:
+            break
+
+        if sig_type == x509_guid and sig_size > EFI_GUID_SIZE:
+            entries_start = list_offset + sig_list_header_size + sig_header_size
+            entries_end = list_offset + sig_list_size
+
+            for entry_offset in range(entries_start, entries_end, sig_size):
+                # EFI_SIGNATURE_DATA is owner GUID, then the certificate.
+                cert = sig_list[entry_offset + EFI_GUID_SIZE : entry_offset + sig_size]
+                if cert == der_bytes:
+                    return True
+
+        list_offset += sig_list_size
+
+    return False
+
+
+def is_secure_boot_enabled() -> bool:
+    """Returns whether Secure Boot is enabled."""
+    return read_efivar("SecureBoot", EFI_NS_GLOBAL)[0] == 1
+
+
+def is_setup_mode_enabled() -> bool:
+    """Returns whether the system is in Setup Mode."""
+    return read_efivar("SetupMode", EFI_NS_GLOBAL)[0] == 1
+
+
+class Bootloader(enum.Enum):
+    """A bootloader, e.g. `GRUB2` or `SYSTEMD_BOOT`."""
+
+    SYSTEMD_BOOT = enum.auto()
+    GRUB2 = enum.auto()
+
+    @classmethod
+    def from_running(cls) -> "Bootloader":
+        """Gets the `Bootloader` in use on the running system.
+
+        Raises:
+            RuntimeError: The bootloader could not be determined.
+            FileNotFoundError: Could not find systemd `LoaderInfo` efivar.
+        """
+
+        raw_bootloader = read_efivar_str("LoaderInfo", EFI_NS_SYSTEMD)
+        if "GRUB 2" in raw_bootloader:
+            return cls.GRUB2
+        if "systemd-boot" in raw_bootloader:
+            return cls.SYSTEMD_BOOT
+        raise RuntimeError(f"Unknown bootloader: {raw_bootloader}")
+
+
+def is_shim_system() -> bool:
+    """Returns whether the system booted with shim."""
+    return (EFIVARS / f"MokListRT-{EFI_NS_SHIM}").exists()
+
+
+def is_efi_system() -> bool:
+    """Returns whether the system has a UEFI firmware."""
+    return EFIVARS.exists()
+
+
+def serialize(request: EnrollEfiKeys | EnrollMokKey) -> str:
+    """Serialises a data object to be passed to the inner function."""
+
+    return json.dumps(dataclasses.asdict(request))
+
+
+def deserialize(request: str) -> EnrollEfiKeys | EnrollMokKey:
+    """Deserialises a data object passed to the inner function.
+
+    Raises:
+        ValueError: Unknown action type.
+        TypeError: Unexpected fields for action.
+    """
+
+    data = json.loads(request)
+    action = data.get("action")
+    cls = _TYPES.get(action)
+    if cls is None:
+        raise ValueError(f"Unknown action for secure boot worker: {action!r}")
+
+    # TypeError if there are unexpected or missing fields.
+    return cls(**data)

--- a/files/system/usr/libexec/secureblue/system-update-available
+++ b/files/system/usr/libexec/secureblue/system-update-available
@@ -12,6 +12,15 @@
 
 set -euo pipefail
 
+# bootc/composefs images do not have rpm-ostree installed.
+if [[ ! -f "/usr/bin/rpm-ostree" ]]; then
+    if bootc upgrade --check 2>&1 | grep -q "No changes in"; then
+        exit 1
+    else
+        exit 0
+    fi
+fi
+
 deployment=$(rpm-ostree status --json | jq -cr '.deployments[0]')
 image_ref=$(jq -cr '."container-image-reference"' <<<"${deployment}")
 image_ref="${image_ref#*:}"

--- a/files/system/usr/libexec/secureblue/update_system.py
+++ b/files/system/usr/libexec/secureblue/update_system.py
@@ -10,18 +10,25 @@ import sys
 from pathlib import Path
 from subprocess import DEVNULL, CalledProcessError, Popen, run
 
+from utils import BootcBackend
+
 
 def main() -> int:
     try:
         run(["/usr/libexec/secureblue/verify-provenance.sh"], check=True)
-        run(["/usr/bin/rpm-ostree", "upgrade"], check=True)
-        if Path("/usr/libexec/secureblue/security-update-notification").is_file():
-            Popen(
-                ["/usr/libexec/secureblue/security-update-notification"],
-                start_new_session=True,
-                stdout=DEVNULL,
-                stderr=DEVNULL,
-            )
+
+        if BootcBackend.from_running() == BootcBackend.OSTREE:
+            run(["/usr/bin/rpm-ostree", "upgrade"], check=True)
+            if Path("/usr/libexec/secureblue/security-update-notification").is_file():
+                Popen(
+                    ["/usr/libexec/secureblue/security-update-notification"],
+                    start_new_session=True,
+                    stdout=DEVNULL,
+                    stderr=DEVNULL,
+                )
+        else:
+            print("You must be authorized as an administrator to trigger an update.")
+            run(["/usr/bin/run0", "--via-shell", "/usr/bin/bootc", "upgrade"], check=True)
         return 0
     except CalledProcessError:
         print("An unexpected error occured.")

--- a/files/system/usr/libexec/secureblue/utils/__init__.py
+++ b/files/system/usr/libexec/secureblue/utils/__init__.py
@@ -11,6 +11,7 @@ Various utility functions used in secureblue scripts.
 import enum
 import json
 import os
+import platform
 import subprocess
 import sys
 import textwrap
@@ -60,6 +61,18 @@ def parse_basic_toggle_args(*, prompt: str | None = None) -> ToggleMode:
         raise CommandUsageError("Invalid option selected") from e
 
 
+class BootcBackend(enum.Enum):
+    """A bootc storage backend: either `OSTREE` (legacy) or `COMPOSEFS` (UKI)."""
+
+    COMPOSEFS = enum.auto()
+    OSTREE = enum.auto()
+
+    @classmethod
+    def from_running(cls) -> "BootcBackend":
+        """Gets the `BootcBackend` of the running system."""
+        return cls.OSTREE if Path("/usr/bin/rpm-ostree").exists() else cls.COMPOSEFS
+
+
 class Image(enum.Enum):
     """Fedora atomic base image"""
 
@@ -71,19 +84,12 @@ class Image(enum.Enum):
     IOT = enum.auto()
 
     @classmethod
-    def from_image_ref(cls, image_ref: str) -> "Image | None":
-        """Convert an image reference to the corresponding Image enum instance."""
-        image_dict: dict[str, Image] = {
-            "silverblue": cls.SILVERBLUE,
-            "kinoite": cls.KINOITE,
-            "sericea": cls.SERICEA,
-            "cosmic": cls.COSMIC,
-            "securecore": cls.COREOS,
-            "iot": cls.IOT,
-        }
-        image_name = image_ref.rsplit("/", maxsplit=1)[-1]
-        image_prefix = image_name.split("-", maxsplit=1)[0]
-        return image_dict.get(image_prefix)
+    def from_running(cls) -> "Image | None":
+        """Gets the `Image` of the running system."""
+        os_release = platform.freedesktop_os_release()
+        image = os_release["IMAGE_ID"]  # e.g. silverblue-main-hardened
+        image_prefix = image.split("-", maxsplit=1)[0]
+        return cls.by_alias(image_prefix)
 
     @classmethod
     def by_alias(cls, alias: str) -> "Image | None":
@@ -111,8 +117,10 @@ class Image(enum.Enum):
         return not self.is_server()
 
 
-def booted_image_ref() -> str:
+def ostree_booted_image_ref() -> str:
     """Get the image reference of the booted deployment."""
+    if BootcBackend.from_running() != BootcBackend.OSTREE:
+        raise RuntimeError("Cannot get booted OSTree image on a composefs bootc system.")
     ostree_status = command_stdout("/usr/bin/rpm-ostree", "status", "--json")
     image_ref = json.loads(ostree_status)["deployments"][0]["container-image-reference"]
     if not isinstance(image_ref, str):
@@ -209,7 +217,7 @@ def is_rpm_package_installed(name: str) -> bool:
 def logout(prompt: str | None = None) -> None:
     if prompt is not None and not ask_yes_no(prompt):
         return
-    match Image.from_image_ref(booted_image_ref()):
+    match Image.from_running():
         case Image.SERICEA:
             subprocess.run(["/usr/sbin/swaymsg", "exit"], check=True)
         case Image.KINOITE:

--- a/files/system/usr/libexec/secureblue/verify-provenance.sh
+++ b/files/system/usr/libexec/secureblue/verify-provenance.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-# SPDX-FileCopyrightText: Copyright 2025 The Secureblue Authors
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -9,8 +9,12 @@ set -euo pipefail
 # Ensure $HOME is set.
 export HOME=${HOME:-~}
 
-image_ref=$(rpm-ostree status --booted --json | jq -cr '.deployments[0]."container-image-reference"')
-image_ref=${image_ref#*:docker://}
+if [[ -f "/usr/bin/rpm-ostree" ]]; then
+    image_ref=$(rpm-ostree status --booted --json | jq -cr '.deployments[0]."container-image-reference"')
+    image_ref=${image_ref#*:docker://}
+else
+    image_ref=$(jq -r '.status.booted.image.image.image' /run/bootc/status.json)
+fi
 case "${image_ref}" in
     ghcr.io/secureblue/*)
         source_uri='github.com/secureblue/secureblue'
@@ -20,15 +24,17 @@ case "${image_ref}" in
         exit 1
         ;;
 esac
+
 echo "Verifying build provenance for ${image_ref}..."
 
 image_tag="${image_ref##*:}"
 case "${image_tag}" in
-    latest)
+    latest|latest-uki|uki)
         branch='live'
         ;;
     br-*)
-        branch="${image_tag#br-}"
+        branch="${image_tag%-uki}"
+        branch="${branch#br-}"
         branch="${branch%-*}"
         ;;
     *)

--- a/modules/secureblue-signing/secureblue-signing.sh
+++ b/modules/secureblue-signing/secureblue-signing.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-CONTAINER_DIR='/usr/etc/containers'
+CONTAINER_DIR='/usr/share/secureblue/etc/containers'
 ETC_CONTAINER_DIR='/etc/containers'
 MODULE_DIRECTORY="${MODULE_DIRECTORY:-/tmp/modules}"
 IMAGE_REGISTRY_TITLE=$(echo "${IMAGE_REGISTRY}" | cut -d'/' -f2-)
@@ -38,7 +38,6 @@ jq --arg image_registry "${IMAGE_REGISTRY}" \
         }
     ] } + .' "${POLICY_FILE}" > POLICY.tmp
 
-# covering our bases here since /usr/etc is technically unsupported, reevaluate once bootc is the primary deployment tool
 cp POLICY.tmp "${CONTAINER_DIR}/policy.json"
 cp POLICY.tmp "${ETC_CONTAINER_DIR}/policy.json"
 rm POLICY.tmp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,3 +63,6 @@ pycodestyle.max-doc-length = 100
 
 # Allow partial executable paths in subprocess invocations in dev tools
 "tools/*.py" = ["S607"]
+
+[tool.pylint.main]
+source-roots = ["files/system/usr/libexec/secureblue"]

--- a/recipes/common/common-modules.yml
+++ b/recipes/common/common-modules.yml
@@ -4,7 +4,7 @@
 
 modules:
   - type: script
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     scripts:
       - removeunusedrepos.sh
       - httpsmirrors.sh
@@ -15,7 +15,7 @@ modules:
       - check-rpm-ostree-version.sh
 
   - type: files
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     files:
       - source: system/usr
         destination: /usr
@@ -27,13 +27,13 @@ modules:
   - from-file: common/common-scripts.yml
 
   - type: justfiles
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     validate: true
     include:
       - common
 
   - type: script
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     scripts:
       - signkernel.sh
     secrets:

--- a/recipes/common/common-packages.yml
+++ b/recipes/common/common-packages.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 type: dnf
-source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
 install:
   install-weak-deps: false
   packages:

--- a/recipes/common/common-scripts.yml
+++ b/recipes/common/common-scripts.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 type: script
-source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
 scripts:
   - set-ld-preload.sh
   - hardenlogindefs.sh

--- a/recipes/common/cosmic-modules.yml
+++ b/recipes/common/cosmic-modules.yml
@@ -4,7 +4,7 @@
 
 modules:
   - type: dnf
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     install:
       install-weak-deps: false
       packages:
@@ -18,12 +18,12 @@ modules:
         - fedora-third-party
         - fedora-workstation-repositories
   - type: systemd
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     system:
       enabled:
         - cosmic-greeter
   - type: files
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     files:
       - source: system/cosmic
         destination: /

--- a/recipes/common/desktop-modules.yml
+++ b/recipes/common/desktop-modules.yml
@@ -4,14 +4,14 @@
 
 modules:
   - type: files
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     files:
       - source: system/desktop
         destination: /
   - from-file: common/desktop-packages.yml
   - from-file: common/desktop-scripts.yml
   - type: justfiles
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     validate: true
     include:
       - desktop

--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 type: dnf
-source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
 install:
   install-weak-deps: false
   packages:

--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -33,7 +33,7 @@ install:
     # ensure universal font coverage
     - google-noto-fonts-all
 
-    # libvirt/qemu/kvm packages
+    # Virtualization packages
     - libvirt
     - libvirt-nss
     - qemu-device-display-virtio-gpu
@@ -47,9 +47,7 @@ install:
     - virt-install
     - virt-manager
     - virt-viewer
-
-    # Needed for podman-machine
-    - gvisor-tap-vsock
+    - podman-machine
 
     # ensure MTP support parity
     - libmtp

--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -48,6 +48,9 @@ install:
     - virt-manager
     - virt-viewer
 
+    # Needed for podman-machine
+    - gvisor-tap-vsock
+
     # ensure MTP support parity
     - libmtp
     - gvfs-mtp

--- a/recipes/common/desktop-scripts.yml
+++ b/recipes/common/desktop-scripts.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 type: script
-source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
 scripts:
   - install-trivalent.sh
   - installsubresourcefilter.sh

--- a/recipes/common/final-modules.yml
+++ b/recipes/common/final-modules.yml
@@ -4,7 +4,7 @@
 
 modules:
   - type: script
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     scripts:
       - addimageinfo.sh
       - regenerateinitramfs.sh

--- a/recipes/common/final-modules.yml
+++ b/recipes/common/final-modules.yml
@@ -15,3 +15,4 @@ modules:
       - ensuresudoabsent.sh
       - check-selinux-fcontext.sh
       - libdnf5-clear-history.sh
+      - backupetc.sh

--- a/recipes/common/kinoite-modules.yml
+++ b/recipes/common/kinoite-modules.yml
@@ -4,7 +4,7 @@
 
 modules:
   - type: dnf
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     remove:
       packages:
         - kde-connect
@@ -23,23 +23,23 @@ modules:
         - fedora-workstation-repositories
         - fedora-third-party
   - type: dnf
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     install:
       install-weak-deps: false
       packages:
         - krunner-bazaar
   - type: files
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     files:
       - source: system/kinoite
         destination: /
   - type: justfiles
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     validate: true
     include:
       - kinoite.just
   - type: script
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     scripts:
       - setdefaultkdewallpapers.sh
       - systemsettings-standard-malloc.sh

--- a/recipes/common/nvidia-install.yml
+++ b/recipes/common/nvidia-install.yml
@@ -4,19 +4,19 @@
 
 modules:
   - type: files
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     files:
       - source: system/nvidia
         destination: /
 
   - type: justfiles
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     validate: true
     include:
       - nvidia
 
   - type: script
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     scripts:
       - installnvidiakmod.sh
     secrets:
@@ -27,7 +27,7 @@ modules:
           destination: /tmp/certs/private_key.priv
 
   - type: script
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     scripts:
       - installnvidiapackages.sh
       - remove-nvidia-repos.sh

--- a/recipes/common/proprietary-modules.yml
+++ b/recipes/common/proprietary-modules.yml
@@ -4,7 +4,7 @@
 
 modules:
   - type: dnf
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     install:
       install-weak-deps: false
       packages:
@@ -12,7 +12,7 @@ modules:
         - pipewire-libs-extra
 
   - type: dnf
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     replace:
       - from-repo: fedora-multimedia
         skip-unavailable: true
@@ -28,7 +28,7 @@ modules:
           - mesa-vulkan-drivers
 
   - type: dnf
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     replace:
       - from-repo: fedora-multimedia
         skip-unavailable: true

--- a/recipes/common/selinux-modules.yml
+++ b/recipes/common/selinux-modules.yml
@@ -4,7 +4,7 @@
 
 modules:
   - type: script
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     scripts:
       - installselinuxpolicies.sh
       - set-selinux-booleans.sh

--- a/recipes/common/sericea-modules.yml
+++ b/recipes/common/sericea-modules.yml
@@ -4,16 +4,16 @@
 
 modules:
   - type: files
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     files:
       - source: system/sericea
         destination: /
   - type: script
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     scripts:
       - disablewlrportals.sh
   - type: dnf
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     install:
       packages:
         - adw-gtk3-theme

--- a/recipes/common/server-modules.yml
+++ b/recipes/common/server-modules.yml
@@ -4,7 +4,7 @@
 
 modules:
   - type: dnf
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     install:
       install-weak-deps: false
       packages:
@@ -14,13 +14,13 @@ modules:
         - policycoreutils-python-utils
 
   - type: files
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     files:
       - source: system/server
         destination: /
 
   - type: script
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     scripts:
       - excludepcsc.sh
       - setserverdefaultzone.sh

--- a/recipes/common/silverblue-modules.yml
+++ b/recipes/common/silverblue-modules.yml
@@ -4,7 +4,7 @@
 
 modules:
   - type: dnf
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     install:
       install-weak-deps: false
       packages:
@@ -32,20 +32,20 @@ modules:
         - fedora-third-party
         - fedora-workstation-repositories
   - type: gschema-overrides
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     include:
       - zz1-secureblue.gschema.override
   - type: script
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     scripts:
       - removedkmshelper.sh
   - type: files
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     files:
       - source: system/silverblue
         destination: /
   - type: justfiles
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     validate: true
     include:
       - silverblue.just

--- a/recipes/common/zfs-modules.yml
+++ b/recipes/common/zfs-modules.yml
@@ -4,7 +4,7 @@
 
 modules:
   - type: script
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     scripts:
       - installzfskmod.sh
     secrets:
@@ -14,7 +14,7 @@ modules:
           type: file
           destination: /tmp/certs/private_key.priv
   - type: files
-    source: ghcr.io/blue-build/modules@sha256:0b74310a559451a6faf9b33f583855dfe5b2cdbe5d90603f2869dd4867c9b485
+    source: ghcr.io/blue-build/modules@sha256:a21771c64475511f5d7f8ab98bfb74217658c9958c2b1cb956d9c0bcbbdeed29
     files:
       - source: system/zfs
         destination: /

--- a/uki/Containerfile.addons
+++ b/uki/Containerfile.addons
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+ARG RELEASE=overridden
+
+# Capture scripts from the git repo
+FROM scratch as scripts
+COPY uki/scripts /
+
+FROM quay.io/fedora/fedora-minimal:${RELEASE} as builder
+
+RUN --mount=type=tmpfs,target=/run \
+    --mount=type=tmpfs,target=/tmp \
+    --mount=type=tmpfs,target=/var \
+    dnf install -y systemd-ukify sbsigntools
+
+RUN --mount=type=tmpfs,target=/run \
+    --mount=type=bind,from=scripts,src=/,target=/run/scripts \
+    --mount=type=secret,id=secureboot_key \
+    --mount=type=secret,id=secureboot_crt \
+    /run/scripts/sign-uki-addons.sh
+
+FROM scratch
+COPY --from=builder /addons/ /

--- a/uki/Containerfile.base
+++ b/uki/Containerfile.base
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+# SPDX-FileCopyrightText: Timothée Ravier <tim@siosm.fr>
+#
+# SPDX-License-Identifier: Apache-2.0 AND CC0-1.0
+
+ARG BASE=overridden
+ARG SYSTEMDBOOT=overridden
+ARG UKIADDONS=overridden
+
+# Capture scripts from the git repo
+FROM scratch as scripts
+COPY uki/scripts /
+
+FROM $SYSTEMDBOOT as systemd-boot
+
+FROM $UKIADDONS as uki-addons
+
+FROM $BASE as rootfs-base
+
+# General changes done to the base image
+RUN --mount=type=tmpfs,target=/run \
+    --mount=type=tmpfs,target=/tmp \
+    --mount=type=tmpfs,target=/var \
+    --mount=type=bind,from=scripts,src=/,target=/run/scripts \
+    /run/scripts/prepare-rootfs.sh
+
+# Replace Fedora's systemd-boot with our signed one
+COPY --from=systemd-boot /systemd-bootx64.efi /usr/lib/systemd/boot/efi/systemd-bootx64.efi
+
+# Copy UKI addons into the filesystem so they can be added as needed at runtime.
+COPY --from=uki-addons / /usr/share/secureblue/uki/addons/
+COPY uki/keys/*/*.auth /usr/share/secureblue/uki/keys/
+COPY uki/keys/*/*.der /usr/share/secureblue/uki/keys/
+
+# Make sure we pass the lints
+FROM rootfs-base as lint
+RUN --mount=type=bind,from=scripts,src=/,target=/run/scripts \
+    bootc container lint --fatal-warnings --no-truncate --skip nonempty-run-tmp
+
+# Remove the kernel and initrd from the base image
+FROM rootfs-base as rootfs
+RUN --mount=type=bind,from=scripts,src=/,target=/run/scripts \
+    /run/scripts/remove-kernel-initrd.sh
+
+# Rechunk container image to ensure that we compute the correct composefs hash
+# - Use more layers (128)
+# - Ignore legacy ostree folders
+FROM quay.io/coreos/chunkah AS chunkah
+RUN --mount=from=rootfs,src=/,target=/chunkah,ro \
+    --mount=type=bind,target=/run/src,rw \
+        chunkah build \
+            --max-layers 256 \
+            --prune /ostree \
+            --prune /sysroot/ostree \
+            --output oci:/run/src/out
+
+# Create the final base image from the rechunked oci output
+FROM oci:out as rootfs-chunked
+LABEL containers.bootc 1
+ENV container=oci
+STOPSIGNAL SIGRTMIN+3
+CMD ["/sbin/init"]

--- a/uki/Containerfile.kernel
+++ b/uki/Containerfile.kernel
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Timothée Ravier <tim@siosm.fr>
+# SPDX-License-Identifier: CC0-1.0
+
+ARG BASE=overridden
+FROM $BASE as rootfs
+
+RUN <<EORUN
+set -euxo pipefail
+kver=$(cd "/usr/lib/modules" && echo *) && \
+mv "/usr/lib/modules/$kver/vmlinuz" "/vmlinuz"
+EORUN
+
+FROM scratch
+COPY --from=rootfs /vmlinuz /vmlinuz

--- a/uki/Containerfile.systemd-boot
+++ b/uki/Containerfile.systemd-boot
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+# SPDX-FileCopyrightText: Timothée Ravier <tim@siosm.fr>
+#
+# SPDX-License-Identifier: Apache-2.0 AND CC0-1.0
+
+ARG RELEASE=overridden
+FROM quay.io/fedora/fedora-minimal:${RELEASE} as builder
+
+RUN <<EORUN
+set -euxo pipefail
+dnf install -y systemd-boot-unsigned sbsigntools
+EORUN
+
+RUN --mount=type=tmpfs,target=/run \
+    --mount=type=secret,id=secureboot_key \
+    --mount=type=secret,id=secureboot_crt \
+    <<EORUN
+set -euxo pipefail
+sbsign \
+    --key /run/secrets/secureboot_key \
+    --cert /run/secrets/secureboot_crt \
+    --output /systemd-bootx64.efi \
+    /usr/lib/systemd/boot/efi/systemd-bootx64.efi
+EORUN
+
+FROM scratch
+COPY --from=builder /systemd-bootx64.efi /systemd-bootx64.efi

--- a/uki/Containerfile.uki
+++ b/uki/Containerfile.uki
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+# SPDX-FileCopyrightText: Timothée Ravier <tim@siosm.fr>
+#
+# SPDX-License-Identifier: Apache-2.0 AND CC0-1.0
+
+ARG BASE=overridden
+ARG KERNEL=overriden
+ARG RELEASE=overridden
+
+# Capture scripts from the git repo
+FROM scratch as scripts
+COPY uki/scripts /
+
+FROM $KERNEL as kernel
+
+FROM $BASE as rootfs
+
+# Rebuild the initramfs now that dracut's configuration is complete.
+FROM rootfs as initramfs
+RUN --mount=type=tmpfs,target=/run \
+    --mount=type=tmpfs,target=/tmp \
+    --mount=type=tmpfs,target=/var/tmp \
+    --mount=type=bind,from=scripts,src=/,target=/run/scripts \
+    /run/scripts/rebuild-initrd.sh
+
+FROM quay.io/fedora/fedora-minimal:${RELEASE} as sealed-uki
+# Install prerequisites.
+RUN --mount=type=tmpfs,target=/run \
+    --mount=type=tmpfs,target=/tmp \
+    --mount=type=tmpfs,target=/var \
+    <<EORUN
+set -euxo pipefail
+dnf install -y systemd-ukify sbsigntools jq
+dnf install -y --enablerepo=updates-testing --refresh bootc
+EORUN
+
+# Copy the kernel and the initramfs into the image to build the UKI.
+COPY --from=kernel /vmlinuz /vmlinuz
+COPY --from=initramfs /initramfs /initramfs
+RUN --mount=type=tmpfs,target=/run \
+    --mount=type=tmpfs,target=/tmp \
+    --mount=type=tmpfs,target=/var/tmp \
+    --mount=type=secret,id=secureboot_key \
+    --mount=type=secret,id=secureboot_crt \
+    --mount=type=bind,from=rootfs,src=/,target=/run/target,ro \
+    --mount=type=bind,target=/run/src,ro \
+    --mount=type=bind,from=scripts,src=/,target=/run/scripts \
+    /run/scripts/uki.sh
+
+# Copy UKI to the final image.
+FROM rootfs as final
+COPY --from=sealed-uki /boot/EFI/Linux /boot/EFI/Linux

--- a/uki/README.md
+++ b/uki/README.md
@@ -1,0 +1,43 @@
+## Build instructions
+
+1. In the repository root, run `uki/create-uki-keys.sh`. Back up the `uki/keys/` that were generated, and upload the contents of `uki/keys/db/db.key` as the `UKI_DB_KEY` secret to GitHub.
+2. Manually trigger the `Sign UKI addons` and `Sign systemd-boot` workflows on GitHub.
+3. Trigger a secureblue build as usual. The UKI will be built after the normal `silverblue-main-hardened` image is done.
+
+## Test instructions
+
+### Preparing the VM
+
+1. Create a VM in virt-manager with:
+    - A 32+ GiB VirtIO disk
+    - 16 GiB memory (this is to act as a tmpfs while pulling the container).
+    - Use UEFI-based firmware with Secure Boot enabled (`OVMF_CODE_4M.secboot.qcow2`).
+    - An emulated TPM (CRB).
+2. Download the [CoreOS ISO](https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-live-iso.x86_64.iso) and attach to the VM.
+3. If you want to use Platform Key-based secure boot, enter Setup Mode by removing the Platform Key:
+    - In virt-manager: Boot Options > Enable boot menu
+    - Start the VM, press Esc during boot menu
+    - Go to EFI Firmware Setup
+    - Go to Device Manager > Secure Boot Configuration
+    - Set Secure Boot Mode to Custom Mode
+    - Custom Secure Boot Options > PK Options > Delete PK
+    - Exit setup and reboot into CoreOS
+
+Installation also works on bare metal.
+
+### Installing secureblue UKI (testing)
+
+Once CoreOS has booted:
+
+- Set your keyboard layout (e.g. `sudo loadkeys uk`)
+- If you're installing on bare metal with WiFi, connect to the Internet.
+- Now download, verify and run the installer:
+
+```
+$ git clone https://github.com/secureblue/secureblue.git
+$ sha256sum secureblue/uki/install.sh
+974d39f8147567b51638c46641da243efc3b61a5a1a90e84e23efe432e17e6ff  secureblue/uki/install.sh
+$ sha256sum secureblue/cosign.pub
+9cbd48de48d467f86e0f31f9454c6e0bb663f3d033ecd92143f62577eb1cb5eb  secureblue/cosign.pub
+$ sudo secureblue/uki/install.sh
+```

--- a/uki/create-uki-keys.sh
+++ b/uki/create-uki-keys.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# This script creates secure boot keys (a platform key, a key exchange key and
+# database key). These, alongside Microsoft's certificates, are converted to EFI
+# signature lists, and (self-)signed to produce authenticated variables that can
+# be enrolled in the firmware.
+
+cd "$(dirname "$0")"
+
+mkdir keys/
+uuid=$(systemd-id128 new --uuid)
+echo "${uuid}" > keys/GUID
+
+for key in PK KEK db; do
+  mkdir "keys/${key}"
+
+  # Make new secure boot keys (PK, KEK, db).
+  openssl req -new -x509 -nodes -subj "/CN=secureblue ${key} CA $(date +%Y)/" \
+    -keyout "keys/${key}/${key}.key" -out "keys/${key}/${key}.pem" &> /dev/null
+  openssl x509 -outform DER -in "keys/${key}/${key}.pem" -out "keys/${key}/${key}.der"
+
+  # Convert to an EFI signature list.
+  sbsiglist --owner "${uuid}" --type x509 \
+    --output "keys/${key}/${key}.esl" "keys/${key}/${key}.der"
+done
+
+# Now sign the EFI signature lists. The PK is a self-signed payload, and it
+# signs the KEK, which signs the db. This attribute is standard.
+attr=NON_VOLATILE,RUNTIME_ACCESS,BOOTSERVICE_ACCESS,TIME_BASED_AUTHENTICATED_WRITE_ACCESS
+sbvarsign --attr "${attr}" --key keys/PK/PK.key --cert keys/PK/PK.pem \
+  --output "keys/PK/PK.auth" PK keys/PK/PK.esl
+sbvarsign --attr "${attr}" --key keys/PK/PK.key --cert keys/PK/PK.pem \
+  --output "keys/KEK/KEK.auth" KEK keys/KEK/KEK.esl
+sbvarsign --attr "${attr}" --key keys/KEK/KEK.key --cert keys/KEK/KEK.pem \
+  --output "keys/db/db.auth" db keys/db/db.esl
+
+echo "Please back up your keys:"
+echo " - \"$(pwd)/keys/PK/PK.key\","
+echo " - \"$(pwd)/keys/KEK/KEK.key\","
+echo " - \"$(pwd)/keys/db/db.key\" (upload to GitHub as the UKI_DB_KEY secret),"
+echo "and commit the generated .auth, .der and .pem files to the repository."

--- a/uki/install.sh
+++ b/uki/install.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+shopt -s nullglob
+cd "$(dirname "$0")"
+
+github_repo_owner="secureblue"
+github_repo_name="secureblue"
+image_ref="ghcr.io/${github_repo_owner}/silverblue-main-hardened:uki"
+
+if [[ $(/usr/bin/id -u) -ne 0 ]]; then
+    echo "This script must be run as root."
+    exit 1
+fi
+
+# The CoreOS installer has a permissive container policy by default.
+mkdir -p /etc/pki/containers
+cp ../cosign.pub "/etc/pki/containers/${github_repo_owner}.pub"
+cat > /etc/containers/policy.json << EOF
+{
+    "default": [{"type": "reject"}],
+    "transports": {
+        "docker": {
+            "ghcr.io/${github_repo_owner}": [
+                {
+                    "type": "sigstoreSigned",
+                    "keyPath": "/etc/pki/containers/${github_repo_owner}.pub",
+                    "signedIdentity": {"type": "matchRepository"}
+                }
+            ]
+        }
+    }
+}
+EOF
+cat > /etc/containers/registries.d/secureblue.yaml << EOF
+docker:
+  ghcr.io/${github_repo_owner}:
+    use-sigstore-attachments: true
+EOF
+
+# Get slsa-verifier.
+slsa_verifier_version="2.7.1"
+slsa_verifier_sha256="946dbec729094195e88ef78e1734324a27869f03e2c6bd2f61cbc06bd5350339"
+crane_version="0.21.7"
+crane_sha256="1a57bc98207fa1c0d04bf760699099e26f8383499bfd55b99c1b919a928a7230"
+curl -fLsS -o /usr/local/bin/slsa-verifier \
+    "https://github.com/slsa-framework/slsa-verifier/releases/download/v${slsa_verifier_version}/slsa-verifier-linux-amd64"
+echo "${slsa_verifier_sha256}  /usr/local/bin/slsa-verifier" | sha256sum -c -
+chmod +x /usr/local/bin/slsa-verifier
+
+# Get crane.
+crane_tarball=$(mktemp)
+curl -fLsS -o "${crane_tarball}" \
+    "https://github.com/google/go-containerregistry/releases/download/v${crane_version}/go-containerregistry_Linux_x86_64.tar.gz"
+echo "${crane_sha256}  ${crane_tarball}" | sha256sum -c -
+tar -xzf "${crane_tarball}" -C /usr/local/bin crane
+rm -f "${crane_tarball}"
+
+# Get digest and verify provenance.
+full_ref=$(crane digest --full-ref "${image_ref}")
+slsa-verifier verify-image --source-uri "github.com/${github_repo_owner}/${github_repo_name}" "${full_ref}"
+
+# Partition the disk.
+esp_uuid=$(uuidgen)
+root_uuid=$(uuidgen)
+mkdir -p /run/repart.d
+cat > /run/repart.d/01-esp.conf << EOF
+[Partition]
+Type=esp
+Format=vfat
+UUID=${esp_uuid}
+SizeMinBytes=2G
+SizeMaxBytes=2G
+EOF
+cat > /run/repart.d/02-sysroot.conf << EOF
+[Partition]
+Type=root
+Format=btrfs
+UUID=${root_uuid}
+SizeMinBytes=20G
+Encrypt=key-file
+EOF
+
+lsblk
+echo "Choose a disk to install to, e.g. /dev/vda, /dev/sda or /dev/nvme0n1."
+echo "This will erase the disk."
+read -r -p "Enter disk: " disk
+if [[ ! -b "${disk}" ]] || [[ $(lsblk -ndo TYPE "${disk}") != "disk" ]]; then
+    echo "Invalid disk."
+    exit 1
+fi
+
+echo "Choose a LUKS encryption password."
+read -r -s -p "Password: " password && echo
+read -r -s -p "Confirm: " password2 && echo
+if [[ "${password}" == "${password2}" ]]; then
+    keyfile=$(mktemp)
+    printf "%s" "${password}" > "${keyfile}"
+else
+    echo "Passwords do not match."
+    exit 1
+fi
+unset password password2
+
+cleanup() {
+    rm -f "${keyfile}"
+    umount /var/lib/containers/storage/ || true
+    umount /mnt/boot/ || true
+    umount /mnt/ || true
+    cryptsetup close root || true
+}
+trap cleanup EXIT
+systemd-repart --dry-run=no --empty=force "--key-file=${keyfile}" "${disk}"
+udevadm settle
+sleep 1
+
+# Mount the partitions.
+cryptsetup open "--key-file=${keyfile}" "/dev/disk/by-partuuid/${root_uuid}" root
+mount /dev/mapper/root /mnt/
+mkdir /mnt/boot/
+mount "/dev/disk/by-partuuid/${esp_uuid}" /mnt/boot/
+
+# Pull the image.
+mount -t tmpfs -o size=10240M containers /var/lib/containers/storage/
+chcon "system_u:object_r:container_var_lib_t:s0" /var/lib/containers/storage
+podman pull "${full_ref}"
+
+# Perform the installation.
+podman run --rm --privileged --pid=host --ipc=host \
+    --security-opt label=type:unconfined_t \
+    -v /var/lib/containers:/var/lib/containers -v /dev:/dev \
+    -v /:/run/host \
+    -v "/etc/pki/containers/${github_repo_owner}.pub:/etc/pki/containers/${github_repo_owner}.pub:ro" \
+    -v /etc/containers/policy.json:/etc/containers/policy.json:ro \
+    "${full_ref}" \
+    bootc install to-filesystem \
+        "--source-imgref=registry:${full_ref}" \
+        "--target-imgref=${image_ref}" \
+        --bootloader=systemd --composefs-backend --skip-finalize \
+        /run/host/mnt/
+
+# Configure systemd-boot timeout.
+sed -i 's/#timeout 3/timeout 3/' /mnt/boot/loader/loader.conf
+
+# Add boot.mount (systemd-gpt-auto-generator doesn't work with composefs+LUKS).
+# In future, something like Anaconda will do all of this.
+etc_dirs=(/mnt/state/deploy/*/etc)
+if [[ ${#etc_dirs[@]} -ne 1 ]]; then
+    echo "Expected only one deployment, found ${#etc_dirs[@]}."
+    exit 1
+fi
+etc_dir=${etc_dirs[0]}
+escaped_esp="$(systemd-escape -p "/dev/disk/by-partuuid/${esp_uuid}")"
+cat > "${etc_dir}/systemd/system/boot.mount" << EOF
+[Unit]
+Description=EFI System Partition
+Requires=systemd-fsck@${escaped_esp}.service
+After=systemd-fsck@${escaped_esp}.service
+After=blockdev@${escaped_esp}.target
+
+[Mount]
+What=/dev/disk/by-partuuid/${esp_uuid}
+Where=/boot
+Type=vfat
+Options=fmask=0177,dmask=0077,rw,nodev,nosuid,noexec
+
+[Install]
+WantedBy=local-fs.target
+EOF
+mkdir -p "${etc_dir}/systemd/system/local-fs.target.wants"
+ln -s /etc/systemd/system/boot.mount "${etc_dir}/systemd/system/local-fs.target.wants/boot.mount"
+
+# Optionally install shim.
+cat << EOF
+Choose a secure boot option:
+1. shim - Safe for all devices.
+   Your firmware must trust the Microsoft Third Party CA, which signs many
+   bootloaders and ROMs. This greatly increases attack surface but is compatible
+   with all hardware.
+2. secureblue Platform Key - Suitable for some devices.
+   Your firmware will only trust secureblue. This offers improved security, but
+   this can BRICK YOUR DEVICE by breaking the display if your external GPU
+   requires an option ROM to work.
+EOF
+read -r -p "Choose an option (1 or 2): " secure_boot
+if [[ "${secure_boot}" != "2" ]]; then
+    if [[ "${secure_boot}" != "1" ]]; then
+        echo "Invalid selection; defaulting to shim."
+    fi
+    shim_dirs=(/usr/lib/efi/shim/*/EFI)
+    if [[ ${#shim_dirs[@]} -ne 1 ]]; then
+        echo "Expected only one shim installation, found ${#shim_dirs[@]}."
+        exit 1
+    fi
+    shim_dir=${shim_dirs[0]}
+    # BOOT/{BOOTX64.EFI, fbx64.efi, etc.}
+    cp "${shim_dir}"/BOOT/* /mnt/boot/EFI/BOOT/
+    # fedora/{shim.efi, shimx64.efi, BOOTX64.CSV, mmx64.efi, etc.}
+    cp -r "${shim_dir}"/fedora /mnt/boot/EFI/
+    # Put MokManager in BOOT/.
+    cp "${shim_dir}"/fedora/mmx64.efi /mnt/boot/EFI/BOOT/
+    # Rename systemd-boot to grubx64.efi as this is hardcoded into shim.
+    mv /mnt/boot/EFI/systemd/systemd-bootx64.efi /mnt/boot/EFI/fedora/grubx64.efi
+    rmdir /mnt/boot/EFI/systemd
+    # We need to import the key that signed systemd-boot.
+    printf "secureblue\nsecureblue\n" | mokutil --import keys/db/db.der
+fi
+
+sync
+
+# Reboot the system.
+if [[ "${secure_boot}" == "1" ]]; then
+    echo "Installation is finished. When the system reboots, you need to choose"
+    echo "\"Enroll MOK\" and enter \"secureblue\" as the password."
+else
+    echo "Installation is finished. Make sure your device is in Setup Mode by deleting"
+    echo "the Secure Boot Platform Key in your UEFI settings."
+fi
+read -r -p "Press enter to reboot."
+systemctl reboot

--- a/uki/scripts/prepare-rootfs.sh
+++ b/uki/scripts/prepare-rootfs.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+# SPDX-FileCopyrightText: Timothée Ravier <tim@siosm.fr>
+#
+# SPDX-License-Identifier: Apache-2.0 AND CC0-1.0
+
+set -euxo pipefail
+
+# Install composefs/UKI-specific packages.
+# We replace systemd-boot with a signed version at a later stage.
+dnf install -y fsverity-utils systemd-boot-unsigned efitools
+# bootc >1.16.0 needed.
+dnf upgrade -y --enablerepo=updates-testing --refresh bootc
+# TODO: Install sbctl from our own copr for use by advanced users, see
+# <https://github.com/secureblue/secureblue/issues/1917>.
+
+# Remove rpm-ostree legacy files.
+dnf remove -y \
+    rpm-ostree \
+    rpm-ostree-libs \
+    gnome-software-rpm-ostree \
+    plasma-discover-rpm-ostree
+rpm -e bootupd
+rm -vrf "/usr/lib/bootupd"
+rm -vrf "/usr/lib/ostree-boot"
+rm -vrf "/usr/etc"
+
+# Remove GRUB packages.
+grub_packages=(
+    "grub2-common"
+    "grub2-efi-x64"
+    "grub2-pc"
+    "grub2-pc-modules"
+    "grub2-tools"
+    "grub2-tools-minimal"
+)
+if [[ "$(rpm -qa | grep -c grub2-efi-ia32)" -ne 0 ]]; then
+    grub_packages+=("grub2-efi-ia32")
+fi
+rpm -e --nodeps "${grub_packages[@]}"
+
+# Add kargs to bootc kargs.d; see uki.sh where we parse these for the UKI.
+cat > "/usr/lib/bootc/kargs.d/10-rootfs.toml" << 'EOF'
+kargs = [
+  "rw",
+  "rootflags=compress=zstd:1",
+]
+EOF
+cat > "/usr/lib/bootc/kargs.d/10-plymouth.toml" << 'EOF'
+kargs = [
+  "quiet",
+  "rhgb",
+]
+EOF
+# Temporary. See: https://github.com/systemd/systemd/issues/40159 and
+# https://github.com/systemd/systemd/issues/40485.
+cat > "/usr/lib/bootc/kargs.d/20-tpm2-workaround.toml" << 'EOF'
+kargs = [
+  "rd.systemd.mask=systemd-tpm2-setup-early.service",
+  "systemd.mask=systemd-tpm2-setup-early.service",
+  "systemd.mask=systemd-tpm2-setup.service",
+  "systemd.mask=systemd-pcrphase.service",
+  "systemd.mask=systemd-pcrproduct.service",
+]
+EOF
+
+# bootc installation configuration.
+cat > "/usr/lib/bootc/install/80-rootfs.toml" << 'EOF'
+# Default to btrfs
+[install.filesystem.root]
+type = "btrfs"
+EOF
+cat > "/usr/lib/bootc/install/90-install.toml" << 'EOF'
+# Need systemd as the bootloader
+[install]
+bootloader = "systemd"
+EOF
+
+# bootc-specific dracut configuration.
+cat > "/usr/lib/dracut/dracut.conf.d/20-secureblue.conf" << 'EOF'
+install_items+=" /usr/lib64/libhardened_malloc.so /usr/lib64/libno_rlimit_as.so "
+EOF
+cat > "/usr/lib/dracut/dracut.conf.d/20-bootc-composefs.conf" << 'EOF'
+# Dracut will always fail to set security.selinux xattrs at build time
+# https://github.com/dracut-ng/dracut-ng/issues/1561
+export DRACUT_NO_XATTR=1
+
+# Enable composefs backend in dracut
+add_dracutmodules+=" bootc "
+
+# Include systemd's hwdb
+# See: https://github.com/systemd/systemd/issues/40159
+# See: https://github.com/systemd/systemd/issues/40485
+install_items+=" /etc/udev/hwdb.bin "
+EOF
+cat > "/usr/lib/dracut/dracut.conf.d/20-omit-modules.conf" << 'EOF'
+# Remove more dracut modules to reduce the size of the initramfs.
+omit_dracutmodules+=" fips fips-crypto-policies lunmask lvm memstrack modsign nss-softokn "
+EOF
+cat > "/usr/lib/dracut/dracut.conf.d/59-altfiles.conf" << 'EOF'
+# https://issues.redhat.com/browse/RHEL-49590
+# On image mode systems we use nss-altfiles for passwd and group,
+# this makes sure dracut uses them which also fixes kdump writing to NFS.
+install_items+=" /usr/lib/passwd /usr/lib/group "
+EOF
+
+# Set systemd presets.
+cat > "/usr/lib/systemd/system-preset/30-secureblue-uki.preset" << 'EOF'
+enable bootc-status.service
+enable bootc-upgrade.timer
+EOF
+systemctl preset-all --preset-mode=enable-only
+
+# Prepare folders in /boot
+mkdir -p /boot/EFI/Linux

--- a/uki/scripts/rebuild-initrd.sh
+++ b/uki/scripts/rebuild-initrd.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euxo pipefail
+
+kver=$(cd "/usr/lib/modules" && echo *)
+
+dracut \
+    --verbose \
+    --kver "${kver}" \
+    --force \
+    --install "/etc/passwd /etc/group" \
+    --no-hostonly \
+    --reproducible \
+    "/initramfs"

--- a/uki/scripts/remove-kernel-initrd.sh
+++ b/uki/scripts/remove-kernel-initrd.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+# SPDX-FileCopyrightText: Timothée Ravier <tim@siosm.fr>
+#
+# SPDX-License-Identifier: Apache-2.0 AND CC0-1.0
+
+set -euxo pipefail
+
+kver=$(cd "/usr/lib/modules" && echo *)
+
+# Remove the initramfs from the base image. We'll rebuilt it in a later stage
+# for each GPU vendor target and include it in the UKI.
+rm "/usr/lib/modules/${kver}/initramfs.img"
+
+# Remove the kernel from the base image as we made a copy in another stage. It
+# will be included in the UKI in a later stage.
+rm "/usr/lib/modules/${kver}/vmlinuz"

--- a/uki/scripts/sign-uki-addons.sh
+++ b/uki/scripts/sign-uki-addons.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euxo pipefail
+
+# Optional secureblue kernel arguments. Each one will be signed to make an
+# individual UKI addon. Be careful with these! If they can make the system less
+# secure when combined in a non-obvious way, we cannot revoke our signature.
+addons=(
+    "lockdown=confidentiality"
+    "ia32_emulation=0"
+    "nosmt=force"
+    "amd_iommu=force_isolation"
+    "bdev_allow_write_mounted=0"
+    "debugfs=off"
+    "efi=disable_early_pci_dma"
+    "gather_data_sampling=force"
+    "mem_encrypt=on"
+    "oops=panic"
+    "amdgpu.dcdebugmask=0x10" # https://invent.kde.org/kde-linux/kde-linux/-/merge_requests/431
+)
+# We need a UKI addon (karg or initrd) to get the right keyboard layout at the
+# LUKS screen. Taken from `localectl list-keymaps`, deduplicated with niche ones
+# removed.
+keymaps=(
+    ara be bg_bds-utf8 br-abnt2 ch ch-fr cz de dk ee es fa "fi" fr gb gr hr hu
+    il it jp106 kr lt lv nl no pl pt ro rs-latin ru se si sk tr ua-utf us
+)
+addons+=("${keymaps[@]/#/vconsole.keymap=}")
+
+mkdir /addons
+for addon in "${addons[@]}"; do
+    # The equals symbol is not allowed in FAT32 filenames, so replace it with __.
+    filename="${addon//=/__}"
+    ukify build \
+        --cmdline "${addon}" \
+        --signtool sbsign \
+        --secureboot-private-key /run/secrets/secureboot_key \
+        --secureboot-certificate /run/secrets/secureboot_crt \
+        --output "/addons/${filename}.addon.efi"
+done

--- a/uki/scripts/uki.sh
+++ b/uki/scripts/uki.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+# SPDX-FileCopyrightText: Timothée Ravier <tim@siosm.fr>
+#
+# SPDX-License-Identifier: Apache-2.0 AND CC0-1.0
+
+set -euxo pipefail
+
+target="/run/target"
+output="/boot/EFI/Linux"
+secrets="/run/secrets"
+
+# Find the kernel version (needed for output filename)
+kver=$(cd "${target}/usr/lib/modules" && echo *)
+
+# Baseline ukify options
+mkdir -p "${output}"
+ukifyargs=(
+    --measure
+    --json pretty
+    --output "${output}/${kver}.efi"
+    --signtool sbsign
+    --secureboot-private-key "${secrets}/secureboot_key"
+    --secureboot-certificate "${secrets}/secureboot_crt"
+)
+
+# In future, `bootc container ukify` will compute the composefs digest, read
+# kargs from kargs.d, and invoke ukify in one step. But the current
+# implementation needs the kernel and initrd in the image, and we can't remove
+# them later without changing the composefs hash, so we do it manually instead.
+# See: https://github.com/bootc-dev/bootc/issues/2185.
+# bootc container ukify --rootfs ${target} -- ${ukifyargs[@]}
+
+# Compute the composefs digest from the mounted rootfs
+digest="$(bootc container compute-composefs-digest "${target}")"
+
+# For the cmdline, add the composefs digest and parse the kargs from kargs.d,
+# which includes the kargs set in prepare-rootfs.sh. This is temporary, see
+# above.
+kargs_d=$(
+    grep -rh '"' "${target}/usr/lib/bootc/kargs.d" |
+    grep -v '^#' | sed 's/,$//' | tr -d ' "' | tr '\n' ' '
+)
+printf "composefs=%s %s\n" "${digest}" "${kargs_d}" > /etc/kernel/cmdline
+
+# Generate and sign the UKI with the digest embedded
+ukify build \
+    --linux "/vmlinuz" \
+    --initrd "/initramfs" \
+    --uname="${kver}" \
+    --cmdline "@/etc/kernel/cmdline" \
+    --os-release "@${target}/usr/lib/os-release" \
+    "${ukifyargs[@]}"


### PR DESCRIPTION
# Overview

This PR introduces a downstream image `silverblue-main-hardened:uki` from `silverblue-main-hardened:latest`. Other desktops should work fine too. It also makes various changes to `ujust`s for compatibility with an rpm-ostree-less system, adds dev tooling for Secure Boot, an installer script, and a new `ujust enroll-secure-boot-keys`. This is how the build works:

<img width="586" height="579" alt="UKI build flowchart" src="https://github.com/user-attachments/assets/40a58d65-e6bf-4280-b0c7-ff510bcea108" />

# Build instructions

1. In the repository root, run `uki/create-uki-keys.sh`. Back up the `uki/keys/` that were generated, and upload the contents of `uki/keys/db/db.key` as the `UKI_DB_KEY` secret to GitHub.
2. Manually trigger the `Sign UKI addons` and `Sign systemd-boot` workflows on GitHub.
3. Trigger a secureblue build as usual. The UKI will be built after the normal `silverblue-main-hardened` image is done.

# Test instructions

## Preparing the VM

1. Create a VM in virt-manager with:
    - A 32+ GiB VirtIO disk
    - 16 GiB memory (this is to act as a tmpfs while pulling the container).
    - Use UEFI-based firmware with Secure Boot enabled (`OVMF_CODE_4M.secboot.qcow2`).
    - An emulated TPM (CRB).
2. Download the [CoreOS ISO](https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-live-iso.x86_64.iso) and attach to the VM.
3. If you want to use Platform Key-based secure boot, enter Setup Mode by removing the Platform Key:
  a. In virt-manager: Boot Options > Enable boot menu
  b. Start the VM, press Esc during boot menu
  c. Go to EFI Firmware Setup
  d. Go to Device Manager > Secure Boot Configuration
  e. Set Secure Boot Mode to Custom Mode
  f. Custom Secure Boot Options > PK Options > Delete PK
  g. Exit setup and reboot into CoreOS

Installation also works on bare metal.

## Installing secureblue UKI (testing)
Once CoreOS has booted:
- Set your keyboard layout (e.g. `sudo loadkeys uk`)
- If you're installing on bare metal with WiFi, connect to the Internet.
- Now download, verify and run the installer from my test branch:
```
$ git clone https://github.com/alexvojproc/secureblue.git
$ sha256sum secureblue/uki/install.sh 
4709bf898f5e2356606d52f11045c9c61d5fcb8431445219011f1dce5791e573  secureblue/uki/install.sh
$ sha256sum secureblue/uki/keys/db/db.der 
40104d66a9c5c97d58bc87e29fd666c5722da706ca7f825620bb1de35070784c  secureblue/uki/keys/db/db.der
$ sha256sum secureblue/cosign.pub 
5991b67d50c4a72c71735604acd31489852af7de75d5f8d164f3881d4ec793eb  secureblue/cosign.pub
$ sudo secureblue/uki/install.sh
```

A copy of these instructions (which will become relevant after this commit is merged) has been placed in `uki/README.md`.

# Changelog

In addition to what's mentioned above:
- Signing and provenance during UKI builds, and verification in `ujust update-system`
- Separation of concerns in `shared-runner-setup` by adding `needs_cosign`, `needs_slsa_crane` and `update_podman` inputs and moving BlueBuild-specific logic back into `build-one-recipe`
- Phase out `/usr/etc/` in favour of `/usr/share/secureblue/etc/`
- Updated `ujust`s to remove hard dependency on rpm-ostree: `update-system`, `rebase-secureblue`, `debug-info`, `clean-system`, `ujust setup-usbguard`, `ujust set-xwayland`
- Skip image signature check for bootc systems in `audit-secureblue` in favour of the container policy audit
- Updated the "out of date", security update and secure boot enrollment pop-up checks
- Updated the MOTD
- Disabled `ujust`s: `install-docker`, `uninstall-docker`, `install-vpn`, `install-steam`, `luks-disable-fido2-unlock`, `luks-disable-tpm2-autounlock`, `luks-enable-fido2-unlock`, `luks-enable-tpm2-autounlock`, `install-dangerzone`
- Added a `bootc-status.service` to work around https://github.com/bootc-dev/bootc/issues/409
- Added automatic update service `bootc-upgrade.service`/`bootc-upgrade.timer`
- Added `ujust enroll-secure-boot-keys`, which supports enrolling keys into the MOK or directly into the UEFI.
  - Uses IPC with JSON over stdin with shared data objects in `shared/secure_boot.py` to communicate with the inner SandboxedFunction. Maybe we can use this model in future, as it was less error-prone than parsing command line arguments.
    - Amended `SandboxedFunction.run()` to accept `stdin` argument.
- Added `uki/create-uki-keys.sh` to set up the Secure Boot keychain.
- Added `uki/install.sh` to install onto a VM or bare metal before we get ISOs.

# TODOs

In rough order:

1. https://github.com/secureblue/secureblue/issues/2344
2. https://github.com/secureblue/secureblue/issues/2343
4. https://github.com/secureblue/secureblue/issues/2341
5. https://github.com/secureblue/secureblue/issues/2342
6. https://github.com/secureblue/secureblue/issues/2370
7. https://github.com/secureblue/secureblue/issues/1721
8. https://github.com/secureblue/secureblue/issues/2345
    - I will update https://github.com/secureblue/secureblue/pull/1763 to support/manage UKI addons.
    - I still feel that `lockdown=confidentiality` should be an 'optional' karg in our tooling, and I have chosen to make it an addon rather than baking it into the UKI. This is because, even though 99% of users will enable it, if a karg is baked in, there is no way to remove it. Lockdown prevents modules from loading that are not signed by a key in the kernel's keychain, and until we [build our own kernel](https://github.com/secureblue/kernel/issues/5), this will be the case for devices where Secure Boot is disabled and ZFS or Nvidia are required.