### PR TITLE
feat(uki): build other desktop sealed images

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: build
+
 permissions: {}
+
 on:
   schedule:
     - cron: "00 6 * * *" # build at 6:00 UTC every day
@@ -28,6 +30,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
+
 jobs:
   silverblue-main:
     name: Build silverblue main
@@ -82,6 +85,25 @@ jobs:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
 
+  kinoite-main-sealed:
+    name: Build kinoite main sealed
+    if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
+    needs: kinoite-main
+    permissions:
+      contents: read # Needed to pull the repo for the build
+      actions: read # Needed to read actions and actions logs for provenance generation
+      packages: write # Needed to publish images
+      id-token: write # Needed for token generation for signing
+    uses: ./.github/workflows/build-sealed-image.yml
+    with:
+      image: ${{ needs.kinoite-main.outputs.IMAGE_NAME }}
+      base_tag: ${{ needs.kinoite-main.outputs.IMAGE_TAG }}
+      base_digest: ${{ needs.kinoite-main.outputs.IMAGE_DIGEST }}
+      image_version: ${{ needs.kinoite-main.outputs.IMAGE_VERSION }}
+    secrets:
+      COSIGN_KEY: ${{ secrets.SIGNING_SECRET }}
+      UKI_DB_KEY: ${{ secrets.UKI_DB_KEY }}
+
   sericea-main:
     name: Build sericea main
     if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
@@ -98,6 +120,25 @@ jobs:
     secrets:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
+
+  sericea-main-sealed:
+    name: Build sericea main sealed
+    if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
+    needs: sericea-main
+    permissions:
+      contents: read # Needed to pull the repo for the build
+      actions: read # Needed to read actions and actions logs for provenance generation
+      packages: write # Needed to publish images
+      id-token: write # Needed for token generation for signing
+    uses: ./.github/workflows/build-sealed-image.yml
+    with:
+      image: ${{ needs.sericea-main.outputs.IMAGE_NAME }}
+      base_tag: ${{ needs.sericea-main.outputs.IMAGE_TAG }}
+      base_digest: ${{ needs.sericea-main.outputs.IMAGE_DIGEST }}
+      image_version: ${{ needs.sericea-main.outputs.IMAGE_VERSION }}
+    secrets:
+      COSIGN_KEY: ${{ secrets.SIGNING_SECRET }}
+      UKI_DB_KEY: ${{ secrets.UKI_DB_KEY }}
 
   cosmic-main:
     name: Build cosmic main
@@ -116,80 +157,8 @@ jobs:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
 
-  silverblue-nvidia:
-    name: Build silverblue nvidia images
-    if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
-    needs: silverblue-main
-    permissions:
-      contents: read # Needed to pull the repo for the build
-      actions: read # Needed to read actions and actions logs for provenance generation
-      packages: write # Needed to publish images
-      id-token: write # Needed for token generation for signing
-    strategy:
-      fail-fast: false
-      matrix:
-        recipe:
-          - general/recipe-silverblue-nvidia.yml
-          - general/recipe-silverblue-nvidia-open.yml
-    uses: ./.github/workflows/build-one-recipe.yml
-    with:
-      recipe: ${{ matrix.recipe }}
-      rechunk: true
-      clear-plan: ${{ inputs.clear-plan || false }}
-    secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
-      KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
-
-  kinoite-nvidia:
-    name: Build kinoite nvidia images
-    if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
-    needs: kinoite-main
-    permissions:
-      contents: read # Needed to pull the repo for the build
-      actions: read # Needed to read actions and actions logs for provenance generation
-      packages: write # Needed to publish images
-      id-token: write # Needed for token generation for signing
-    strategy:
-      fail-fast: false
-      matrix:
-        recipe:
-          - general/recipe-kinoite-nvidia.yml
-          - general/recipe-kinoite-nvidia-open.yml
-    uses: ./.github/workflows/build-one-recipe.yml
-    with:
-      recipe: ${{ matrix.recipe }}
-      rechunk: true
-      clear-plan: ${{ inputs.clear-plan || false }}
-    secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
-      KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
-
-  sericea-nvidia:
-    name: Build sericea nvidia images
-    if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
-    needs: sericea-main
-    permissions:
-      contents: read # Needed to pull the repo for the build
-      actions: read # Needed to read actions and actions logs for provenance generation
-      packages: write # Needed to publish images
-      id-token: write # Needed for token generation for signing
-    strategy:
-      fail-fast: false
-      matrix:
-        recipe:
-          - general/recipe-sericea-nvidia.yml
-          - general/recipe-sericea-nvidia-open.yml
-    uses: ./.github/workflows/build-one-recipe.yml
-    with:
-      recipe: ${{ matrix.recipe }}
-      rechunk: true
-      clear-plan: ${{ inputs.clear-plan || false }}
-    secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
-      KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
-
-  cosmic-nvidia:
-    name: Build cosmic nvidia images
+  cosmic-main-sealed:
+    name: Build cosmic main sealed
     if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
     needs: cosmic-main
     permissions:
@@ -197,20 +166,15 @@ jobs:
       actions: read # Needed to read actions and actions logs for provenance generation
       packages: write # Needed to publish images
       id-token: write # Needed for token generation for signing
-    strategy:
-      fail-fast: false
-      matrix:
-        recipe:
-          - general/recipe-cosmic-nvidia.yml
-          - general/recipe-cosmic-nvidia-open.yml
-    uses: ./.github/workflows/build-one-recipe.yml
+    uses: ./.github/workflows/build-sealed-image.yml
     with:
-      recipe: ${{ matrix.recipe }}
-      rechunk: true
-      clear-plan: ${{ inputs.clear-plan || false }}
+      image: ${{ needs.cosmic-main.outputs.IMAGE_NAME }}
+      base_tag: ${{ needs.cosmic-main.outputs.IMAGE_TAG }}
+      base_digest: ${{ needs.cosmic-main.outputs.IMAGE_DIGEST }}
+      image_version: ${{ needs.cosmic-main.outputs.IMAGE_VERSION }}
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
-      KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
+      COSIGN_KEY: ${{ secrets.SIGNING_SECRET }}
+      UKI_DB_KEY: ${{ secrets.UKI_DB_KEY }}
 
   securecore-main:
     name: Build securecore main images
@@ -229,8 +193,8 @@ jobs:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
 
-  securecore-nvidia:
-    name: Build securecore nvidia images
+  securecore-main-sealed:
+    name: Build securecore main sealed
     if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
     needs: securecore-main
     permissions:
@@ -238,62 +202,15 @@ jobs:
       actions: read # Needed to read actions and actions logs for provenance generation
       packages: write # Needed to publish images
       id-token: write # Needed for token generation for signing
-    strategy:
-      fail-fast: false
-      matrix:
-        recipe:
-          - securecore/recipe-securecore-nvidia.yml
-          - securecore/recipe-securecore-nvidia-open.yml
-    uses: ./.github/workflows/build-one-recipe.yml
+    uses: ./.github/workflows/build-sealed-image.yml
     with:
-      recipe: ${{ matrix.recipe }}
-      rechunk: true
-      clear-plan: ${{ inputs.clear-plan || false }}
+      image: ${{ needs.securecore-main.outputs.IMAGE_NAME }}
+      base_tag: ${{ needs.securecore-main.outputs.IMAGE_TAG }}
+      base_digest: ${{ needs.securecore-main.outputs.IMAGE_DIGEST }}
+      image_version: ${{ needs.securecore-main.outputs.IMAGE_VERSION }}
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
-      KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
-
-  securecore-zfs-main:
-    name: Build securecore zfs main images
-    if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
-    needs: securecore-main
-    permissions:
-      contents: read # Needed to pull the repo for the build
-      actions: read # Needed to read actions and actions logs for provenance generation
-      packages: write # Needed to publish images
-      id-token: write # Needed for token generation for signing
-    uses: ./.github/workflows/build-one-recipe.yml
-    with:
-      recipe: securecore/recipe-securecore-zfs-main.yml
-      rechunk: true
-      clear-plan: ${{ inputs.clear-plan || false }}
-    secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
-      KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
-
-  securecore-zfs-nvidia:
-    name: Build securecore zfs nvidia images
-    if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
-    needs: securecore-zfs-main
-    permissions:
-      contents: read # Needed to pull the repo for the build
-      actions: read # Needed to read actions and actions logs for provenance generation
-      packages: write # Needed to publish images
-      id-token: write # Needed for token generation for signing
-    strategy:
-      fail-fast: false
-      matrix:
-        recipe:
-          - securecore/recipe-securecore-zfs-nvidia.yml
-          - securecore/recipe-securecore-zfs-nvidia-open.yml
-    uses: ./.github/workflows/build-one-recipe.yml
-    with:
-      recipe: ${{ matrix.recipe }}
-      rechunk: true
-      clear-plan: ${{ inputs.clear-plan || false }}
-    secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
-      KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
+      COSIGN_KEY: ${{ secrets.SIGNING_SECRET }}
+      UKI_DB_KEY: ${{ secrets.UKI_DB_KEY }}
 
   iot-main:
     name: Build iot main images
@@ -312,8 +229,8 @@ jobs:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
 
-  iot-nvidia:
-    name: Build iot nvidia images
+  iot-main-sealed:
+    name: Build iot main sealed
     if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
     needs: iot-main
     permissions:
@@ -321,59 +238,12 @@ jobs:
       actions: read # Needed to read actions and actions logs for provenance generation
       packages: write # Needed to publish images
       id-token: write # Needed for token generation for signing
-    strategy:
-      fail-fast: false
-      matrix:
-        recipe:
-          - iot/recipe-iot-nvidia.yml
-          - iot/recipe-iot-nvidia-open.yml
-    uses: ./.github/workflows/build-one-recipe.yml
+    uses: ./.github/workflows/build-sealed-image.yml
     with:
-      recipe: ${{ matrix.recipe }}
-      rechunk: true
-      clear-plan: ${{ inputs.clear-plan || false }}
+      image: ${{ needs.iot-main.outputs.IMAGE_NAME }}
+      base_tag: ${{ needs.iot-main.outputs.IMAGE_TAG }}
+      base_digest: ${{ needs.iot-main.outputs.IMAGE_DIGEST }}
+      image_version: ${{ needs.iot-main.outputs.IMAGE_VERSION }}
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
-      KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
-
-  iot-zfs-main:
-    name: Build iot zfs main images
-    if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
-    needs: iot-main
-    permissions:
-      contents: read # Needed to pull the repo for the build
-      actions: read # Needed to read actions and actions logs for provenance generation
-      packages: write # Needed to publish images
-      id-token: write # Needed for token generation for signing
-    uses: ./.github/workflows/build-one-recipe.yml
-    with:
-      recipe: iot/recipe-iot-zfs-main.yml
-      rechunk: true
-      clear-plan: ${{ inputs.clear-plan || false }}
-    secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
-      KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
-
-  iot-zfs-nvidia:
-    name: Build iot zfs nvidia images
-    if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
-    needs: iot-zfs-main
-    permissions:
-      contents: read # Needed to pull the repo for the build
-      actions: read # Needed to read actions and actions logs for provenance generation
-      packages: write # Needed to publish images
-      id-token: write # Needed for token generation for signing
-    strategy:
-      fail-fast: false
-      matrix:
-        recipe:
-          - iot/recipe-iot-zfs-nvidia.yml
-          - iot/recipe-iot-zfs-nvidia-open.yml
-    uses: ./.github/workflows/build-one-recipe.yml
-    with:
-      recipe: ${{ matrix.recipe }}
-      rechunk: true
-      clear-plan: ${{ inputs.clear-plan || false }}
-    secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
-      KERNEL_PRIVKEY: ${{ secrets.KERNEL_PRIVKEY }}
+      COSIGN_KEY: ${{ secrets.SIGNING_SECRET }}
+      UKI_DB_KEY: ${{ secrets.UKI_DB_KEY }}


### PR DESCRIPTION
- Drop non-main images in `build-all` and add sealed image variants for silverblue-main, kinoite-main, sericea-main, cosmic-main, securecore-main and iot-main.