### PR TITLE
fix(just): usage info for with-standard-malloc

### DIFF
--- a/files/justfiles/common/wrappers.just
+++ b/files/justfiles/common/wrappers.just
@@ -10,10 +10,19 @@ audit-secureblue *args:
 
 # Run a non-flatpak application with standard memory allocator
 [no-cd]
+[no-exit-message]
 [positional-arguments]
 with-standard-malloc *args:
     #!/bin/sh
-    LD_PRELOAD='' exec "$@"
+    if [ "$#" -eq 0 ] || [ "$1" = '--help' ]; then
+        echo 'Usage: ujust with-standard-malloc COMMAND [ARGS...]'
+        echo 'Runs COMMAND with the standard memory allocator instead of hardened_malloc.'
+        exit
+    fi
+    if [ "${1-}" = '--' ]; then
+        shift
+    fi
+    LD_PRELOAD='' exec -- "$@"
 
 # Sets bluetooth kernel modules on/off (requires reboot)
 [positional-arguments]


### PR DESCRIPTION
`ujust with-standard-malloc` should print usage info if called with no arguments or with `--help`. Previously, it would just do nothing in this case, which was confusing.

Also suppress "recipe failed" message if exit code is nonzero, pass `--` argument to `exec` to ensure arguments aren't misinterpreted as `exec` options, and strip leading `--` argument in line with standard conventions for argument handling.