### PR TITLE
fix: allow flatpak-system-helper to create user namespaces

### DIFF
--- a/files/scripts/selinux/user_namespace/grant_userns.cil
+++ b/files/scripts/selinux/user_namespace/grant_userns.cil
@@ -4,3 +4,5 @@
 
 (allow colord_t self (user_namespace (create)))
 (allow devicekit_power_t self (user_namespace (create)))
+(allow flatpak_helper_t self (user_namespace (create)))
+

--- a/files/scripts/selinux/user_namespace/grant_userns.cil
+++ b/files/scripts/selinux/user_namespace/grant_userns.cil
@@ -4,5 +4,3 @@
 
 (allow colord_t self (user_namespace (create)))
 (allow devicekit_power_t self (user_namespace (create)))
-(allow flatpak_helper_t self (user_namespace (create)))
-

--- a/files/scripts/selinux/user_namespace/harden_userns.cil
+++ b/files/scripts/selinux/user_namespace/harden_userns.cil
@@ -14,6 +14,8 @@
           (typeattributeset userns_privileged_domain (file_manager_type)))
 (optional flatpak_userns_privileged_domain
           (typeattributeset userns_privileged_domain (flatpak_t)))
+(optional flatpak_helper_userns_privileged_domain
+          (typeattributeset userns_privileged_domain (flatpak_helper_t)))
 (optional systemsettings_userns_privileged_domain
           (typeattributeset userns_privileged_domain (systemsettings_t)))
 (optional trivalent_userns_privileged_domain

--- a/files/scripts/selinux/user_namespace/userns_deny_unconfined_relabels.cil
+++ b/files/scripts/selinux/user_namespace/userns_deny_unconfined_relabels.cil
@@ -13,6 +13,8 @@
           (typeattributeset userns_privileged_file_type (file_manager_exec_type)))
 (optional flatpak_userns_privileged_file_type
           (typeattributeset userns_privileged_file_type (flatpak_exec_t)))
+(optional flatpak_helper_userns_privileged_file_type
+          (typeattributeset userns_privileged_file_type (flatpak_helper_exec_t)))
 (optional systemsettings_userns_privileged_file_type
           (typeattributeset userns_privileged_file_type (systemsettings_exec_t)))
 (optional trivalent_userns_privileged_file_type


### PR DESCRIPTION
Needed for some postinstall scripts. This service already runs as root.