### PR TITLE
feat: Add session timeout to server images

### DIFF
--- a/files/system/server/etc/profile.d/bash-timeout.sh
+++ b/files/system/server/etc/profile.d/bash-timeout.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/bash
 
+# This sets the default idle timeout to 5 minutes.
+# If desired, users can set a different value in their .bashrc file.
+
 export TMOUT=300

--- a/files/system/server/etc/profile.d/bash-timeout.sh
+++ b/files/system/server/etc/profile.d/bash-timeout.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+export TMOUT=300


### PR DESCRIPTION
Closes: https://github.com/secureblue/secureblue/issues/2425

This sets the default idle timeout to 5 minutes. 
If desired, users can set a different value in their `.bashrc` file.