### PR TITLE
feat: install gvisor-tap-vsock

### DIFF
--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -48,6 +48,9 @@ install:
     - virt-manager
     - virt-viewer
 
+    # Needed for podman-machine
+    - gvisor-tap-vsock
+
     # ensure MTP support parity
     - libmtp
     - gvfs-mtp


### PR DESCRIPTION
This package is needed for `podman machine`, which is a useful tool for users who want to run containers with stronger isolation and without having to allow unprivileged user namespaces. The package and its dependencies are fairly small (about 6 MB download size and 18 MB installed size).