### PR TITLE
chore(build): update BlueBuild to latest CLI/action

### DIFF
--- a/.github/workflows/build-one-recipe.yml
+++ b/.github/workflows/build-one-recipe.yml
@@ -217,11 +217,11 @@ jobs:
           echo "clear_plan=${clear_plan}" >> "${GITHUB_OUTPUT}"
 
       - name: Build secureblue
-        uses: blue-build/github-action@24d146df25adc2cf579e918efe2d9bff6adea408 # v1.11.1
+        uses: blue-build/github-action@836161eb076426a451e6a0054f722b1153b8b3ad # v1.12.0
         env:
           KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
         with:
-          cli_version: v0.9.33
+          cli_version: v0.9.36
           recipe: ${{ inputs.recipe }}
           cosign_private_key: ${{ secrets.SIGNING_SECRET }}
           registry_token: ${{ github.token }}
@@ -256,7 +256,7 @@ jobs:
       packages: write # for uploading attestations.
     # Currently this must be referenced by tag, not by hash:
     # https://github.com/slsa-framework/slsa-github-generator?tab=readme-ov-file#referencing-slsa-builders-and-generators
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0 # zizmor: ignore[unpinned-uses]
     with:
       image: ${{ needs.bluebuild.outputs.FULL_IMAGE_REF }}
       digest: ${{ needs.bluebuild.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -189,11 +189,11 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: Build secureblue
-        uses: blue-build/github-action@24d146df25adc2cf579e918efe2d9bff6adea408 # v1.11.1
+        uses: blue-build/github-action@836161eb076426a451e6a0054f722b1153b8b3ad # v1.12.0
         env:
           KERNEL_PRIVKEY: ${{ steps.test_keys.outputs.kernel_privkey }}
         with:
-          cli_version: v0.9.33
+          cli_version: v0.9.36
           recipe: ${{ inputs.recipe }}
           push: false
           registry_token: ${{ github.token }}


### PR DESCRIPTION
* Update blue-build/github-action to [v1.12.0]. Full list of changes: [v1.11.1...v1.12.0]
* Update blue-build/cli to [v0.9.36]. Full list of changes: [v0.9.33...v0.9.36]

These include a couple changes that are particularly of interest:

* The latest CLI version adds automatic retries to the initial image pull step, which should significantly reduce how often network/server issues lead to build failures in that step. (This has been the cause of a lot of recent build failures.)
* This BlueBuild version supports rechunking images using [Chunkah]. This PR doesn't switch over to using Chunkah, but I think we should consider it in the near future.

[v1.12.0]: https://github.com/blue-build/github-action/releases/tag/v1.12.0
[v1.11.1...v1.12.0]: https://github.com/blue-build/github-action/compare/v1.11.1...v1.12.0
[v0.9.36]: https://github.com/blue-build/cli/releases/tag/v0.9.36
[v0.9.33...v0.9.36]: https://github.com/blue-build/cli/compare/v0.9.33...v0.9.36
[Chunkah]: https://github.com/coreos/chunkah