### PR TITLE
fix: don't skip sealed builds when triggered by github bot

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -44,7 +44,7 @@ jobs:
 
   silverblue-main-sealed:
     name: Build silverblue main sealed
-    if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
+    if: github.triggering_actor == 'royaloughtness' || github.triggering_actor == 'github-actions[bot]' || github.event_name == 'schedule' || github.event_name == 'push'
     needs: silverblue-main
     permissions:
       contents: read # Needed to pull the repo for the build
@@ -79,7 +79,7 @@ jobs:
 
   kinoite-main-sealed:
     name: Build kinoite main sealed
-    if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
+    if: github.triggering_actor == 'royaloughtness' || github.triggering_actor == 'github-actions[bot]' || github.event_name == 'schedule' || github.event_name == 'push'
     needs: kinoite-main
     permissions:
       contents: read # Needed to pull the repo for the build
@@ -114,7 +114,7 @@ jobs:
 
   sericea-main-sealed:
     name: Build sericea main sealed
-    if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
+    if: github.triggering_actor == 'royaloughtness' || github.triggering_actor == 'github-actions[bot]' || github.event_name == 'schedule' || github.event_name == 'push'
     needs: sericea-main
     permissions:
       contents: read # Needed to pull the repo for the build
@@ -149,7 +149,7 @@ jobs:
 
   cosmic-main-sealed:
     name: Build cosmic main sealed
-    if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
+    if: github.triggering_actor == 'royaloughtness' || github.triggering_actor == 'github-actions[bot]' || github.event_name == 'schedule' || github.event_name == 'push'
     needs: cosmic-main
     permissions:
       contents: read # Needed to pull the repo for the build
@@ -184,7 +184,7 @@ jobs:
 
   securecore-main-sealed:
     name: Build securecore main sealed
-    if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
+    if: github.triggering_actor == 'royaloughtness' || github.triggering_actor == 'github-actions[bot]' || github.event_name == 'schedule' || github.event_name == 'push'
     needs: securecore-main
     permissions:
       contents: read # Needed to pull the repo for the build
@@ -219,7 +219,7 @@ jobs:
 
   iot-main-sealed:
     name: Build iot main sealed
-    if: github.triggering_actor == 'royaloughtness' || github.event_name == 'schedule' || github.event_name == 'push'
+    if: github.triggering_actor == 'royaloughtness' || github.triggering_actor == 'github-actions[bot]' || github.event_name == 'schedule' || github.event_name == 'push'
     needs: iot-main
     permissions:
       contents: read # Needed to pull the repo for the build


### PR DESCRIPTION
These were missed during the rebase