### PR TITLE
fix: Make set-flathub-unfiltered only check for user remotes

### DIFF
--- a/files/system/desktop/usr/libexec/secureblue/set_flathub_unfiltered.py
+++ b/files/system/desktop/usr/libexec/secureblue/set_flathub_unfiltered.py
@@ -42,7 +42,9 @@ ujust set-flathub-unfiltered --help
 
 
 def unfiltered_remote_enabled() -> bool:
-    remotes: list[str] = command_stdout("flatpak", "remotes", "--columns=url,subset").splitlines()
+    remotes: list[str] = command_stdout(
+        "flatpak", "remotes", "--user", "--columns=url,subset"
+    ).splitlines()
     flathub_urls: list[str] = ["https://dl.flathub.org/repo/", "https://dl.flathub.org/beta-repo/"]
 
     for remote in remotes:


### PR DESCRIPTION
`ujust set-flathub-unfiltered` checks for both user and system remotes, leading to issues with scripts like `ujust install-steam` to fail if the user previously added the unfiltered flathub remote at the system level because it is hardcoded to always install steam from a user remote. 

This change fixes that, ensuring the unfiltered flathub remote gets added even if the user previously added the system remote.