### PR TITLE
chore(deps): group dependabot updates for pre-commit hooks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      pre-commit:
+        applies-to: "version-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
Have dependabot group non-security version updates for pre-commit hooks into a single weekly PR.