### PR TITLE
fix(zfsbuild): use existing KERNEL_VERSION variable to install matching kernel

### DIFF
--- a/files/scripts/installzfskmod.sh
+++ b/files/scripts/installzfskmod.sh
@@ -14,7 +14,7 @@ curl -fLsS --retry 5 -o data.json "https://api.github.com/repos/openzfs/zfs/rele
 ZFS_VERSION=$(jq -r --arg ZMV "zfs-${ZFS_MINOR_VERSION}" '[ .[] | select(.prerelease==false and .draft==false) | select(.tag_name | startswith($ZMV))][0].tag_name' data.json|cut -f2- -d-)
 echo "ZFS_VERSION==${ZFS_VERSION}"
 
-dnf install -y --setopt=install_weak_deps=False "kernel-devel-matched-$(rpm -q 'kernel' --queryformat '%{VERSION}')"
+dnf install -y --setopt=install_weak_deps=False "kernel-devel-matched-${KERNEL_VERSION}"
 dnf install -y --setopt=install_weak_deps=False autoconf automake gcc pv akmods mock libunwind-devel pam-devel libatomic libtirpc-devel libblkid-devel libuuid-devel libudev-devel openssl-devel libaio-devel libattr-devel elfutils-libelf-devel python3-devel python3-cffi libffi-devel libcurl-devel ncompress python3-setuptools
 
 


### PR DESCRIPTION
Using `{VERSION}` alone is insufficient and can result in installing the devel package for a mismatched kernel.