### PR TITLE
feat: tools for building sysext from repo's /usr directories

### DIFF
--- a/.github/workflows/shell-script-lint.yml
+++ b/.github/workflows/shell-script-lint.yml
@@ -61,11 +61,11 @@ jobs:
         id: file_list
         run: |
           tempfile="$(mktemp)"
-          # We need to examine object modes to exclude directories that are the target
-          # of a symbolic link, which get included in the output of `git ls-files` and
-          # would otherwise be passed to awk, triggering a warning.
+          # Examine object modes to exclude objects that are not regular files,
+          # which get included in the output of `git ls-files` and would
+          # otherwise be passed to awk, triggering warnings or errors.
           git ls-files -z --format='%(objectmode) %(path)' \
-            | sed -Enz -e '/^120/d' -e 's/^[0-9]+ //p' > "${tempfile}"
+            | sed -Enz -e '/^10/s/^[0-9]+ //p' > "${tempfile}"
           echo "file_list=${tempfile}" >> "${GITHUB_OUTPUT}"
 
       - name: Check shell script shebangs

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Containerfile
 __pycache__
 uv.lock
 justfile-tmp-*
+sysext-tmp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/sysextbuddy"]
+	path = tools/sysextbuddy
+	url = https://github.com/tulilirockz/sysextbuddy.git

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+@_default:
+    just --list
+
+# Compare vendered RPM repo GPG keys to remote GPG keys
+check-repo-keys:
+    exec tools/check_repo_keys.py
+
+# Run ShellCheck on shell scripts embedded in justfiles
+shellcheck-justfiles:
+    exec tools/shellcheck_justfiles.py
+
+# Build systemd sysext from this repo's version of /usr
+[group('sysext')]
+build-sysext:
+    exec tools/build-sysext.sh
+
+# Install sysext, immediately applying this repo's version of /usr to the running system
+[confirm("Caution: This applies this repo's version of /usr directly to your system.\nOnly do this on a trusted branch.\nProceed? [y/N]")]
+[group('sysext')]
+install-sysext: build-sysext
+    run0 --via-shell tools/install-sysext.sh
+
+# Remove sysext, restoring the system's /usr to its original state
+[group('sysext')]
+remove-sysext:
+    run0 --via-shell tools/remove-sysext.sh

--- a/tools/build-sysext.sh
+++ b/tools/build-sysext.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+umask 022
+cd "${0%/*}"
+cd "$(git rev-parse --show-toplevel)"
+mkdir -p sysext-tmp
+find sysext-tmp -mindepth 1 -delete
+
+if [[ "$(awk -F= '$1 == "ID" { print $2; exit }' /usr/lib/os-release)" != 'secureblue' ]]; then
+    echo 'This script must be run on a secureblue system.' >&2
+    exit 1
+fi
+
+image_name="$(awk -F= '$1 == "VARIANT_ID" { print $2; exit }' /usr/lib/os-release)"
+
+echo 'Copying files to sysext-tmp...'
+
+cp -a files/system/usr files/system/etc sysext-tmp
+justfiles=(files/justfiles/common/*.just)
+
+case "${image_name}" in
+    cosmic-*)
+        cp -a files/system/{cosmic,desktop}/* sysext-tmp
+        justfiles+=(files/justfiles/desktop/*.just)
+        ;;
+    kinoite-*)
+        cp -a files/system/{kinoite,desktop}/* sysext-tmp
+        justfiles+=(files/justfiles/desktop/*.just files/justfiles/kinoite.just)
+        ;;
+    sericea-*)
+        cp -a files/system/{sericea,desktop}/* sysext-tmp
+        justfiles+=(files/justfiles/desktop/*.just)
+        ;;
+    silverblue-*)
+        cp -a files/system/{silverblue,desktop}/* sysext-tmp
+        justfiles+=(files/justfiles/desktop/*.just files/justfiles/silverblue.just)
+        ;;
+    iot-*|securecore-*)
+        cp -a files/system/server/* sysext-tmp
+        ;;
+    *)
+        echo "Unknown image name '${image_name}'" >&2
+        exit 1
+        ;;
+esac
+
+if [[ "${image_name}" == *-nvidia-* ]]; then
+    cp -a files/system/nvidia/* sysext-tmp
+    justfiles+=(files/justfiles/nvidia/*.just)
+fi
+
+if [[ "${image_name}" == *-zfs-* ]]; then
+    cp -a files/system/zfs/* sysext-tmp
+fi
+
+for justfile_src in "${justfiles[@]}"; do
+    justfile_dest="/usr/share/bluebuild/${justfile_src#files/}"
+    install -Dp -m 0644 "${justfile_src}" "sysext-tmp${justfile_dest}"
+    printf 'import "%s"\n' "${justfile_dest}" >> sysext-tmp/usr/share/ublue-os/just/60-custom.just
+done
+
+chmod -R u=rwX,go=rX sysext-tmp
+
+git submodule update --init tools/sysextbuddy
+
+echo 'Building sysext...'
+tools/sysextbuddy/sysextbuddy \
+    --name secureblue-dev \
+    --output sysext-tmp/secureblue-dev.raw \
+    sysext-tmp

--- a/tools/install-sysext.sh
+++ b/tools/install-sysext.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+umask 022
+cd "${0%/*}"
+cd "$(git rev-parse --show-toplevel)"
+install -Dm 644 -t /run/extensions sysext-tmp/secureblue-dev.raw
+systemd-sysext refresh

--- a/tools/remove-sysext.sh
+++ b/tools/remove-sysext.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+umask 022
+rm -f /run/extensions/secureblue-dev.raw
+systemd-sysext refresh


### PR DESCRIPTION
Add Justfile and associated scripts for building, installing, and uninstalling a systemd sysext based on the local repo's version of `/usr`. This allows contributors to immediately test out local changes to `/usr` on their system without having to build and switch to a test image, and restore their system's original `/usr` just as easily.

The sysext is built by merging the various `usr` directories in `files/system` as appropriate for the image the sysext is built on. For example, on `kinoite-main-hardened`, the `usr` directories in `files/system`, `files/system/desktop`, and `files/system/kinoite` would all be applied.

The Justfile also includes a couple other recipes for running scripts in the `tools` directory, and can serve as an organizational tool for such scripts.

The `sysextbuddy` script for building the sysext is installed as a git submodule at `tools/sysextbuddy`, pinned to a commit.