### PR TITLE
fix: install podman-machine metapackage

### DIFF
--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -33,7 +33,7 @@ install:
     # ensure universal font coverage
     - google-noto-fonts-all
 
-    # libvirt/qemu/kvm packages
+    # Virtualization packages
     - libvirt
     - libvirt-nss
     - qemu-device-display-virtio-gpu
@@ -47,9 +47,7 @@ install:
     - virt-install
     - virt-manager
     - virt-viewer
-
-    # Needed for podman-machine
-    - gvisor-tap-vsock
+    - podman-machine
 
     # ensure MTP support parity
     - libmtp


### PR DESCRIPTION
This is the proper way to make podman-machine usable on the system; this doesn't install any additional packages compared to just directly installing gvisor-tap-vsock, but does some necessary additional setup such as creating symlinks so podman-machine can find all the necessary helper binaries.