### PR TITLE
fix(uki): free disk space unconditionally

### DIFF
--- a/.github/workflows/build-sealed-image.yml
+++ b/.github/workflows/build-sealed-image.yml
@@ -57,8 +57,6 @@ jobs:
 
       - name: "Free disk space"
         uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
 
       - name: "Check out repository"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
For some reason, the Kinoite sealed image build keeps failing:
```
error: Computing composefs digest: Reading container root: Reading container root: Ensuring object from file descriptor: Ensuring object from reader: No space left on device (os error 28)
```

https://github.com/secureblue/secureblue/actions/runs/31212949115/job/92999878876

Hopefully an extra 20 GB or so will help?