### PR TITLE
feat(uki): improvements to UKI installer

### DIFF
--- a/uki/README.md
+++ b/uki/README.md
@@ -19,8 +19,8 @@ secureblue offers two options for Secure Boot. You should choose one:
    Your firmware will only trust secureblue. This offers improved security, but
    this can BRICK YOUR DEVICE by breaking the display if your external GPU
    requires an option ROM to work.
-    - A compatibility test will be added in a future version to determine
-      whether using a platform key is safe.
+   - A compatibility test will be added in a future version to determine
+     whether using a platform key is safe.
 
 In general, the Platform Key option is suitable for laptops, but not for
 desktops. However, modifying settings is entirely at your own risk, and you

--- a/uki/README.md
+++ b/uki/README.md
@@ -3,9 +3,7 @@
 ### 1. System requirements
 
 - 32+ GiB disk space
-- 16+ GiB memory
-  - This requirement will be reduced when ISOs are available. For now, lots of
-    memory is needed to hold secureblue in RAM before installing it to disk.
+- 4+ GiB memory
 - UEFI-based firmware
 - For measured boot: a TPM 2.0
 
@@ -13,13 +11,16 @@
 
 secureblue offers two options for Secure Boot. You should choose one:
 
-1. **shim** - Safe for all devices. However, your firmware must trust the
-   Microsoft Third Party CA, which signs many bootloaders and ROMs. This greatly
-   increases attack surface but is compatible with all hardware.
-2. **secureblue Platform Key** - Only suitable for some devices. Your firmware
-   will only trust secureblue. This offers improved security, but this can BRICK
-   YOUR DEVICE by breaking the display if your external GPU requires an option
-   ROM to work.
+1. **shim** - Safe for all devices.
+   However, your firmware must trust the Microsoft Third Party CA, which signs
+   many bootloaders and ROMs. This greatly increases attack surface but is
+   compatible with all hardware.
+2. **secureblue Platform Key - WARNING: Not suitable for all devices.**
+   Your firmware will only trust secureblue. This offers improved security, but
+   this can BRICK YOUR DEVICE by breaking the display if your external GPU
+   requires an option ROM to work.
+    - A compatibility test will be added in a future version to determine
+      whether using a platform key is safe.
 
 In general, the Platform Key option is suitable for laptops, but not for
 desktops. However, modifying settings is entirely at your own risk, and you
@@ -77,6 +78,8 @@ defaults.
   `secureblue/uki/install.sh` and `secureblue/uki/keys/db/db.der` with
   `sha256sum`.
 - Start the installation: `sudo secureblue/uki/install.sh`
+- If using the Platform Key: run `ujust enroll-secure-boot-keys` after
+  installation.
 - Report any bugs to [secureblue's GitHub Issues page](https://github.com/secureblue/secureblue/issues).
 
 ## Making your own UKI build (advanced)

--- a/uki/install.sh
+++ b/uki/install.sh
@@ -12,11 +12,18 @@ github_repo_owner="secureblue"
 github_repo_name="secureblue"
 ghcr_tag="br-testing-44-uki"
 
-if [[ $(/usr/bin/id -u) -ne 0 ]]; then
-    echo "This script must be run as root."
+if [[ $(id -u) -ne 0 ]]; then
+    echo "The installer must be run as root."
     exit 1
 fi
 
+total_ram_kb=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
+if [[ "${total_ram_kb}" -lt 3800000 ]]; then
+    echo "The installer requires at least 4 GB of RAM."
+    exit 1
+fi
+
+# Select an image.
 valid_images=(
     silverblue-main-hardened
     kinoite-main-hardened
@@ -25,6 +32,7 @@ valid_images=(
     iot-main-hardened
     securecore-main-hardened
 )
+clear
 echo "Choose an image to install:"
 printf -- "- %s\n" "${valid_images[@]}"
 read -r -p "Enter a full image name: " ghcr_image
@@ -89,8 +97,8 @@ full_ref=$(crane digest --full-ref "${image_ref}")
 slsa-verifier verify-image --source-uri "github.com/${github_repo_owner}/${github_repo_name}" "${full_ref}"
 
 # Partition the disk.
-esp_uuid=$(uuidgen)
-root_uuid=$(uuidgen)
+esp_uuid=$(systemd-id128 new --uuid)
+root_uuid=$(systemd-id128 new --uuid)
 mkdir -p /run/repart.d
 cat > /run/repart.d/01-esp.conf << EOF
 [Partition]
@@ -109,7 +117,9 @@ SizeMinBytes=20G
 Encrypt=key-file
 EOF
 
+clear
 lsblk
+echo
 echo "Choose a disk to install to, e.g. /dev/vda, /dev/sda or /dev/nvme0n1."
 echo "This will erase the disk."
 read -r -p "Enter disk: " disk
@@ -118,6 +128,7 @@ if [[ ! -b "${disk}" ]] || [[ $(lsblk -ndo TYPE "${disk}") != "disk" ]]; then
     exit 1
 fi
 
+echo
 echo "Choose a LUKS encryption password."
 read -r -s -p "Password: " password && echo
 read -r -s -p "Confirm: " password2 && echo
@@ -131,8 +142,13 @@ fi
 unset password password2
 
 cleanup() {
-    rm -f "${keyfile}"
-    umount /var/lib/containers/storage/ || true
+    # Clean up /tmp, swap, then /mnt/tmp, then unmount everything else.
+    rm -rf /tmp/*
+    mount -o remount,size=1G /tmp
+    swapoff /mnt/tmp/swap/swapfile || true
+    umount /var/lib/containers/storage || true
+    rm -rf /mnt/tmp
+    sync
     umount /mnt/boot/ || true
     umount /mnt/ || true
     cryptsetup close root || true
@@ -148,16 +164,35 @@ mount /dev/mapper/root /mnt/
 mkdir /mnt/boot/
 mount "/dev/disk/by-partuuid/${esp_uuid}" /mnt/boot/
 
-# Pull the image.
-mount -t tmpfs -o size=10240M containers /var/lib/containers/storage/
+# Use /mnt/tmp as a temporary download location, rather than using RAM.
+mkdir -p /mnt/tmp/storage
+mount --bind /mnt/tmp/storage /var/lib/containers/storage
 chcon "system_u:object_r:container_var_lib_t:s0" /var/lib/containers/storage
+mkdir /mnt/tmp/tmp
+export TMPDIR=/mnt/tmp/tmp
+mkdir /mnt/tmp/swap
+chattr +C /mnt/tmp/swap
+fallocate -l 4G /mnt/tmp/swap/swapfile
+chmod 0600 /mnt/tmp/swap/swapfile
+mkswap /mnt/tmp/swap/swapfile
+swapon /mnt/tmp/swap/swapfile
+mount -o remount,size=8G /tmp
+mkdir /mnt/tmp/empty
+
+# Pull the image.
+clear
+echo "Downloading secureblue..."
 podman pull "${full_ref}"
 
 # Perform the installation.
+clear
+echo "Installing secureblue, this may take some time..."
 podman run --rm --privileged --pid=host --ipc=host \
     --security-opt label=type:unconfined_t \
-    -v /var/lib/containers:/var/lib/containers -v /dev:/dev \
+    -v /var/lib/containers:/var/lib/containers \
+    -v /dev:/dev \
     -v /:/run/host \
+    -v /mnt/tmp/empty:/run/host/mnt/tmp \
     -v "/etc/pki/containers/${github_repo_owner}.pub:/etc/pki/containers/${github_repo_owner}.pub:ro" \
     -v /etc/containers/policy.json:/etc/containers/policy.json:ro \
     "${full_ref}" \
@@ -198,17 +233,40 @@ EOF
 mkdir -p "${etc_dir}/systemd/system/local-fs.target.wants"
 ln -s /etc/systemd/system/boot.mount "${etc_dir}/systemd/system/local-fs.target.wants/boot.mount"
 
+# Create user.
+clear
+echo "Enter the details of your login account. It will be added to the admin (wheel) group."
+echo "You should NOT choose a system username, like 'root' or 'admin'."
+echo "Your password will be set to 'secureblue'. You must change it after logging in."
+echo
+read -r -p "Username: " username
+password=$(openssl passwd -6 "secureblue")
+last_changed=$(( $(date +%s) / 86400 ))
+echo "${username}:x:1000:1000:${username}:/var/home/${username}:/bin/bash" >> "${etc_dir}/passwd"
+echo "${username}:${password}:${last_changed}:0:99999:7:::" >> "${etc_dir}/shadow"
+echo "${username}:x:1000:" >> "${etc_dir}/group"
+sed -i "s/^wheel:x:10:$/&${username}/" "${etc_dir}/group"
+var_dir="/mnt/state/os/default/var"
+mkdir -p "${var_dir}/home/${username}/"
+cp -a "${etc_dir}/skel/." "${var_dir}/home/${username}/"
+chown -R 1000:1000 "${var_dir}/home/${username}"
+chmod 0700 "${var_dir}/home/${username}"
+
 # Optionally install shim.
-cat << EOF
+clear
+cat << 'EOF'
 Choose a secure boot option:
+
 1. shim - Safe for all devices.
    Your firmware must trust the Microsoft Third Party CA, which signs many
    bootloaders and ROMs. This greatly increases attack surface but is compatible
    with all hardware.
-2. secureblue Platform Key - Suitable for some devices.
+
+2. secureblue Platform Key - WARNING: Not suitable for all devices.
    Your firmware will only trust secureblue. This offers improved security, but
    this can BRICK YOUR DEVICE by breaking the display if your external GPU
    requires an option ROM to work.
+
 EOF
 read -r -p "Choose an option (1 or 2): " secure_boot
 if [[ "${secure_boot}" != "2" ]]; then
@@ -231,18 +289,34 @@ if [[ "${secure_boot}" != "2" ]]; then
     mv /mnt/boot/EFI/systemd/systemd-bootx64.efi /mnt/boot/EFI/fedora/grubx64.efi
     rmdir /mnt/boot/EFI/systemd
     # We need to import the key that signed systemd-boot.
-    printf "secureblue\nsecureblue\n" | mokutil --import keys/db/db.der
+    printf "secureblue\nsecureblue\n" | mokutil --import keys/db/db.der > /dev/null
 fi
 
-sync
+cleanup
 
 # Reboot the system.
+clear
+cat << EOF
+Installation is finished.
+
+Username: ${username}
+Password: secureblue
+
+EOF
 if [[ "${secure_boot}" == "1" ]]; then
-    echo "Installation is finished. When the system reboots, you need to choose"
-    echo "\"Enroll MOK\" and enter \"secureblue\" as the password."
+cat << EOF
+When the system reboots, you need to choose "Enroll MOK" and enter "secureblue"
+as the password.
+EOF
 else
-    echo "Installation is finished. Make sure your device is in Setup Mode by deleting"
-    echo "the Secure Boot Platform Key in your UEFI settings."
+cat << 'EOF'
+After logging in, you must run `ujust enroll-secure-boot-key` to finish setting
+up secure boot.
+
+Make sure your device is in Setup Mode first by deleting the Platform Key in
+your UEFI settings.
+
+EOF
 fi
-read -r -p "Press enter to reboot."
+read -r -p "Press enter to reboot or Ctrl+C to exit to terminal."
 systemctl reboot

--- a/uki/install.sh
+++ b/uki/install.sh
@@ -12,18 +12,18 @@ github_repo_owner="secureblue"
 github_repo_name="secureblue"
 ghcr_tag="br-testing-44-uki"
 
+# Check prerequisites.
 if [[ $(id -u) -ne 0 ]]; then
     echo "The installer must be run as root."
     exit 1
 fi
-
 total_ram_kb=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
 if [[ "${total_ram_kb}" -lt 3800000 ]]; then
     echo "The installer requires at least 4 GB of RAM."
     exit 1
 fi
 
-# Select an image.
+# Ask the user to select an image.
 valid_images=(
     silverblue-main-hardened
     kinoite-main-hardened
@@ -49,9 +49,10 @@ if [[ "${valid}" -ne 1 ]]; then
 fi
 image_ref="ghcr.io/${github_repo_owner}/${ghcr_image}:${ghcr_tag}"
 
-# The CoreOS installer has a permissive container policy by default.
+# The CoreOS installer has a permissive container policy by default. We modify
+# it to verify the cosign signature of the selected image.
 mkdir -p /etc/pki/containers
-cp ../cosign.pub "/etc/pki/containers/${github_repo_owner}.pub"
+cp ../cosign.pub "/etc/pki/containers/secureblue.pub"
 cat > /etc/containers/policy.json << EOF
 {
     "default": [{"type": "reject"}],
@@ -60,7 +61,7 @@ cat > /etc/containers/policy.json << EOF
             "ghcr.io/${github_repo_owner}": [
                 {
                     "type": "sigstoreSigned",
-                    "keyPath": "/etc/pki/containers/${github_repo_owner}.pub",
+                    "keyPath": "/etc/pki/containers/secureblue.pub",
                     "signedIdentity": {"type": "matchRepository"}
                 }
             ]
@@ -92,11 +93,11 @@ echo "${crane_sha256}  ${crane_tarball}" | sha256sum -c -
 tar -xzf "${crane_tarball}" -C /usr/local/bin crane
 rm -f "${crane_tarball}"
 
-# Get digest and verify provenance.
+# Get digest of selected image and verify provenance.
 full_ref=$(crane digest --full-ref "${image_ref}")
 slsa-verifier verify-image --source-uri "github.com/${github_repo_owner}/${github_repo_name}" "${full_ref}"
 
-# Partition the disk.
+# Create the configuration for systemd-repart to partition the disk.
 esp_uuid=$(systemd-id128 new --uuid)
 root_uuid=$(systemd-id128 new --uuid)
 mkdir -p /run/repart.d
@@ -113,10 +114,11 @@ cat > /run/repart.d/02-sysroot.conf << EOF
 Type=root
 Format=btrfs
 UUID=${root_uuid}
-SizeMinBytes=20G
+SizeMinBytes=28G
 Encrypt=key-file
 EOF
 
+# Display available block devices and ask the user to select one.
 clear
 lsblk
 echo
@@ -128,6 +130,7 @@ if [[ ! -b "${disk}" ]] || [[ $(lsblk -ndo TYPE "${disk}") != "disk" ]]; then
     exit 1
 fi
 
+# Ask the user for a LUKS encryption password for FDE on the root partition.
 echo
 echo "Choose a LUKS encryption password."
 read -r -s -p "Password: " password && echo
@@ -141,45 +144,59 @@ else
 fi
 unset password password2
 
+# Trap to clean up mounts that we set up later.
 cleanup() {
-    # Clean up /tmp, swap, then /mnt/tmp, then unmount everything else.
+    rm -f "${keyfile}"
+    # We expand /tmp to 8G later, so we need to clear it then shrink it to avoid
+    # OOMing when the swapfile is disabled.
     rm -rf /tmp/*
     mount -o remount,size=1G /tmp
+    # Disable the swapfile.
     swapoff /mnt/tmp/swap/swapfile || true
+    # Delete the swapfile, TMPDIR and container storage created on the disk.
     umount /var/lib/containers/storage || true
     rm -rf /mnt/tmp
+    # Now clean up remaining mounts.
     sync
     umount /mnt/boot/ || true
     umount /mnt/ || true
     cryptsetup close root || true
 }
 trap cleanup EXIT
-systemd-repart --dry-run=no --empty=force "--key-file=${keyfile}" "${disk}"
+
+# Partition the installation disk. Try twice.
+systemd-repart --dry-run=no --empty=force "--key-file=${keyfile}" "${disk}" || \
+    systemd-repart --dry-run=no --empty=force "--key-file=${keyfile}" "${disk}"
 udevadm settle
 sleep 1
 
-# Mount the partitions.
+# Mount the installation partitions to /mnt and /mnt/boot.
 cryptsetup open "--key-file=${keyfile}" "/dev/disk/by-partuuid/${root_uuid}" root
 mount /dev/mapper/root /mnt/
 mkdir /mnt/boot/
 mount "/dev/disk/by-partuuid/${esp_uuid}" /mnt/boot/
 
-# Use /mnt/tmp as a temporary download location, rather than using RAM.
+# To reduce the RAM requirement, we can use the installation disk for temporary
+# storage in /mnt/tmp, and clean it up afterwards.
+# Use the disk for container storage for podman (for the downloaded image).
 mkdir -p /mnt/tmp/storage
 mount --bind /mnt/tmp/storage /var/lib/containers/storage
 chcon "system_u:object_r:container_var_lib_t:s0" /var/lib/containers/storage
+# During the download of the image, a large $TMPDIR is needed.
 mkdir /mnt/tmp/tmp
 export TMPDIR=/mnt/tmp/tmp
+# To provide additional buffer, create a 4G swapfile on the disk.
 mkdir /mnt/tmp/swap
 chattr +C /mnt/tmp/swap
 fallocate -l 4G /mnt/tmp/swap/swapfile
 chmod 0600 /mnt/tmp/swap/swapfile
 mkswap /mnt/tmp/swap/swapfile
 swapon /mnt/tmp/swap/swapfile
+# With the swap space, we can expand the /tmp tmpfs to 8G as well.
 mount -o remount,size=8G /tmp
 mkdir /mnt/tmp/empty
 
-# Pull the image.
+# Pull the secureblue image.
 clear
 echo "Downloading secureblue..."
 podman pull "${full_ref}"
@@ -187,13 +204,15 @@ podman pull "${full_ref}"
 # Perform the installation.
 clear
 echo "Installing secureblue, this may take some time..."
+# We need to mask /mnt/tmp with an empty directory, as bootc validates that
+# the installation target only contains mountpoints.
 podman run --rm --privileged --pid=host --ipc=host \
     --security-opt label=type:unconfined_t \
-    -v /var/lib/containers:/var/lib/containers \
-    -v /dev:/dev \
     -v /:/run/host \
+    -v /dev:/dev \
     -v /mnt/tmp/empty:/run/host/mnt/tmp \
-    -v "/etc/pki/containers/${github_repo_owner}.pub:/etc/pki/containers/${github_repo_owner}.pub:ro" \
+    -v /var/lib/containers:/var/lib/containers \
+    -v "/etc/pki/containers/secureblue.pub:/etc/pki/containers/secureblue.pub:ro" \
     -v /etc/containers/policy.json:/etc/containers/policy.json:ro \
     "${full_ref}" \
     bootc install to-filesystem \
@@ -202,14 +221,16 @@ podman run --rm --privileged --pid=host --ipc=host \
         --bootloader=systemd --composefs-backend --skip-finalize \
         /run/host/mnt/
 
-# Configure systemd-boot timeout.
+# Configure systemd-boot on the target system to give a GRUB-like menu to select
+# the desired bootc deployment (e.g. for rollback).
 sed -i 's/#timeout 3/timeout 3/' /mnt/boot/loader/loader.conf
 
-# Add boot.mount (systemd-gpt-auto-generator doesn't work with composefs+LUKS).
-# In future, something like Anaconda will do all of this.
+# Configure /boot (boot.mount) on the target system. systemd-gpt-auto-generator
+# can't automatically do this with composefs+LUKS, so we do it manually.
 etc_dirs=(/mnt/state/deploy/*/etc)
 if [[ ${#etc_dirs[@]} -ne 1 ]]; then
     echo "Expected only one deployment, found ${#etc_dirs[@]}."
+    echo "This is a bug! Report to https://github.com/secureblue/secureblue/issues."
     exit 1
 fi
 etc_dir=${etc_dirs[0]}
@@ -233,19 +254,25 @@ EOF
 mkdir -p "${etc_dir}/systemd/system/local-fs.target.wants"
 ln -s /etc/systemd/system/boot.mount "${etc_dir}/systemd/system/local-fs.target.wants/boot.mount"
 
-# Create user.
+# Create the login user on the target system.
 clear
-echo "Enter the details of your login account. It will be added to the admin (wheel) group."
-echo "You should NOT choose a system username, like 'root' or 'admin'."
-echo "Your password will be set to 'secureblue'. You must change it after logging in."
-echo
+cat << EOF
+Enter the details of your login account. It will be added to the wheel group.
+You should NOT choose a system username, like 'root' or 'admin'.
+Your password will be set to 'secureblue'. You must change it after logging in.
+
+EOF
 read -r -p "Username: " username
+# We use a hardcoded password because yescrypt isn't available here, only
+# SHA512, so the user will have to change it themselves after firstrun.
 password=$(openssl passwd -6 "secureblue")
 last_changed=$(( $(date +%s) / 86400 ))
 echo "${username}:x:1000:1000:${username}:/var/home/${username}:/bin/bash" >> "${etc_dir}/passwd"
 echo "${username}:${password}:${last_changed}:0:99999:7:::" >> "${etc_dir}/shadow"
+# Now add the user to the wheel group.
 echo "${username}:x:1000:" >> "${etc_dir}/group"
 sed -i "s/^wheel:x:10:$/&${username}/" "${etc_dir}/group"
+# Create their home directory using /etc/skel and set correct permissions.
 var_dir="/mnt/state/os/default/var"
 mkdir -p "${var_dir}/home/${username}/"
 cp -a "${etc_dir}/skel/." "${var_dir}/home/${username}/"
@@ -276,25 +303,29 @@ if [[ "${secure_boot}" != "2" ]]; then
     shim_dirs=(/usr/lib/efi/shim/*/EFI)
     if [[ ${#shim_dirs[@]} -ne 1 ]]; then
         echo "Expected only one shim installation, found ${#shim_dirs[@]}."
+        echo "This is a bug! Report to https://github.com/secureblue/secureblue/issues."
         exit 1
     fi
     shim_dir=${shim_dirs[0]}
-    # BOOT/{BOOTX64.EFI, fbx64.efi, etc.}
+
+    # Install shim.
+    # Install the shim EFI binaries.
     cp "${shim_dir}"/BOOT/* /mnt/boot/EFI/BOOT/
-    # fedora/{shim.efi, shimx64.efi, BOOTX64.CSV, mmx64.efi, etc.}
     cp -r "${shim_dir}"/fedora /mnt/boot/EFI/
-    # Put MokManager in BOOT/.
+    # mmx64.efi is MokManager, and we want it to run by default.
     cp "${shim_dir}"/fedora/mmx64.efi /mnt/boot/EFI/BOOT/
     # Rename systemd-boot to grubx64.efi as this is hardcoded into shim.
     mv /mnt/boot/EFI/systemd/systemd-bootx64.efi /mnt/boot/EFI/fedora/grubx64.efi
     rmdir /mnt/boot/EFI/systemd
-    # We need to import the key that signed systemd-boot.
+    # systemd-boot was signed with the secureblue MOK, so that needs to be
+    # imported before first boot.
     printf "secureblue\nsecureblue\n" | mokutil --import keys/db/db.der > /dev/null
 fi
 
+# Everything succeeded, so clean up now to delete /mnt/tmp before firstrun.
 cleanup
 
-# Reboot the system.
+# Display instructions and reboot the system.
 clear
 cat << EOF
 Installation is finished.
@@ -307,6 +338,7 @@ if [[ "${secure_boot}" == "1" ]]; then
 cat << EOF
 When the system reboots, you need to choose "Enroll MOK" and enter "secureblue"
 as the password.
+
 EOF
 else
 cat << 'EOF'

--- a/uki/install.sh
+++ b/uki/install.sh
@@ -52,7 +52,7 @@ image_ref="ghcr.io/${github_repo_owner}/${ghcr_image}:${ghcr_tag}"
 # The CoreOS installer has a permissive container policy by default. We modify
 # it to verify the cosign signature of the selected image.
 mkdir -p /etc/pki/containers
-cp ../cosign.pub "/etc/pki/containers/secureblue.pub"
+cp ../cosign.pub /etc/pki/containers/secureblue.pub
 cat > /etc/containers/policy.json << EOF
 {
     "default": [{"type": "reject"}],
@@ -115,7 +115,6 @@ Type=root
 Format=btrfs
 UUID=${root_uuid}
 SizeMinBytes=28G
-Encrypt=key-file
 EOF
 
 # Display available block devices and ask the user to select one.
@@ -132,21 +131,25 @@ fi
 
 # Ask the user for a LUKS encryption password for FDE on the root partition.
 echo
-echo "Choose a LUKS encryption password."
-read -r -s -p "Password: " password && echo
-read -r -s -p "Confirm: " password2 && echo
-if [[ "${password}" == "${password2}" ]]; then
-    keyfile=$(mktemp)
-    printf "%s" "${password}" > "${keyfile}"
-else
-    echo "Passwords do not match."
-    exit 1
+read -r -p "Would you like to configure disk encryption? [Y/n] " luks
+if [[ ! "${luks}" =~ ^[Nn] ]]; then
+    echo "Choose a LUKS encryption password."
+    read -r -s -p "Password: " password && echo
+    read -r -s -p "Confirm: " password2 && echo
+    if [[ "${password}" == "${password2}" ]]; then
+        keyfile=$(mktemp)
+        printf "%s" "${password}" > "${keyfile}"
+        unset password password2
+    else
+        echo "Passwords do not match."
+        exit 1
+    fi
+    echo "Encrypt=key-file" >> /run/repart.d/02-sysroot.conf
+    echo "KeyFile=${keyfile}" >> /run/repart.d/02-sysroot.conf
 fi
-unset password password2
 
 # Trap to clean up mounts that we set up later.
 cleanup() {
-    rm -f "${keyfile}"
     # We expand /tmp to 8G later, so we need to clear it then shrink it to avoid
     # OOMing when the swapfile is disabled.
     rm -rf /tmp/*
@@ -165,14 +168,18 @@ cleanup() {
 trap cleanup EXIT
 
 # Partition the installation disk. Try twice.
-systemd-repart --dry-run=no --empty=force "--key-file=${keyfile}" "${disk}" || \
-    systemd-repart --dry-run=no --empty=force "--key-file=${keyfile}" "${disk}"
+systemd-repart --dry-run=no --empty=force "${disk}" || \
+    systemd-repart --dry-run=no --empty=force "${disk}"
 udevadm settle
 sleep 1
 
 # Mount the installation partitions to /mnt and /mnt/boot.
-cryptsetup open "--key-file=${keyfile}" "/dev/disk/by-partuuid/${root_uuid}" root
-mount /dev/mapper/root /mnt/
+if [[ ! "${luks}" =~ ^[Nn] ]]; then
+    cryptsetup open "--key-file=${keyfile}" "/dev/disk/by-partuuid/${root_uuid}" root
+    mount /dev/mapper/root /mnt/
+else
+    mount "/dev/disk/by-partuuid/${root_uuid}" /mnt/
+fi
 mkdir /mnt/boot/
 mount "/dev/disk/by-partuuid/${esp_uuid}" /mnt/boot/
 
@@ -192,8 +199,8 @@ fallocate -l 4G /mnt/tmp/swap/swapfile
 chmod 0600 /mnt/tmp/swap/swapfile
 mkswap /mnt/tmp/swap/swapfile
 swapon /mnt/tmp/swap/swapfile
-# With the swap space, we can expand the /tmp tmpfs to 8G as well.
-mount -o remount,size=8G /tmp
+# With the swap space, we can expand the /tmp tmpfs to 4G as well.
+mount -o remount,size=4G /tmp
 mkdir /mnt/tmp/empty
 
 # Pull the secureblue image.
@@ -278,6 +285,11 @@ mkdir -p "${var_dir}/home/${username}/"
 cp -a "${etc_dir}/skel/." "${var_dir}/home/${username}/"
 chown -R 1000:1000 "${var_dir}/home/${username}"
 chmod 0700 "${var_dir}/home/${username}"
+# We have to manually set the SELinux contexts, otherwise they'll be etc_t.
+chcon -R "unconfined_u:object_r:user_home_t:s0" "${var_dir}/home/${username}"
+chcon "unconfined_u:object_r:user_home_dir_t:s0" "${var_dir}/home/${username}"
+chcon -R "unconfined_u:object_r:config_home_t:s0" "${var_dir}/home/${username}/.config" || true
+chcon -R "unconfined_u:object_r:virt_home_t:s0" "${var_dir}/home/${username}/.config/libvirt" || true
 
 # Optionally install shim.
 clear
@@ -285,9 +297,9 @@ cat << 'EOF'
 Choose a secure boot option:
 
 1. shim - Safe for all devices.
-   Your firmware must trust the Microsoft Third Party CA, which signs many
-   bootloaders and ROMs. This greatly increases attack surface but is compatible
-   with all hardware.
+   However, your firmware must trust the Microsoft Third Party CA, which signs
+   many bootloaders and ROMs. This greatly increases attack surface but is
+   compatible with all hardware.
 
 2. secureblue Platform Key - WARNING: Not suitable for all devices.
    Your firmware will only trust secureblue. This offers improved security, but
@@ -311,9 +323,9 @@ if [[ "${secure_boot}" != "2" ]]; then
     # Install shim.
     # Install the shim EFI binaries.
     cp "${shim_dir}"/BOOT/* /mnt/boot/EFI/BOOT/
-    cp -r "${shim_dir}"/fedora /mnt/boot/EFI/
+    cp -r "${shim_dir}/fedora" /mnt/boot/EFI/
     # mmx64.efi is MokManager, and we want it to run by default.
-    cp "${shim_dir}"/fedora/mmx64.efi /mnt/boot/EFI/BOOT/
+    cp "${shim_dir}/fedora/mmx64.efi" /mnt/boot/EFI/BOOT/
     # Rename systemd-boot to grubx64.efi as this is hardcoded into shim.
     mv /mnt/boot/EFI/systemd/systemd-bootx64.efi /mnt/boot/EFI/fedora/grubx64.efi
     rmdir /mnt/boot/EFI/systemd
@@ -342,7 +354,7 @@ as the password.
 EOF
 else
 cat << 'EOF'
-After logging in, you must run `ujust enroll-secure-boot-key` to finish setting
+After logging in, you must run `ujust enroll-secure-boot-keys` to finish setting
 up secure boot.
 
 Make sure your device is in Setup Mode first by deleting the Platform Key in


### PR DESCRIPTION
- Drop RAM requirement from 16 GB to 4 GB for the UKI installer
  - Place a swap file, container layers, and temporary download files onto the target disk in a temporary directory, rather than in RAM.
  - Add a hard check that 3.8 GB is present.
- Create a new user on the target disk and adds it to the wheel group.
  - This allows COSMIC to work, and other desktop environments that don't show a setup wizard when no user is detected.
- Make UI clearer and clarify messaging for Platform Key.
- Add comments for code clarity.
- Make LUKS encryption optional.