### PR TITLE
fix(uki): fix signing and provenance for sealed images

### DIFF
--- a/.github/workflows/build-sealed-image.yml
+++ b/.github/workflows/build-sealed-image.yml
@@ -59,7 +59,6 @@ jobs:
       - name: "Set up runner"
         uses: ./.github/workflows/shared-runner-setup
         with:
-          needs_cosign: true
           needs_slsa_crane: true
 
       - name: "Log in to registry"
@@ -184,10 +183,23 @@ jobs:
       contents: read # Needed to pull the repo for the build
       packages: write # Needed to sign images
     steps:
+      - name: "Check out repository"
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
       - name: "Set up runner"
         uses: ./.github/workflows/shared-runner-setup
         with:
           needs_cosign: true
+
+      - name: "Log in to registry"
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        with:
+          registry: "ghcr.io/${{ github.repository_owner }}"
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: "Sign container image"
         run: |
           cosign sign -y --key env://COSIGN_KEY "ghcr.io/${GITHUB_REPOSITORY_OWNER}/${IMAGE}@${DIGEST}"
@@ -195,10 +207,10 @@ jobs:
           COSIGN_EXPERIMENTAL: false
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
           IMAGE: ${{ inputs.image }}
-          DIGEST: ${{ needs.build-sealed-image.outputs.IMAGE_DIGEST }}
+          DIGEST: ${{ needs.uki-sign-sealed-image.outputs.IMAGE_DIGEST }}
 
   provenance:
-    needs: cosign-sealed-image
+    needs: uki-sign-sealed-image
     permissions:
       actions: read # for detecting the Github Actions environment.
       id-token: write # for creating OIDC tokens for signing.
@@ -208,7 +220,7 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0 # zizmor: ignore[unpinned-uses]
     with:
       image: "ghcr.io/${{ github.repository_owner }}/${{ inputs.image }}"
-      digest: ${{ needs.build-sealed-image.outputs.IMAGE_DIGEST }}
+      digest: ${{ needs.uki-sign-sealed-image.outputs.IMAGE_DIGEST }}
       registry-username: ${{ github.actor }}
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sign-systemd-boot.yml
+++ b/.github/workflows/sign-systemd-boot.yml
@@ -39,8 +39,6 @@ jobs:
 
       - name: "Runner setup"
         uses: ./.github/workflows/shared-runner-setup
-        with:
-          needs_cosign: 'true'
 
       - name: "Log in to registry"
         uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7

--- a/.github/workflows/sign-uki-addons.yml
+++ b/.github/workflows/sign-uki-addons.yml
@@ -37,8 +37,6 @@ jobs:
 
       - name: "Set up runner"
         uses: ./.github/workflows/shared-runner-setup
-        with:
-          needs_cosign: 'true'
 
       - name: "Log in to registry"
         uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7


### PR DESCRIPTION
Replicates #2426, #2427 and #2429 for the `build-sealed-image` workflow.

Fixes https://github.com/secureblue/secureblue/actions/runs/29355751151/job/87170486968:
> Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/secureblue/secureblue/.github/workflows/shared-runner-setup'. Did you forget to run actions/checkout before running your local action?
