### PR TITLE
chore(po): update source files list for audit script

### DIFF
--- a/files/po/po-source-files.json
+++ b/files/po/po-source-files.json
@@ -3,7 +3,8 @@
         "files/system/usr/libexec/secureblue/audit_secureblue.py",
         "files/system/usr/libexec/secureblue/auditor/__init__.py",
         "files/system/usr/libexec/secureblue/audit_flatpak/__init__.py",
+        "files/system/usr/libexec/secureblue/audit_flatpak/filesystem.py",
         "files/system/usr/libexec/secureblue/audit_utils/__init__.py",
-        "files/system/usr/libexec/secureblue/utils/__init__.py"
+        "files/system/usr/libexec/secureblue/audit_utils/containers.py"
     ]
 }


### PR DESCRIPTION
This is needed for `tools/update_po.py` to produce a POT file containing all the translatable strings.