### PR TITLE
fix(uki): stop using tmpfs for /var/tmp

### DIFF
--- a/.github/workflows/build-sealed-image.yml
+++ b/.github/workflows/build-sealed-image.yml
@@ -55,6 +55,11 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: "Free disk space"
+        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
+        with:
+          skip-if-available: "64G"
+
       - name: "Check out repository"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/build-sealed-image.yml
+++ b/.github/workflows/build-sealed-image.yml
@@ -55,9 +55,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: "Free disk space"
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-
       - name: "Check out repository"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/uki/Containerfile.uki
+++ b/uki/Containerfile.uki
@@ -39,7 +39,6 @@ COPY --from=kernel /vmlinuz /vmlinuz
 COPY --from=initramfs /initramfs /initramfs
 RUN --mount=type=tmpfs,target=/run \
     --mount=type=tmpfs,target=/tmp \
-    --mount=type=tmpfs,target=/var/tmp \
     --mount=type=secret,id=secureboot_key \
     --mount=type=secret,id=secureboot_crt \
     --mount=type=bind,from=rootfs,src=/,target=/run/target,ro \


### PR DESCRIPTION
This fixes the ENOSPC during the Kinoite UKI build:
```
++ bootc container compute-composefs-digest /run/target
error: Computing composefs digest: Reading container root: Reading container root: Ensuring object from file descriptor: Ensuring object from reader: No space left on device (os error 28)
```
The thing running out of space was a tmpfs (probably 8G in size), so not related to disk space exhaustion at all.

This PR switches to using disk instead of tmpfs, and switches to only running the free-disk-space action if less than 64G storage is available.