### PR TITLE
feat: install SELinux policy for brew-proxy

### DIFF
--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -21,6 +21,7 @@ install:
     - bazaar
     - homebrew
     - brew-proxy
+    - brew-proxy-selinux
     - firewall-config
 
     # yubikey enablement


### PR DESCRIPTION
This is required for brew-proxy v0.3.0 to work properly on systems using Fedora's SELinux policy.

This PR should be merged immediately after brew-proxy v0.3.0 is built in the secureblue copr repo.

Changelog entry, for reference: https://codeberg.org/HastD/brew-proxy/src/branch/main/CHANGELOG.md#v0-3-0-2026-06-16