### PR TITLE
fix: set 0750 perms for /var/lib/chrony

### DIFF
--- a/files/system/usr/lib/tmpfiles.d/chrony-secureblue.conf
+++ b/files/system/usr/lib/tmpfiles.d/chrony-secureblue.conf
@@ -1,1 +1,1 @@
-d /var/lib/chrony 0755 chrony chrony 30d
+d /var/lib/chrony 0750 chrony chrony 30d


### PR DESCRIPTION
This matches how Fedora's packaging configures it.

Fixes #2476.