### PR TITLE
fix(uki): change dependency for provenance job

### DIFF
--- a/.github/workflows/sign-systemd-boot.yml
+++ b/.github/workflows/sign-systemd-boot.yml
@@ -119,7 +119,7 @@ jobs:
           DIGEST: ${{ needs.uki-sign-systemd-boot.outputs.IMAGE_DIGEST }}
 
   provenance:
-    needs: cosign-systemd-boot
+    needs: uki-sign-systemd-boot
     permissions:
       actions: read # for detecting the Github Actions environment.
       id-token: write # for creating OIDC tokens for signing.

--- a/.github/workflows/sign-uki-addons.yml
+++ b/.github/workflows/sign-uki-addons.yml
@@ -117,7 +117,7 @@ jobs:
           DIGEST: ${{ needs.uki-sign-uki-addons.outputs.IMAGE_DIGEST }}
 
   provenance:
-    needs: cosign-uki-addons
+    needs: uki-sign-uki-addons
     permissions:
       actions: read # for detecting the Github Actions environment.
       id-token: write # for creating OIDC tokens for signing.


### PR DESCRIPTION
SLSA provenance for the "Sign systemd-boot" and "Sign UKI addons" workflows doesn't actually depend on cosign; it only depends on generating the container.

This change makes `needs.uki-sign-systemd-boot.outputs.IMAGE_DIGEST` resolve to something, which fixes:
> main.go:74: error during command execution: signing ghcr.io/secureblue/systemd-boot@: parsing reference: could not parse reference: ghcr.io/secureblue/systemd-boot@

@RoyalOughtness 