### PR TITLE
feat: separate with-standard-malloc; clean up justfiles

### DIFF
--- a/.github/workflows/shell-script-lint.yml
+++ b/.github/workflows/shell-script-lint.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - 'files/system/**'
+      - 'files/justfiles/**'
       - '**.sh'
       - '.shellcheckrc'
       - '.github/workflows/shell-script-lint.yml'

--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -4,24 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-uid := `id -u`
-shell := `grep :$(id -u): /etc/passwd | cut -d: -f7`
-
-# Boot into this device's BIOS/UEFI screen.
-bios:
-    #!/usr/bin/sh
-    exec /usr/bin/python3 /usr/libexec/secureblue/bios.py
-
-# Show all messages from this boot
-logs-this-boot:
-    #! /bin/run0 /bin/bash
-    journalctl -b 0
-
-# Show all messages from last boot
-logs-last-boot:
-    #! /bin/run0 /bin/bash
-    journalctl -b -1
-
 # Enroll secureblue's signing key for secure boot - Enter password "secureblue" if prompted
 enroll-secureblue-secure-boot-key:
     #! /bin/run0 /bin/bash

--- a/files/justfiles/common/wrappers.just
+++ b/files/justfiles/common/wrappers.just
@@ -4,99 +4,88 @@
 
 # Audit secureblue
 [positional-arguments]
-audit-secureblue *args:
-    #!/bin/sh
+@audit-secureblue *args:
     exec /usr/bin/python3 /usr/libexec/secureblue/audit_secureblue.py "$@"
 
 # Run a non-flatpak application with standard memory allocator
 [no-cd]
 [no-exit-message]
 [positional-arguments]
-with-standard-malloc *args:
-    #!/bin/sh
-    if [ "$#" -eq 0 ] || [ "$1" = '--help' ]; then
-        echo 'Usage: ujust with-standard-malloc COMMAND [ARGS...]'
-        echo 'Runs COMMAND with the standard memory allocator instead of hardened_malloc.'
-        exit
-    fi
-    if [ "${1-}" = '--' ]; then
-        shift
-    fi
-    LD_PRELOAD='' exec -- "$@"
+@with-standard-malloc *args:
+    exec /usr/bin/with-standard-malloc "$@"
 
 # Sets bluetooth kernel modules on/off (requires reboot)
 [positional-arguments]
-set-bluetooth-modules *args:
-    #!/bin/sh
+@set-bluetooth-modules *args:
     exec /usr/bin/python3 /usr/libexec/secureblue/bluetooth_main.py "$@"
 
 # Sets webcam kernel modules on/off (requires reboot)
 [positional-arguments]
-set-webcam-modules *args:
-    #!/bin/sh
+@set-webcam-modules *args:
     exec /usr/bin/python3 /usr/libexec/secureblue/webcam_main.py "$@"
 
 # Interactively select secure DNS servers
 [positional-arguments]
-dns-selector *args:
-    #!/bin/sh
+@dns-selector *args:
     exec /usr/bin/python3 /usr/libexec/secureblue/dns_selector.py "$@"
 
 # Add additional boot parameters for hardening (requires reboot)
-set-kargs-hardening:
-    #!/bin/sh
+@set-kargs-hardening:
     exec /usr/bin/python3 /usr/libexec/secureblue/set_kargs_hardening.py
 
 # Remove all hardening boot parameters (requires reboot)
-remove-kargs-hardening:
-    #!/bin/sh
+@remove-kargs-hardening:
     exec /usr/bin/python3 /usr/libexec/secureblue/remove_kargs_hardening.py
 
 # Create the admin user and remove wheel from the normal user
 [positional-arguments]
-create-admin *args:
-    #!/bin/sh
+@create-admin *args:
     exec /usr/bin/python3 /usr/libexec/secureblue/create_admin.py "$@"
 
 # Enable, disable, or check status of unconfined-domain user namespace creation.
 [positional-arguments]
-set-unconfined-userns *args:
-    #!/bin/sh
+@set-unconfined-userns *args:
     exec /usr/bin/python3 /usr/libexec/secureblue/set_unconfined_userns.py "$@"
 
 # Enable, disable, or check status of container-domain user namespace creation.
 [positional-arguments]
-set-container-userns *args:
-    #!/bin/sh
+@set-container-userns *args:
     exec /usr/bin/python3 /usr/libexec/secureblue/set_container_userns.py "$@"
 
 # Install Dangerzone (sandboxed PDF sanitizer)
 [positional-arguments]
-install-dangerzone:
-    #!/bin/sh
+@install-dangerzone:
     exec /usr/bin/python3 /usr/libexec/secureblue/install_dangerzone.py "$@"
 
 # Toggle display of the user-motd in terminal
-toggle-user-motd:
-    #!/bin/sh
+@toggle-user-motd:
     exec /usr/bin/python3 /usr/libexec/secureblue/toggle_user_motd.py
 
 # Toggle DHCP hostname sending.
 [positional-arguments]
-set-dhcp-hostname-sending *args:
-    #!/bin/sh
+@set-dhcp-hostname-sending *args:
     exec /usr/bin/python3 /usr/libexec/secureblue/dhcp_hostname_sending_main.py "$@"
 
 # Enable, disable, or check status of always-upgrade-on-boot
 [positional-arguments]
-set-always-upgrade-on-boot *args:
-    #!/bin/sh
+@set-always-upgrade-on-boot *args:
     exec /usr/bin/python3 /usr/libexec/secureblue/set_always_upgrade_on_boot.py "$@"
 
 # Configure ptrace support (for anticheat, debugging tools, etc.)
 [positional-arguments]
-set-ptrace *args:
-    #!/bin/sh
+@set-ptrace *args:
     exec /usr/bin/python3 /usr/libexec/secureblue/set_ptrace.py "$@"
 
 alias set-anticheat-support := set-ptrace
+
+# Boot into this device's BIOS/UEFI screen.
+@bios:
+    exec /usr/bin/python3 /usr/libexec/secureblue/bios.py
+
+# Show all messages from this boot
+@logs-this-boot:
+    exec /usr/bin/run0 --via-shell journalctl -b 0
+
+# Show all messages from last boot
+@logs-last-boot:
+    exec /usr/bin/run0 --via-shell journalctl -b -1

--- a/files/justfiles/desktop/desktop.just
+++ b/files/justfiles/desktop/desktop.just
@@ -4,18 +4,15 @@
 
 # Enable or disable Homebrew installation
 [positional-arguments]
-set-brew *args:
-    #!/bin/sh
+@set-brew *args:
     exec /usr/bin/python3 /usr/libexec/secureblue/brew_main.py "$@"
 
 # Toggle libvirt daemons on or off
 [positional-arguments]
-set-libvirt-daemons *args:
-    #!/bin/sh
+@set-libvirt-daemons *args:
     exec /usr/bin/python3 /usr/libexec/secureblue/set_libvirt_daemons.py "$@"
 
 # Enable or disable Xwayland
 [positional-arguments]
-set-xwayland *args:
-    #!/bin/sh
+@set-xwayland *args:
     exec /usr/bin/python3 /usr/libexec/secureblue/set_xwayland.py "$@"

--- a/files/justfiles/desktop/flatpak.just
+++ b/files/justfiles/desktop/flatpak.just
@@ -3,19 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Add the unfiltered Flathub flatpak repo
-enable-flathub-unfiltered:
-    #!/usr/bin/bash
-    flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+@enable-flathub-unfiltered:
+    exec /usr/bin/flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 
 # Remove the unfiltered Flathub flatpak repo
-disable-flathub-unfiltered:
-    #!/usr/bin/bash
-    flatpak remote-delete --user flathub
+@disable-flathub-unfiltered:
+    exec /usr/bin/flatpak remote-delete --user flathub
 
 # Harden flatpaks by preloading hardened_malloc (highest supported hwcap). When called with a flatpak application ID as an argument, applies the overrides to that application instead of globally.
 [positional-arguments]
-harden-flatpak *args:
-    #!/usr/bin/sh
+@harden-flatpak *args:
     exec /usr/bin/python3 /usr/libexec/secureblue/harden_flatpak.py "$@"
 
 # Harden Flatpaks further by disabling all permissions by default and rejecting known arbitrary DBus names, applies only to the current user

--- a/files/justfiles/nvidia/kargs.just
+++ b/files/justfiles/nvidia/kargs.just
@@ -3,11 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set Nvidia kernel arguments
-set-kargs-nvidia:
-    #!/usr/bin/sh
-    /usr/bin/python3 /usr/libexec/secureblue/set_kargs_nvidia.py
+@set-kargs-nvidia:
+    exec /usr/bin/python3 /usr/libexec/secureblue/set_kargs_nvidia.py
 
 # Remove Nvidia kernel arguments
-remove-kargs-nvidia:
-    #!/usr/bin/sh
-    /usr/bin/python3 /usr/libexec/secureblue/remove_kargs_nvidia.py
+@remove-kargs-nvidia:
+    exec /usr/bin/python3 /usr/libexec/secureblue/remove_kargs_nvidia.py

--- a/files/system/usr/bin/with-standard-malloc
+++ b/files/system/usr/bin/with-standard-malloc
@@ -1,0 +1,21 @@
+#!/usr/bin/bash
+
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+    echo 'Usage: with-standard-malloc COMMAND [ARGS...]'
+    echo 'Runs COMMAND with the standard memory allocator instead of hardened_malloc.'
+    exit
+}
+
+case "${1-}" in
+    ''|--help) usage ;;
+    --) shift ;;
+    *) ;;
+esac
+
+LD_PRELOAD='' exec -- "$@"


### PR DESCRIPTION
* Separate out `with-standard-malloc` into an executable at `/usr/bin/with-standard-malloc`, so it can be invoked as simply `with-standard-malloc COMMAND [ARGS...]`. Also simplify the argument-handling logic a bit.
* Make wrapper scripts in justfiles into shell recipes rather than shebang recipes, which avoids an unnecessary intermediate step of creating a temporary file with the script contents. Use `@` sigil for these recipes so they don't echo the commands they run.
* Move `bios`, `logs-this-boot`, and `logs-last-boot` scripts to `wrappers.just`, and also convert them to one-line shell recipes.
* Remove unused justfile variables `uid` and `shell` from `utilities.just`.
* Add `files/justfiles` to list of paths that trigger shell script lint workflow.