### PR TITLE
fix(nvidia): use precise version for kernel-devel-matched

### DIFF
--- a/files/scripts/installnvidiakmod.sh
+++ b/files/scripts/installnvidiakmod.sh
@@ -16,7 +16,9 @@ else
     nvidia_repo='fedora-nvidia-580'
 fi
 
-dnf install -y --setopt=install_weak_deps=False "kernel-devel-matched-$(rpm -q 'kernel' --queryformat '%{VERSION}')"
+KERNEL_VERSION="$(rpm -q 'kernel' --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+
+dnf install -y --setopt=install_weak_deps=False "kernel-devel-matched-${KERNEL_VERSION}"
 
 dnf install -y --setopt=install_weak_deps=False akmods gcc-c++
 
@@ -27,8 +29,6 @@ dnf install -y --setopt=install_weak_deps=False \
     --enable-repo="${nvidia_repo}" \
     --disable-repo='fedora-multimedia' \
     nvidia-kmod-common nvidia-modprobe akmod-nvidia
-
-KERNEL_VERSION="$(rpm -q "kernel" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 
 echo "Installing kmod..."
 akmods --force --kernels "${KERNEL_VERSION}" --kmod "nvidia"


### PR DESCRIPTION
The installed version of `kernel-devel-matched` needs to exactly match the installed kernel version, including the release number. Otherwise, if there's a more recent kernel release with the same version number, it will pull in the newer kernel as a dependency.