### PR TITLE
fix: remove existing kernel signature before signing

### DIFF
--- a/files/scripts/installandsignkernel.sh
+++ b/files/scripts/installandsignkernel.sh
@@ -11,15 +11,16 @@ KERNEL_VERSION="$(rpm -q 'kernel' --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')
 SECUREBLUE_KERNEL_VERSION="${KERNEL_VERSION/.fc/.secureblue.*.fc}"
 dnf install --repo "copr:copr.fedorainfracloud.org:secureblue:packages" "kernel-${SECUREBLUE_KERNEL_VERSION}" -y
 
-
 SECUREBLUE_NEW_KERNEL_VERSION="$(rpm -q 'kernel' --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+VMLINUZ_PATH="/usr/lib/modules/${SECUREBLUE_NEW_KERNEL_VERSION}/vmlinuz"
 PUBLIC_KEY_DER_PATH='../system/usr/share/pki/akmods/certs/akmods-secureblue.der'
 PUBLIC_KEY_CRT_PATH='./certs/public_key.crt'
 PRIVATE_KEY_PATH='/tmp/certs/private_key.priv'
 
 openssl x509 -in "${PUBLIC_KEY_DER_PATH}" -out "${PUBLIC_KEY_CRT_PATH}"
+sbattach --remove "${VMLINUZ_PATH}"
 sbsign --cert "${PUBLIC_KEY_CRT_PATH}" \
     --key "${PRIVATE_KEY_PATH}" \
-    --output "/usr/lib/modules/${SECUREBLUE_NEW_KERNEL_VERSION}/vmlinuz" \
-    "/usr/lib/modules/${SECUREBLUE_NEW_KERNEL_VERSION}/vmlinuz"
-sbverify --list "/usr/lib/modules/${SECUREBLUE_NEW_KERNEL_VERSION}/vmlinuz"
+    --output "${VMLINUZ_PATH}" \
+    "${VMLINUZ_PATH}"
+sbverify --list "${VMLINUZ_PATH}"


### PR DESCRIPTION
secureblue's Linux kernel image should be signed only with the secureblue kernel signing key.