### PR TITLE
fix(uki): check out repo before cosigning systemd-boot/uki-addons

### DIFF
--- a/.github/workflows/build-sealed-image.yml
+++ b/.github/workflows/build-sealed-image.yml
@@ -52,7 +52,7 @@ jobs:
           egress-policy: audit
 
       - name: "Check out repository"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/sign-systemd-boot.yml
+++ b/.github/workflows/sign-systemd-boot.yml
@@ -93,10 +93,16 @@ jobs:
       contents: read # Needed to pull the repo for the build
       packages: write # Needed to sign images
     steps:
+      - name: "Check out repository"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
       - name: "Set up runner"
         uses: ./.github/workflows/shared-runner-setup
         with:
           needs_cosign: true
+
       - name: "Sign container image"
         run: |
           cosign sign -y --key env://COSIGN_KEY ghcr.io/${GITHUB_REPOSITORY_OWNER}/systemd-boot@${DIGEST}

--- a/.github/workflows/sign-systemd-boot.yml
+++ b/.github/workflows/sign-systemd-boot.yml
@@ -33,7 +33,7 @@ jobs:
       IMAGE_DIGEST: ${{ steps.push.outputs.digest }}
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -94,7 +94,7 @@ jobs:
       packages: write # Needed to sign images
     steps:
       - name: "Check out repository"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/sign-uki-addons.yml
+++ b/.github/workflows/sign-uki-addons.yml
@@ -31,7 +31,7 @@ jobs:
       IMAGE_DIGEST: ${{ steps.push.outputs.digest }}
     steps:
       - name: "Check out repository"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -92,7 +92,7 @@ jobs:
       packages: write # Needed to sign images
     steps:
       - name: "Check out repository"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/sign-uki-addons.yml
+++ b/.github/workflows/sign-uki-addons.yml
@@ -91,10 +91,16 @@ jobs:
       contents: read # Needed to pull the repo for the build
       packages: write # Needed to sign images
     steps:
+      - name: "Check out repository"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
       - name: "Set up runner"
         uses: ./.github/workflows/shared-runner-setup
         with:
           needs_cosign: true
+
       - name: "Cosign container image"
         run: |
           cosign sign -y --key env://COSIGN_KEY ghcr.io/${GITHUB_REPOSITORY_OWNER}/uki-addons@${DIGEST}


### PR DESCRIPTION
Fixes errors in [sign-uki-addons](https://github.com/secureblue/secureblue/actions/runs/29342179270/job/87116908991) and [sign-systemd-boot](https://github.com/secureblue/secureblue/actions/runs/29342192304/job/87116805792):
> Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/secureblue/secureblue/.github/workflows/shared-runner-setup'. Did you forget to run actions/checkout before running your local action?