### PR TITLE
feat(selinux): allow passt_t to create user namespaces

### DIFF
--- a/files/scripts/selinux/user_namespace/harden_userns.cil
+++ b/files/scripts/selinux/user_namespace/harden_userns.cil
@@ -16,6 +16,8 @@
           (typeattributeset userns_privileged_domain (flatpak_t)))
 (optional flatpak_helper_userns_privileged_domain
           (typeattributeset userns_privileged_domain (flatpak_helper_t)))
+(optional passt_userns_privileged_domain
+          (typeattributeset userns_privileged_domain (passt_t)))
 (optional systemsettings_userns_privileged_domain
           (typeattributeset userns_privileged_domain (systemsettings_t)))
 (optional trivalent_userns_privileged_domain

--- a/files/scripts/selinux/user_namespace/userns_deny_unconfined_relabels.cil
+++ b/files/scripts/selinux/user_namespace/userns_deny_unconfined_relabels.cil
@@ -15,6 +15,8 @@
           (typeattributeset userns_privileged_file_type (flatpak_exec_t)))
 (optional flatpak_helper_userns_privileged_file_type
           (typeattributeset userns_privileged_file_type (flatpak_helper_exec_t)))
+(optional passt_userns_privileged_file_type
+          (typeattributeset userns_privileged_file_type (passt_exec_t)))
 (optional systemsettings_userns_privileged_file_type
           (typeattributeset userns_privileged_file_type (systemsettings_exec_t)))
 (optional trivalent_userns_privileged_file_type


### PR DESCRIPTION
[passt](https://passt.top/passt/about/) is needed for user-mode networking for virtual machines, and runs in the `passt_t` domain, which seems to be fairly strictly confined. It requires user namespaces to function, so I think this change should improve usability of virtual machines while having minimal impact on security.