### PR TITLE
feat(po): add Serbian localization for audit script

### DIFF
--- a/files/po/sr/audit_secureblue.po
+++ b/files/po/sr/audit_secureblue.po
@@ -1,0 +1,1118 @@
+# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-22 00:29+0000\n"
+"PO-Revision-Date: 2026-06-26 12:13+0200\n"
+"Last-Translator: neocryptics <271640908+neocryptics@users.noreply.github.com>\n"
+"Language-Team: none\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:85
+#, python-brace-format
+msgid "Missing kernel argument: {0}"
+msgstr "Кернел аргумент недостаје: {0}"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:91
+#, python-brace-format
+msgid "Missing kernel argument: {0} (32-bit support)"
+msgstr "Кернел аргумент недостаје: {0} (32-bit подршка)"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:98
+#, python-brace-format
+msgid "Missing kernel argument: {0} (force-disable SMT)"
+msgstr "Кернел аргумент недостаје: {0} (присилно онемогућен SMT)"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:105
+#, python-brace-format
+msgid "Missing kernel argument (unstable): {0}"
+msgstr "Кернел аргумент недостаје (нестабилан): {0}"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:108
+msgid "To set hardened kernel arguments, run:"
+msgstr "Да би поставили очврснуте аргументе за кернел, покрените:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:110
+msgid "Checking for hardened kernel arguments"
+msgstr "Проверавање има ли очврснутих кернел аргумената"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:133
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:144
+#, python-brace-format
+msgid "{0} should be {1}, but is actually {2}."
+msgstr "{0} треба да буде {1}, али је заправо {2}."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:134
+#, python-brace-format
+msgid "This is likely due to a kernel fault, as documented in `{0}`."
+msgstr "Ово је вероватно због грешке у кернелу, као што је документо- "
+"вано у `{0}`"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:151
+msgid "Ensuring no sysctl overrides"
+msgstr "Потврда да нема писања преко sysctl-а"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:169
+msgid "The current image is not signed."
+msgstr "Тренутна слика није под печатом."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:170
+msgid "To rebase to a signed image, run the following command:"
+msgstr "Да би променили базу на слику с печатом, покрените следећу "
+"команду:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:174
+msgid "Ensuring a signed image is in use"
+msgstr "Утврђивање да се користи слика под печатом"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:200
+#, python-brace-format
+msgid "The module {0} is blocked in {1}, but has been loaded anyway."
+msgstr "Модул {0} је блокиран у {1}, али је свакако учитан."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:207
+#: files/system/usr/libexec/secureblue/audit_utils/__init__.py:122
+msgid "Ensuring no modprobe overrides"
+msgstr "Утврђивање да нема писања преко modprobe-а"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:218
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:971
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:980
+#, python-brace-format
+msgid "The file {0} has been modified."
+msgstr "Фајл {0} је модификован."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:225
+#, python-brace-format
+msgid "Container policy has a local override at {0}."
+msgstr "Локално писање преко container policy-а у {0}"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:229
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:265
+msgid "Analyzing container policy"
+msgstr "Анализирање container policy-а"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:234
+msgid "The default container policy is insecure."
+msgstr "Уобичајен container policy је небезбедан."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:243
+#, python-brace-format
+msgid "The default container policy for transport '{0}' is insecure."
+msgstr "Уобичајен container policy за транспорт '{0}' је несигуран."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:259
+#, python-brace-format
+msgid ""
+"Signature validation is disabled for containers at the following scopes:\n"
+"{0}"
+msgstr "Валидација потписа је угашена за container-е на овим опсезима\n"
+"{0}"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:277
+msgid "Unconfined domain user namespace creation is permitted."
+msgstr "Unconfined domain user namespace прављење је дозвољено."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:278
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:296
+msgid "To disallow it, run:"
+msgstr "Да не бисте дозволили, покрените:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:282
+msgid "Ensuring unconfined user namespace creation disallowed"
+msgstr "Утврђивање да није дозвоњено прављење unconfined user "
+"namespace-а"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:295
+msgid "Container domain user namespace creation is permitted."
+msgstr "Правити Container domain user namespace је дозвољено"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:300
+msgid "Ensuring container user namespace creation disallowed"
+msgstr "Утврђивање да правити container user namespace није "
+"дозвољено"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:315
+#, python-brace-format
+msgid "ptrace is allowed and **unrestricted** ({0})!"
+msgstr "ptrace је дозвољен и **неограничен** ({0})!"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:321
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:334
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:348
+msgid "For more info on what this means, see:"
+msgstr "За више информација о томе шта ово значи, погледајте:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:323
+msgid "Check the configuration in /etc/sysctl.d to fix this."
+msgstr "Погледајте конфигурацију у /etc/sysctl.d да ово поправите"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:328
+#, python-brace-format
+msgid "ptrace is allowed, but restricted to child processes ({0})."
+msgstr "ptrace је дозвољен, али ограничен на само подређене "
+"процесе ({0})."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:336
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:350
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:362
+msgid "To forbid ptrace, run:"
+msgstr "Да бисте укинули ptrace, покрените:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:342
+#, python-brace-format
+msgid "ptrace access is restricted to administrative users ({0})."
+msgstr "Приступ ptrace је ограничен административним корисницима ({0})."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:356
+#, python-brace-format
+msgid "ptrace on child processes ({0}) is allowed inside containers."
+msgstr "ptrace на подређеним процесима ({0}) је дозвољен унутар container-а."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:369
+msgid "Ensuring ptrace is forbidden"
+msgstr "Утврђивање да је ptrace забрањен"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:381
+msgid "USBGuard is enabled but has failed to run."
+msgstr "USBGuard је омогућен али није успео да се покрене."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:384
+msgid "USBGuard is not enabled."
+msgstr "USBGuard није омогућен."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:387
+msgid "To set up USBGuard, run:"
+msgstr "Да бисте подесили USBGuard, покрените:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:390
+msgid ""
+"Caution: if you have already set up USBGuard, this will overwrite the "
+"existing policy."
+msgstr "Упозорење: Ако сте већ подесили USBGuard, ово ће преписати "
+"постојећу политику."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:394
+msgid "Ensuring USBGuard is active"
+msgstr "Утврђивање да је USBGuard активан"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:406
+#, python-brace-format
+msgid "{0} is enabled but has failed to run."
+msgstr "{0} је упаљен али није успео да се покрене."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:409
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:692
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:726
+#, python-brace-format
+msgid "{0} is not enabled."
+msgstr "{0} није упаљен."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:412
+msgid "To start and enable it, run:"
+msgstr "Да би га покренули и омогућили, покрените:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:416
+msgid "Ensuring chronyd is active"
+msgstr "Утврђивање активности chronyd-а"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:447
+msgid "DNS over HTTPS in Trivalent is disabled."
+msgstr "DNS преко HTTPS је онемогућен у Триваленту."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:451
+msgid "Consider using DNS over HTTPS in Trivalent to hide queries."
+msgstr "Размислите о коришћењу DNS преко HTTPS-а у Триваленту да "
+"сакријете упите."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:452
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:467
+msgid "However, if you use a VPN, this may cause DNS leaks."
+msgstr "Међутим, ако користите VPN, ово може узроковати DNS цурења."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:453
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:468
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:493
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:541
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:563
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:607
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:637
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:670
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:695
+msgid "To enable it, run:"
+msgstr "Да бисте га омогућили, користите:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:462
+msgid "Secure global DNS is not configured."
+msgstr "Безбедан глобални DNS није подешен."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:466
+msgid "Consider using secure global DNS."
+msgstr "Размотрите коришћење безбедног глобалног DNS-а."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:475
+msgid "The secure DNS resolver is not in use, possibly for a VPN."
+msgstr "Не користи се безбедан DNS resolver, вероватно због VPN-а."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:479
+msgid "To view or reset your current DNS configuration, run:"
+msgstr "Да бисте видели или ресетовали ваша тренутна DNS поде-"
+"шавања, покрените:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:488
+msgid "Local DNSSEC validation is disabled."
+msgstr "Локална DNSSEC валидација је угашена."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:492
+msgid "You should enable local DNSSEC validation to prevent DNS hijacking."
+msgstr "Требало би да угасите логаклну DNSSEC валидацију како бисте спречили"
+"DNS hijacking."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:501
+msgid "Using a VPN alongside Unbound without Global DNS may cause DNS leaks."
+msgstr "Коришћење VPN-а са Unbound-ом без глобалног DNS-а може проузроковати"
+"DNS цурење."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:506
+msgid "If you use a VPN, switch your DNS resolver to systemd-resolved:"
+msgstr "Ако користите VPN, пребаците DNS resolver на systemd-resolved:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:516
+msgid "Ensuring system DNS resolution is secure"
+msgstr "Утврђивање да је system DNS resolution сигуран"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:532
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1282
+#, python-brace-format
+msgid "Unable to read file {0}."
+msgstr "Не може се прочитати фајл {0}."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:540
+msgid "MAC randomization is not enabled."
+msgstr "MAC randomization није упаљен."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:547
+msgid "Ensuring MAC randomization is enabled"
+msgstr "Утврђивање да је MAC randomization упаљен"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:559
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:604
+#, python-brace-format
+msgid "{0} is disabled."
+msgstr "{0} је угашен."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:570
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:613
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:645
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:678
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:701
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:729
+#, python-brace-format
+msgid "{0} has failed to run."
+msgstr "{0} није успео да се покрене."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:584
+msgid "Automatic system updates are disabled in /etc/rpm-ostreed.conf"
+msgstr "Аутоматско ажурирање система је онемогућено у /etc/rpm-ostreed.conf"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:588
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1172
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1199
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1204
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1221
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1235
+msgid "To fix this, run:"
+msgstr "Да бисте ово поправили, покрените:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:593
+msgid "Ensuring automatic system updates are enabled"
+msgstr "Утврђивање да је аутоматско ажурирање система упаљено"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:616
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:704
+#, python-brace-format
+msgid "Ensuring {0} is enabled"
+msgstr "Утврђивање да је {0} упаљено"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:634
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:667
+#, python-brace-format
+msgid "{0} is not enabled globally."
+msgstr "{0} није глобално упаљен."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:648
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:681
+#, python-brace-format
+msgid "Ensuring {0} is enabled globally"
+msgstr "Утврђивање да је {0} упаљен глобално"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:734
+msgid "Automatic updates for Homebrew are not enabled."
+msgstr "Аутоматска ажурирања за Homebrew нису упаљена."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:735
+msgid "To enable them, run:"
+msgstr "Да бисте их упалили, покрените:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:741
+msgid "Ensuring automatic Homebrew updates are enabled"
+msgstr "Утврђивање да су аутоматска ажурирање упаљена за Homebrew"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:755
+msgid "The current user is in the wheel group."
+msgstr "Тренутни корисник је у wheel групи."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:756
+msgid "To set up a separate wheel account, run:"
+msgstr "Да бисте подесили одвојени wheel налог, покрените:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:764
+msgid "Ensuring user is not a member of the wheel group"
+msgstr "Утврђивање да корисник није члан wheel групе"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:778
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:789
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:801
+#, python-brace-format
+msgid "The current user is in the group '{0}'."
+msgstr "Тренутни корисник је у групи '{0}'."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:782
+msgid "This allows privilege escalation to root."
+msgstr "Ово дозвољава подизање привилегија на root."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:783
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:795
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:806
+msgid "To remove the user from this group, run:"
+msgstr "Да бисте корисника избацили из ове групе, покрените:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:793
+msgid "This group allows the user to read system and kernel logs."
+msgstr "Ова група дозвољава кориснику да чита извештаје система и кернела."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:794
+msgid "This might make it easier to exploit kernel vulnerabilities."
+msgstr "Ово ће можда омогућити лакше искоришћавање рањивости кернела."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:805
+msgid "This group allows the user to modify the Homebrew installation."
+msgstr "Ова група дозвољава кориснику да модификује Homebrew инсталацију"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:813
+#, python-brace-format
+msgid "The current user is in the unrecognized group '{0}'."
+msgstr "Тренутни корисник је у групи која није препозната '{0}'."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:818
+msgid ""
+"Group memberships can grant additional privileges and may pose security "
+"risks."
+msgstr "Чланства групе могу дати додатне привилегије и могу представљати"
+"безбедносне ризике."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:819
+msgid "You may want to consider removing the user from this group:"
+msgstr "Можда желите избацити корисника из ове групе:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:824
+msgid "Checking if user is in groups with security implications"
+msgstr "Проверавање да ли је корисник у групама са безбедносним"
+"наговештајима"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:837
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:868
+msgid "GNOME"
+msgstr "Гноум"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:840
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:880
+msgid "KDE Plasma"
+msgstr "КДЕ Плазма"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:843
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:888
+msgid "Sway"
+msgstr "Свеј"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:853
+#, python-brace-format
+msgid "Xwayland is enabled for {0}."
+msgstr "Xwayland је омогућен за {0}."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:854
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1010
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1277
+msgid "To disable it, run:"
+msgstr "Да бисте га угасили, покрените:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:858
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:913
+#, python-brace-format
+msgid "Ensuring {0} is disabled for {1}"
+msgstr "Утврђивање да је {0} онемогућен за {1}"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:894
+msgid "COSMIC"
+msgstr "Козмик"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:896
+msgid "COSMIC Files doesn't yet support disabling thumbnails."
+msgstr "Козмик фајлови не подржава гашење тамбнејлова тренутно."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:897
+msgid "Ensuring thumbnailing is disabled for COSMIC"
+msgstr "Утврђивање да је тамбнејловање угашено за Козмик"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:908
+#, python-brace-format
+msgid "Thumbnailing is enabled for {0}."
+msgstr "Тамбнејловање је омогућено за {0}."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:909
+msgid "To disable it, consult the following FAQ:"
+msgstr "Да бисте га угасили, консултујте се са следећим"
+"информацијама и одговорима:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:936
+msgid "GNOME user extensions are enabled."
+msgstr "Гноум корисничке екстензије су омогућене."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:937
+msgid "To disable this, run:"
+msgstr "Да бисте ово угасили, покрените:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:941
+msgid "Ensuring GNOME user extensions are disabled"
+msgstr "Утврђивање угашености Гноум корисничких екстензија"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:953
+msgid "SELinux is in Permissive mode."
+msgstr "СЕЛинукс је у дозвољавајућем моду."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:954
+msgid "To set it to Enforcing mode, run:"
+msgstr "Да бисте га ставили у режим принуде, покрените:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:958
+msgid "Ensuring SELinux is in Enforcing mode"
+msgstr "Утврђивање да је СЕЛинукс у режиму принуде"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:974
+#, python-brace-format
+msgid "The file {0} has been deleted."
+msgstr "Фајл {0} је обрисан."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:977
+#, python-brace-format
+msgid "The file {0} cannot be read."
+msgstr "Фајл {0} се не може прочитати."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:981
+msgid "To reset it, run:"
+msgstr "Да бисте га ресетовали, покрените:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:985
+msgid "Ensuring no environment file overrides"
+msgstr "Утврђивање непостојања фајлова који пишу преко подешава-"
+"ња окружења"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1002
+#, python-brace-format
+msgid "The file {0} was not found or inaccessible."
+msgstr "Фајл {0} није нађен или није доступан."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1009
+msgid "KDE GNHS is enabled."
+msgstr "KDE GNHS је омогућен."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1016
+msgid "Ensuring KDE GHNS is disabled"
+msgstr "Утврђивање да је KDE GHNS онемогућен"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1030
+#, python-brace-format
+msgid "The file {0} was not found."
+msgstr "Фајл {0} није нађен."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1038
+#, python-brace-format
+msgid "{0} has mode {1:o} (expected {2:o})"
+msgstr "{0} има режим {1:o} (очекиван {2:o})"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1046
+#, python-brace-format
+msgid "{0} is owned by a non-root user!"
+msgstr "{0} је под власништвом non-root корисника!"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1049
+#, python-brace-format
+msgid "The file {0} has been modified or deleted."
+msgstr "Фајл {0} је модификован или обрисан."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1050
+msgid "To reset it and enable hardened_malloc for system processes, run:"
+msgstr "Да ресетујете и омогућите hardened_malloc за процесе система, покрените:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1055
+#, python-brace-format
+msgid "Ensuring {0} has expected permissions"
+msgstr "Утврђивање да {0} има очекиване дозволе"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1075
+#, python-brace-format
+msgid "{0} is set, but {1} has been modified."
+msgstr "{0} је подешен, али је {1} модификован."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1081
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1086
+#, python-brace-format
+msgid "The '{0}' variant of {1} has been set."
+msgstr "'{0}' варијанта {1} је подешена."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1090
+#, python-brace-format
+msgid "{0} has not been set."
+msgstr "{0} није подешен."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1093
+#, python-brace-format
+msgid ""
+"The environment variable {0} has been modified or is unset.\n"
+"                Check that {1} has not been overridden in\n"
+"                {2} or related configuration files."
+msgstr "Варијабла окружења {0} је модификована или неподешена.\n"
+"                Проверите да није писано преко {1}\n"
+"                {2} или повезане конфигурацијске фајлове."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1099
+msgid "Ensuring hardened_malloc is set to be preloaded"
+msgstr "Утврђивање да је hardened_malloc подешен за препокренуће"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1126
+msgid "Your hardware does not support secure boot."
+msgstr "Ваш хардвер не подржава secure boot."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1131
+msgid ""
+"The system will be unable to verify that kernel modules are signed or the "
+"boot process."
+msgstr ""
+"Систем неће моћи да потврди да су кернел модули или boot процес под печатом.
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1137
+msgid "Ensuring secure boot is enabled"
+msgstr "Утврђивање да је secure boot омогућен"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1169
+msgid "Bash environment is not locked down."
+msgstr "Bash окружење није закључано."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1170
+msgid "The following files do not appear to be immutable or do not exist:"
+msgstr "Следећи фајлови не изгледају као да су имутабилни или не постоје:"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1179
+msgid "Ensuring current user's bash environment is locked down"
+msgstr "Утврђивање закључавања bash окружења тренутног корисника"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1197
+msgid "CUPS (the printing service) is enabled."
+msgstr "CUPS (штампање) је омогућен."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1202
+msgid "CUPS (the printing service) is disabled, but unmasked."
+msgstr "CUPS (штампање) је онемогућено, али немаскирано."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1209
+#, python-brace-format
+msgid "CUPS (the printing service) has unexpected status '{0}'."
+msgstr "CUPS (штампање) има неочекивани статус '{0}'."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1215
+#, python-brace-format
+msgid "{0} is enabled."
+msgstr "{0} је омогућен."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1229
+#, python-brace-format
+msgid "{0} is disabled, but unmasked."
+msgstr "{0} је онемогућен, али немаскиран."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1244
+#, python-brace-format
+msgid "{0} has unexpected status '{1}'."
+msgstr "{0} има неочекивани статус '{1}'"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1247
+msgid "Ensuring printing services are disabled"
+msgstr "Утврђивање да је штампање онемогућено"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1264
+#, python-brace-format
+msgid "Webcam module is blacklisted in {0} but is still enabled."
+msgstr "Модул за камеру је онемогућен у {0} али је и даље омогућен."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1267
+msgid "To disable it, you must reboot."
+msgstr "Да угасите, морате да рестартујете систем."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1276
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1285
+msgid "Webcam module is enabled."
+msgstr "Модул за камеру је омогућен."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1287
+#: files/system/usr/libexec/secureblue/audit_utils/__init__.py:123
+msgid "Checking whether webcam module is disabled"
+msgstr "Утврђивање је ли модул за камеру онемогућен"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1308
+#, python-brace-format
+msgid "{0} is configured with an unknown URL."
+msgstr "{0} је подешен са непознатим URL-ом."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1311
+#, python-brace-format
+msgid "{0} is not a verified flatpak repository."
+msgstr "{0} није верификована flatpak репозиторија."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1314
+#, python-brace-format
+msgid "Auditing flatpak remote {0}"
+msgstr "Проверавање flatpak remote-а {0}"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1347
+#, python-brace-format
+msgid "Auditing {0}"
+msgstr "Проверавање {0}"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1363
+msgid "[Audit process interrupted. Exiting.]"
+msgstr "[Процес провере прекинут. Излазим.]"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1376
+msgid "Audit secureblue configuration for security"
+msgstr "Проверавање secureblue поставки за безбедност"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1381
+msgid "usage: "
+msgstr "користи се: "
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1382
+msgid "options"
+msgstr "опције"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1383
+msgid "show this help message and exit"
+msgstr "покажи ову помоћну поруку и изађи"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1386
+msgid "ignore configuration file"
+msgstr "игнориши фајл за поставку"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1388
+msgid "display output as JSON"
+msgstr "прикажи повратну информацију као JSON"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1389
+msgid "skip categories or individual checks"
+msgstr "прескочи категорије или индивидуалне провере"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1406
+#, python-brace-format
+msgid "*** Error in check '{0}' ***"
+msgstr "*** Грешка у провери '{0}' ***"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1408
+msgid "*** Continuing... ***"
+msgstr "*** Настављам... ***"
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1412
+#, python-brace-format
+msgid "Use option '{0}' to skip flatpak recommendations."
+msgstr "Користите опцију '{0}' да прескочите flatpak препоруке."
+
+#: files/system/usr/libexec/secureblue/audit_secureblue.py:1415
+msgid "*** WARNING: Unexpected error occurred. ***"
+msgstr "*** УПОЗОРЕЊЕ: Непозната грешка се десила. ***"
+
+#: files/system/usr/libexec/secureblue/auditor/__init__.py:49
+#: files/system/usr/libexec/secureblue/auditor/__init__.py:66
+msgid "PASS"
+msgstr "ПРОЛАЗИ"
+
+#: files/system/usr/libexec/secureblue/auditor/__init__.py:51
+#: files/system/usr/libexec/secureblue/auditor/__init__.py:68
+#: files/system/usr/libexec/secureblue/audit_utils/__init__.py:125
+msgid "INFO"
+msgstr "ИНФО"
+
+#: files/system/usr/libexec/secureblue/auditor/__init__.py:53
+#: files/system/usr/libexec/secureblue/auditor/__init__.py:70
+msgid "WARN"
+msgstr "УПОЗОРИ"
+
+#: files/system/usr/libexec/secureblue/auditor/__init__.py:55
+#: files/system/usr/libexec/secureblue/auditor/__init__.py:72
+#: files/system/usr/libexec/secureblue/audit_utils/__init__.py:124
+msgid "FAIL"
+msgstr "НЕУСПЕХ"
+
+#: files/system/usr/libexec/secureblue/auditor/__init__.py:57
+#: files/system/usr/libexec/secureblue/auditor/__init__.py:74
+msgid "UNKNOWN"
+msgstr "НЕПОЗНАТО"
+
+#: files/system/usr/libexec/secureblue/auditor/__init__.py:270
+msgid "Recommendations"
+msgstr "Препоруке"
+
+#: files/system/usr/libexec/secureblue/auditor/__init__.py:345
+msgid "Audit"
+msgstr "Провера"
+
+#: files/system/usr/libexec/secureblue/auditor/__init__.py:362
+#, python-brace-format
+msgid "Note: some results omitted due to configuration file or '{0}' argument."
+msgstr "Белешка: неки резултати склоњени због поставки фајла или '{0}' аргумента."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:140
+msgid "permission"
+msgstr "дозвола"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:145
+#, python-brace-format
+msgid "{0} has {1}"
+msgstr "{0} има {1}"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:150
+msgid "This may also be used as a sandbox escape vector."
+msgstr "Ово би се можда и користило као могућност бежања из sandbox-а."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:156
+#, python-brace-format
+msgid "The following flatpak app(s) have {0}:"
+msgstr "Следећа/е flatpak апликација/е имају {0}:"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:160
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:398
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:498
+msgid "To remove this permission from an app, use Flatseal or run:"
+msgstr "Да бисте уклонили ову дозволу апликацији, "
+"користите Flatseal или покрените:"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:162
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:340
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:400
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:479
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:500
+#, python-brace-format
+msgid "(replacing \"{0}\" with the flatpak app ID)"
+msgstr "(замењивање \"{0}\" са ИД-ем flatpak апликације)"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:190
+#, python-brace-format
+msgid "This grants access to {0}."
+msgstr "Ово омогућава приступ {0}."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:196
+msgid "network access"
+msgstr "приступ мрежи"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:201
+msgid "inter-process communications access"
+msgstr "приступ међупроцесним комуникацијама"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:202
+msgid "This is only necessary for better X11 performance."
+msgstr "Ово је једино неопходно за бољи рад X11."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:208
+msgid "X11 access"
+msgstr "X11 приступ"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:209
+msgid "X11 apps can monitor and modify each other's graphics and inputs."
+msgstr "X11 апликације могу да посматрају и мењају графику и улазе туђих апликација."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:215
+msgid "access to the PulseAudio socket"
+msgstr "приступ PulseAudio утичници"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:216
+msgid ""
+"\n"
+"            This grants access to all audio input and output streams.\n"
+"            However, this is necessary for most apps to play sound.\n"
+"        "
+msgstr ""
+"\n"
+"            Ово даје приступ свим аудио улазима и излазима.\n"
+"            Ово је, међутим, неопходно већини апликација како би пуштале звук.\n"
+"        "
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:221
+msgid "access to the D-Bus session bus"
+msgstr "приступ D-Bus бусу сесија"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:222
+msgid "access to the D-Bus system bus"
+msgstr "приступ D-bus бусу система"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:223
+msgid "access to the SSH agent"
+msgstr "приступ SSH агенту"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:228
+msgid "access to all devices"
+msgstr "приступ свим уређајима"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:229
+msgid "This includes input devices, GPUs, raw USB, and virtualization."
+msgstr "Ово укључује улазне уређаје, графичке картице, ниски ниво USB-а и виртуелизацију."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:231
+#, python-brace-format
+msgid "If GPU access is required, allow {0} instead."
+msgstr "Ако је приступ графичкој картици неопходан, дозволи заузврат {0}"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:237
+msgid "access to input devices"
+msgstr "приступ улазним уређајима"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:238
+msgid "This is required for game controllers."
+msgstr "Ово је неопходно за џојстике за игрице."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:240
+msgid "access to kernel-based virtualization"
+msgstr "приступ виртуелизацији базираној на кернелу"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:245
+msgid "access to shared memory."
+msgstr "приступ дељеној меморији."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:252
+msgid "raw access to USB devices."
+msgstr "приступ USB уређајима на најнижем нивоу"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:255
+msgid "bluetooth access"
+msgstr "приступ блутуту"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:256
+msgid "ptrace access"
+msgstr "приступ ptrace-у"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:303
+#, python-brace-format
+msgid "{0} can acquire arbitrary permissions."
+msgstr "{0} може добити било које дозволе."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:306
+msgid "However, this is required for its functionality."
+msgstr "Међутим, ово је неопходно за његову функционалност."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:323
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:328
+#, python-brace-format
+msgid "{0} is requesting {1}"
+msgstr "{0} захтева {1}"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:334
+#, python-brace-format
+msgid "{0} is not requesting {1}"
+msgstr "{0} не захтева {1}"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:336
+#, python-brace-format
+msgid "The following flatpak app(s) are not requesting {0}:"
+msgstr "Следећа/е flatpak апликација/е не траже {0}"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:338
+msgid "To enable it for an app, run:"
+msgstr "Да бисте омогућили апликацији, користите:"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:387
+#, python-brace-format
+msgid "{0} can talk to {1} on the session bus."
+msgstr "{0} може да говори {1} на бусу сесије."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:388
+#, python-brace-format
+msgid "The following flatpak app(s) can talk to {0} on the session bus:"
+msgstr "Следећа/е flatpak апликација/е могу да говоре са {0} на бусу сесије:"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:391
+#, python-brace-format
+msgid "{0} can talk to {1} on the system bus."
+msgstr "{0} може говорити с {1} на бусу система."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:392
+#, python-brace-format
+msgid "The following flatpak app(s) can talk to {0} on the system bus:"
+msgstr "Следећа/е flatpak апликација/е може говорити с {0} на бусу система:"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:397
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:497
+msgid "This grants the ability to acquire arbitrary permissions."
+msgstr "Ово даје могућност добитка било којих дозвола."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:441
+msgid "all system files"
+msgstr "сви фајлови система"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:442
+msgid "all user files"
+msgstr "сви фајлови корисника"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:443
+msgid "other applications' configuration files"
+msgstr "конфигурацијски фајлови других апликација"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:444
+msgid "other applications' cache files"
+msgstr "кеширани фајлови других апликација"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:445
+msgid "other applications' data files"
+msgstr "фајлови података других апликација"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:471
+#, python-brace-format
+msgid "{0} is missing {1} permission"
+msgstr "{0} недостаје {1} дозвола"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:474
+#, python-brace-format
+msgid "The following flatpak app(s) are missing {0} permission:"
+msgstr "Следећој/им flatpak апликацији/ама недостаје {0} дозвола:"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:476
+msgid "This is required to load hardened_malloc."
+msgstr "Ово је неопходно ради учитавања hardened_malloc-а."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:477
+msgid "To add this permission to an app, use Flatseal or run:"
+msgstr "Да бисте додали дозволу апликацији, користите Flatseal или покрените:"
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:493
+#, python-brace-format
+msgid "{0} can modify flatpak permissions."
+msgstr "{0} може да мења дозволе flatpak-а."
+
+#: files/system/usr/libexec/secureblue/audit_flatpak/__init__.py:495
+msgid "The following flatpak app(s) can modify flatpak permissions:"
+msgstr "Следећа/е flatpak апликација/е могу мењати flatpak дозволе:"
+
+#: files/system/usr/libexec/secureblue/audit_utils/__init__.py:38
+msgid "*** WARNING: Running audit script as root is not recommended. ***"
+msgstr "*** УПОЗОРЕЊЕ: Покретати скрипту провере као root се не препоручује. ***"
+
+#: files/system/usr/libexec/secureblue/audit_utils/__init__.py:39
+msgid "*** Some results may be misleading or incomplete. ***"
+msgstr "*** Неки резултати можда наводе погрешно или недовољни. ***"
+
+#: files/system/usr/libexec/secureblue/audit_utils/__init__.py:67
+msgid ""
+"The following status indicators accompany checks run by the audit script:"
+msgstr ""
+"Следећи показатељи стања прате провере покренуте скриптом провере:"
+
+#: files/system/usr/libexec/secureblue/audit_utils/__init__.py:70
+msgid "check failed - the configuration may be less secure."
+msgstr "проверa неуспела - подешавање је може бити мање безбедно."
+
+#: files/system/usr/libexec/secureblue/audit_utils/__init__.py:71
+msgid "partial failure, or less significant issue detected."
+msgstr "делимични неуспех, или мање значајан проблем препознат."
+
+#: files/system/usr/libexec/secureblue/audit_utils/__init__.py:72
+msgid "check passed - no problems detected."
+msgstr "провера прошла - проблеми нису препознати."
+
+#: files/system/usr/libexec/secureblue/audit_utils/__init__.py:73
+msgid "unable to perform check (usually due to a file permission issue)."
+msgstr "не могу урадити проверу (обично због проблема с дозволом неког фајла)."
+
+#: files/system/usr/libexec/secureblue/audit_utils/__init__.py:78
+msgid "For flatpak checks, the status indicators have more specific meanings:"
+msgstr "За flatpak провере, показатори стања морају имати специфичнија значења:"
+
+#: files/system/usr/libexec/secureblue/audit_utils/__init__.py:81
+msgid ""
+"app has permissions that can be used as sandbox escapes, allow it to modify\n"
+"            its own permissions, or otherwise grant very broad access to the "
+"system (e.g. access\n"
+"            to certain directories, direct D-Bus access, X11)."
+msgstr ""
+"апликација има дозволе које се могу користити за бег из sandbox-a, дозволу промене\n"
+"            сопствених дозвола, или другачије дати врло широк приступ "
+"system (e.g. access\n"
+"            одређеним фасциклама, директан приступ D-Bus-у, C11.)."
+
+#: files/system/usr/libexec/secureblue/audit_utils/__init__.py:84
+msgid ""
+"app has permissions that have some sandbox escape potential or otherwise\n"
+"            weaken security (e.g. PulseAudio, Bluetooth, not using "
+"hardened_malloc)."
+msgstr ""
+"Апликација има дозволе које имају потенцијал за бег из sandbox-а или за другачије\n"
+"            срозавање безбедности (нпр. PulseAudio, Bluetooth, не коришћење "
+"hardened_malloc)."
+
+#: files/system/usr/libexec/secureblue/audit_utils/__init__.py:86
+msgid ""
+"no potential sandbox escapes detected but some permissions could increase\n"
+"            attack surface or have privacy implications (e.g. network "
+"access)."
+msgstr ""
+"нису препознати потенцијални бегови из sandbox-а али неке дозволе могу повећати\n"
+"            површину напада или имати утицај на приватност (e.g. network "
+"access)."
+
+#: files/system/usr/libexec/secureblue/audit_utils/__init__.py:88
+msgid "no app permissions flagged (however, not all permissions are audited)."
+msgstr "ниједна дозвола апликације означена (нису све дозволе проверене, додуше)."
+
+#: files/system/usr/libexec/secureblue/audit_utils/__init__.py:94
+msgid ""
+"            Note that some flatpak apps require broad permissions to "
+"function. Permissions being\n"
+"            flagged by the audit script do not necessarily mean that action "
+"should be taken.\n"
+"            "
+msgstr ""
+"            Приметите да неке flatpak апликације захтевају широке дозволе да би "
+"функционисале. Дозволе које су\n"
+"            означене скриптом провере не значе нужно да се треба против њих "
+"нешто предузети.\n"
+"            "
+
+#: files/system/usr/libexec/secureblue/audit_utils/__init__.py:103
+#, python-brace-format
+msgid ""
+"            A configuration file at `{0}` accepts two top-level keys: an "
+"array `{1}` of categories\n"
+"            of checks to skip entirely, and a table `{2}` of checks whose "
+"output should be\n"
+"            suppressed if their status matches the provided value. For "
+"example:\n"
+"            "
+msgstr ""
+"            Фајл поставки у `{0}` прихвата два кључа највишег нивоа "
+"низ `{1}` категорија\n"
+"            провера за потпуно прескакање, и табелу `{2}` провера чија "
+"повратна информација треба бити\n"
+"            пригушена ако њихов статус погађа дату вредност. На "
+"пример:\n"
+"            "


### PR DESCRIPTION
I localized secureblue to Serbian using the instructions in the #localization channel of the Discord server. First pull request, my bad if I did something incorrectly.