### PR TITLE
fix: restrict copr packages to explicit allow-list

### DIFF
--- a/files/system/etc/yum.repos.d/secureblue-packages-fedora.repo
+++ b/files/system/etc/yum.repos.d/secureblue-packages-fedora.repo
@@ -9,3 +9,4 @@ gpgkey=file:///usr/share/pki/rpm-gpg/secureblue-copr-pubkey.gpg
 repo_gpgcheck=0
 enabled=1
 enabled_metadata=1
+includepkgs=bazaar*,brew-proxy*,bubblejail,crane*,hardened_malloc,homebrew,krunner-bazaar*,no_rlimit_as*,run0edit,secureblue-logos,slsa-verifier*,trivalent-subresource-filter


### PR DESCRIPTION
Nvidia images are currently unintentionally picking up kernel packages built in the secureblue Copr repo; these are a work-in-progress that's definitely not intended to be pushed to production. To prevent this or similar issues, use `includepkgs` to explicitly name the packages that are available from the Copr repo.