### PR TITLE
fix: restore chronyd config after Anaconda

### DIFF
--- a/files/system/usr/libexec/secureblue/securebluecleanup
+++ b/files/system/usr/libexec/secureblue/securebluecleanup
@@ -16,6 +16,9 @@ cp /usr/etc/authselect/authselect.conf /etc/authselect/authselect.conf
 cp /usr/etc/firewalld/zones/FedoraWorkstation.xml /etc/firewalld/zones/FedoraWorkstation.xml || true
 cp /usr/etc/firewalld/zones/FedoraServer.xml /etc/firewalld/zones/FedoraServer.xml || true
 
+# Undo chronyd timeserver configuration from Anaconda, which is empty sometimes.
+cp /usr/etc/chrony.conf /etc/chrony.conf
+
 if command -v flatpak &> /dev/null
 then
     flatpak remote-delete --system --force fedora || true


### PR DESCRIPTION
Anaconda overwrites our timeservers if you "Configure NTP" during setup, which tends to break time synchronisation.

This PR just restores the config from /usr/etc/, which is what lots of users have had to do manually anyway.

Closes #2300.