### PR TITLE
fix(audit): dolphinrc config parsing issues

### DIFF
--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -572,7 +572,7 @@ def audit_rpm_ostree_timer():
 
     bad_rpm_ostreed_conf = False
     try:
-        config = configparser.ConfigParser()
+        config = configparser.ConfigParser(delimiters=("=",))
         config.read("/etc/rpm-ostreed.conf")
         if config["Daemon"].get("AutomaticUpdatePolicy") not in ("stage", "apply"):
             bad_rpm_ostreed_conf = True
@@ -868,9 +868,7 @@ def audit_thumbnailing(state):
             de = _("GNOME")
             # show-image-thumbnails controls all thumbnailing
             thumbnail_gsetting_output = command_stdout(
-                "command",
-                "-p",
-                "gsettings",
+                "/usr/bin/gsettings",
                 "get",
                 "org.gnome.nautilus.preferences",
                 "show-image-thumbnails",
@@ -880,7 +878,7 @@ def audit_thumbnailing(state):
             de = _("KDE Plasma")
             dolphinrc_file = Path.home() / ".config/dolphinrc"
             if dolphinrc_file.exists():
-                config = configparser.ConfigParser()
+                config = configparser.ConfigParser(delimiters=("=",), allow_unnamed_section=True)
                 config.read(dolphinrc_file)
                 thumbnail_plugins = config.get("PreviewSettings", "Plugins", fallback="")
                 thumbnailing_disabled = thumbnail_plugins == ""
@@ -894,7 +892,9 @@ def audit_thumbnailing(state):
             de = _("COSMIC")
             status = INFO
             note = Note(_("COSMIC Files doesn't yet support disabling thumbnails."), INFO)
-            yield Report(_("Ensuring thumbnailing is disabled for COSMIC"), status, notes=note)
+            yield Report(
+                _("Ensuring thumbnailing is disabled for {0}").format(de), status, notes=note
+            )
             return
         case _:
             return
@@ -910,7 +910,7 @@ def audit_thumbnailing(state):
             "https://secureblue.dev/faq#thumbnailing",
         ]
         rec = "\n".join(rec_lines)
-    yield Report(_("Ensuring {0} is disabled for {1}").format("thumbnailing", de), status, recs=rec)
+    yield Report(_("Ensuring thumbnailing is disabled for {0}").format(de), status, recs=rec)
 
 
 @audit
@@ -920,9 +920,7 @@ def audit_gnome_extensions(state):
     if state["image"] != Image.SILVERBLUE:
         return
     allowed = command_stdout(
-        "command",
-        "-p",
-        "gsettings",
+        "/usr/bin/gsettings",
         "get",
         "org.gnome.shell",
         "allow-extension-installation",

--- a/files/system/usr/libexec/secureblue/inner/dangerzone.py
+++ b/files/system/usr/libexec/secureblue/inner/dangerzone.py
@@ -16,7 +16,7 @@ DZ_REPO_PATH: Final[str] = "/etc/yum.repos.d/dangerzone.repo"
 
 def enable_repo(path: str | bytes, name: str) -> None:
     """Enable RPM repository"""
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(delimiters=("=",))
     config.read(path)
     if config[name].get("enabled") == "1":
         return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "secureblue"
 version = "4.9"
-requires-python = ">= 3.11"
+requires-python = ">= 3.13"
 maintainers = [{name = "RoyalOughtness"}]
 description = "secureblue is a security-focused desktop and server Linux operating system."
 readme = "docs/README.md"


### PR DESCRIPTION
This fixes errors in the thumbnailing audit caused by `:` being misinterpreted as a delimiter in a KDE config file, and by a config entry without a section header.

Also make the same change to delimiters in other uses of `configparser`, fix a minor issue with translatable strings in the thumbnailing audit, and use `/usr/bin/gsettings` instead of `command -p gsettings` in a couple places.

Fixes #2441.