### PR TITLE
fix: Create swtpm-localca directory if it doesn't exist

### DIFF
--- a/files/system/desktop/usr/lib/tmpfiles.d/libvirt-create-swtpm-localca.conf
+++ b/files/system/desktop/usr/lib/tmpfiles.d/libvirt-create-swtpm-localca.conf
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright 2026 Project Aurora
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Reference: https://github.com/get-aurora-dev/common/blob/main/system_files/dx/usr/lib/tmpfiles.d/swtpm-workaround.conf
+# Reference issue: https://github.com/ublue-os/aurora/issues/2257
+#
+# TODO: Remove once swptm v0.10.1+ lands upstream
+
+d /var/lib/swtpm-localca 0750 tss root
+Z /var/lib/swtpm-localca


### PR DESCRIPTION
This PR ensures that `/var/lib/swtpm-localca`  already exists and has the expected access mode, user and group ownership.

Without this, users may face the following error when setting up a virtual machine:
```
Unable to complete install: 'internal error: Could not run '/usr/bin/swtpm_setup'. Exit status: 1.
```

This issue has already been [fixed](https://github.com/stefanberger/swtpm/commit/d318d40469474eb8f3ccc4a6e9fe0ba100814e20) by the swtpm maintainers, but they haven't shipped a new release with the fix yet. So, this has to be done manually in the meantime.