### PR TITLE
feat: use latest stable kernel version

### DIFF
--- a/files/scripts/installandsignkernel.sh
+++ b/files/scripts/installandsignkernel.sh
@@ -7,11 +7,18 @@
 
 set -euo pipefail
 
-KERNEL_VERSION="$(rpm -q 'kernel' --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+# Get latest stable Fedora kernel version and install corresponding secureblue kernel
+KERNEL_VERSION="$(dnf repoquery \
+    --repo 'updates' \
+    --latest-limit 1 \
+    --arch "${OS_ARCH}" \
+    --queryformat '%{version}-%{release}.%{arch}' \
+    'kernel'
+)"
 SECUREBLUE_KERNEL_VERSION="${KERNEL_VERSION/.fc/.secureblue.*.fc}"
 dnf install --repo "copr:copr.fedorainfracloud.org:secureblue:packages" "kernel-${SECUREBLUE_KERNEL_VERSION}" -y
 
-SECUREBLUE_NEW_KERNEL_VERSION="$(rpm -q 'kernel' --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+SECUREBLUE_NEW_KERNEL_VERSION="$(rpm -q 'kernel' --queryformat '%{version}-%{release}.%{arch}')"
 VMLINUZ_PATH="/usr/lib/modules/${SECUREBLUE_NEW_KERNEL_VERSION}/vmlinuz"
 PUBLIC_KEY_DER_PATH='../system/usr/share/pki/akmods/certs/akmods-secureblue.der'
 PUBLIC_KEY_CRT_PATH='./certs/public_key.crt'


### PR DESCRIPTION
Previously the installed secureblue kernel version was chosen to correspond to the Fedora kernel version installed in the base image. This changes it to always use the latest stable kernel version, which can be newer if a kernel update has been pushed to the Fedora stable repos since the last upstream image build.

Fixes #2506.