### PR TITLE
chore: don't modify container policy for Dangerzone install

### DIFF
--- a/files/system/usr/libexec/secureblue/inner/dangerzone.py
+++ b/files/system/usr/libexec/secureblue/inner/dangerzone.py
@@ -9,11 +9,8 @@ Privileged inner script to install Dangerzone.
 """
 
 import configparser
-import json
 from typing import Final
 
-CONTAINERS_POLICY_PATH: Final[str] = "/etc/containers/policy.json"
-DZ_CONTAINER_PATH: Final[str] = "/usr/share/dangerzone/container.tar"
 DZ_REPO_PATH: Final[str] = "/etc/yum.repos.d/dangerzone.repo"
 
 
@@ -28,23 +25,10 @@ def enable_repo(path: str | bytes, name: str) -> None:
         config.write(f)
 
 
-def set_container_policy() -> None:
-    """Allow Dangerzone container archive in policy.json."""
-    with open(CONTAINERS_POLICY_PATH, "rb") as f:
-        policy = json.load(f)
-    if DZ_CONTAINER_PATH in policy["transports"]["oci-archive"]:
-        return
-    policy["transports"]["oci-archive"][DZ_CONTAINER_PATH] = [{"type": "insecureAcceptAnything"}]
-    with open(CONTAINERS_POLICY_PATH, "w", encoding="utf8") as f:
-        json.dump(policy, f, indent=2)
-
-
 def main() -> None:
     """Install Dangerzone."""
     print("Enabling Dangerzone repository...")
     enable_repo(DZ_REPO_PATH, "dangerzone")
-    print("Setting container policy to allow Dangerzone...")
-    set_container_policy()
 
 
 if __name__ == "__main__":

--- a/files/system/usr/libexec/secureblue/install_dangerzone.py
+++ b/files/system/usr/libexec/secureblue/install_dangerzone.py
@@ -32,10 +32,7 @@ def main() -> int:
 
     inner_script = sandbox.SandboxedFunction(
         "dangerzone.py",
-        read_write_paths=[
-            "/etc/yum.repos.d/dangerzone.repo",
-            "/etc/containers/policy.json",
-        ],
+        read_write_paths=["/etc/yum.repos.d/dangerzone.repo"],
     )
     exit_code = sandbox.run(inner_script)
     if exit_code != 0:


### PR DESCRIPTION
With the newly released [Dangerzone 0.11.0](https://github.com/freedomofpress/dangerzone/releases/tag/v0.11.0), the container is no longer bundled as a tarball with the package. This means that there's no need to make a container policy exception for Dangerzone, as they're just pulling the container normally and we already have policy.json set up to verify the signature for that.