### PR TITLE
fix(uki): fix /etc backup in audit_environment_file

### DIFF
--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -982,7 +982,7 @@ def audit_environment_file():
     note = None
     rec = None
     try:
-        if not filecmp.cmp("/usr" + env_file, env_file):
+        if not filecmp.cmp("/usr/share/secureblue" + env_file, env_file):
             status = WARN
             note = Note(_("The file {0} has been modified.").format(env_file), WARN)
     except FileNotFoundError:


### PR DESCRIPTION
Fixes a bug on UKI images where `ujust audit-secureblue` reports that /etc/environment has been modified, even if it hasn't.

The cause was that the comparison was being made with the old `/usr/etc`, not `/usr/share/secureblue/etc`.