### PR TITLE
fix(uki): log in to registry before cosigning

### DIFF
--- a/.github/workflows/sign-systemd-boot.yml
+++ b/.github/workflows/sign-systemd-boot.yml
@@ -103,6 +103,13 @@ jobs:
         with:
           needs_cosign: true
 
+      - name: "Log in to registry"
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        with:
+          registry: "ghcr.io/${{ github.repository_owner }}"
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: "Sign container image"
         run: |
           cosign sign -y --key env://COSIGN_KEY ghcr.io/${GITHUB_REPOSITORY_OWNER}/systemd-boot@${DIGEST}

--- a/.github/workflows/sign-uki-addons.yml
+++ b/.github/workflows/sign-uki-addons.yml
@@ -101,6 +101,13 @@ jobs:
         with:
           needs_cosign: true
 
+      - name: "Log in to registry"
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        with:
+          registry: "ghcr.io/${{ github.repository_owner }}"
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: "Cosign container image"
         run: |
           cosign sign -y --key env://COSIGN_KEY ghcr.io/${GITHUB_REPOSITORY_OWNER}/uki-addons@${DIGEST}


### PR DESCRIPTION
Fixes "Sign systemd-boot" and "Sign UKI addons" workflows:
> error during command execution: signing [ghcr.io/secureblue/uki-addons@sha256:7c7499a33992dbf374fcc38bffd7de7a076a1c5d19b36684eba132915a688dde]: signing digest: POST https://ghcr.io/v2/secureblue/uki-addons/blobs/uploads/: UNAUTHORIZED: unauthenticated: User cannot be authenticated with the token provided.