### PR TITLE
fix(just): install Steam flatpak as user to prevent permission errors (#2396)

### DIFF
--- a/files/justfiles/desktop/steam.just
+++ b/files/justfiles/desktop/steam.just
@@ -34,6 +34,10 @@ install-steam:
     case "${method_selection}" in
         1)
             echo "Flatpak method selected."
+
+            # Adds flatpak remote in userspace
+            flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+
             if ! flatpak remotes --columns=name | grep -q '^flathub$'; then
                 echo "The Steam flatpak is not verified by Valve and only distributed via the unfiltered Flathub remote." | fold -s
                 read -rp "Would you like to enable the unfiltered Flathub remote now? [Y/n] " flathub_unfiltered
@@ -47,7 +51,7 @@ install-steam:
                 fi
             fi
             echo "Installing Steam flatpak."
-            flatpak install -y flathub com.valvesoftware.Steam
+            flatpak install -y --user flathub com.valvesoftware.Steam
             echo "Disabling hardened_malloc for Steam."
             flatpak override --user --unset-env=LD_PRELOAD --nofilesystem=host-os com.valvesoftware.Steam
 

--- a/files/justfiles/desktop/steam.just
+++ b/files/justfiles/desktop/steam.just
@@ -34,11 +34,7 @@ install-steam:
     case "${method_selection}" in
         1)
             echo "Flatpak method selected."
-
-            # Adds flatpak remote in userspace
-            flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-
-            if ! flatpak remotes --columns=name | grep -q '^flathub$'; then
+            if ! flatpak remotes --user --columns=name | grep -q '^flathub$'; then
                 echo "The Steam flatpak is not verified by Valve and only distributed via the unfiltered Flathub remote." | fold -s
                 read -rp "Would you like to enable the unfiltered Flathub remote now? [Y/n] " flathub_unfiltered
                 flathub_unfiltered=${flathub_unfiltered:-y}


### PR DESCRIPTION
fix(just): install Steam flatpak as user to prevent permission errors

The `ujust install-steam` recipe was failing on secureblue systems because  it attempted a system-wide (--system) Flatpak installation by default.  Due to strict system hardening, non-privileged users lack the permissions  required for system deployment, triggering a "Deploy not allowed" error.

This change explicitly forces the Steam installation into the user space by  adding the `--user` flag. Additionally, it ensures the user-level Flathub  remote is automatically added beforehand to prevent "No remote refs found"  errors during execution.

Closes #2396