### PR TITLE
fix: clarify kmod toggle prompts

### DIFF
--- a/files/system/usr/libexec/secureblue/bluetooth_main.py
+++ b/files/system/usr/libexec/secureblue/bluetooth_main.py
@@ -66,7 +66,7 @@ def main() -> int:
 
     if len(sys.argv) == argc_interactive:
         # Ask interactively.
-        mode = "on" if ask_yes_no("Would you like to load the Bluetooth modules?") else "off"
+        mode = "on" if ask_yes_no("On boot, do you want the Bluetooth modules to load?") else "off"
     elif len(sys.argv) == argc_on_off:
         # Take mode from first argument, i.e. 'on' or 'off'.
         mode = sys.argv[1].casefold()

--- a/files/system/usr/libexec/secureblue/webcam_main.py
+++ b/files/system/usr/libexec/secureblue/webcam_main.py
@@ -66,7 +66,7 @@ def main() -> int:
 
     if len(sys.argv) == argc_interactive:
         # Ask interactively.
-        mode = "on" if ask_yes_no("Would you like to load the Webcam modules?") else "off"
+        mode = "on" if ask_yes_no("On boot, do you want the Webcam modules to load?") else "off"
     elif len(sys.argv) == argc_on_off:
         # Take mode from first argument, i.e. 'on' or 'off'.
         mode = sys.argv[1].casefold()


### PR DESCRIPTION
## Summary
- clarify that Bluetooth module selection applies on boot
- clarify that Webcam module selection applies on boot
- keep the existing toggle behavior unchanged

Fixes #2138

## Validation
- `uvx ruff check files/system/usr/libexec/secureblue/bluetooth_main.py files/system/usr/libexec/secureblue/webcam_main.py`
- Python AST parse and exact prompt assertions for both `ask_yes_no` calls
- `git diff --check`