### PR TITLE
fix: add missing module to zfs-nvidia recipes

### DIFF
--- a/recipes/securecore/recipe-securecore-zfs-nvidia-open.yml
+++ b/recipes/securecore/recipe-securecore-zfs-nvidia-open.yml
@@ -17,5 +17,6 @@ platforms:
   - linux/amd64
 
 modules:
+  - from-file: common/zfs-modules.yml
   - from-file: common/nvidia-install.yml
   - from-file: common/final-modules.yml

--- a/recipes/securecore/recipe-securecore-zfs-nvidia.yml
+++ b/recipes/securecore/recipe-securecore-zfs-nvidia.yml
@@ -17,5 +17,6 @@ platforms:
   - linux/amd64
 
 modules:
+  - from-file: common/zfs-modules.yml
   - from-file: common/nvidia-install.yml
   - from-file: common/final-modules.yml


### PR DESCRIPTION
Unless I'm misinterpreting, it looks like the zfs-nvidia recipe for securecore where missing the zfs-module. Added the module referenced in the zfs recipes