### PR TITLE
feat: preinstall docker

### DIFF
--- a/.github/workflows/build-one-recipe.yml
+++ b/.github/workflows/build-one-recipe.yml
@@ -96,6 +96,7 @@ jobs:
             production.cloudfront.docker.com:443
             registry-1.docker.io:443
             auth.docker.io:443
+            download.docker.com:443
 
             # Negativo packages installation
             negativo17.org:443

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -73,6 +73,7 @@ jobs:
             production.cloudfront.docker.com:443
             registry-1.docker.io:443
             auth.docker.io:443
+            download.docker.com:443
 
             # Negativo packages installation
             negativo17.org:443

--- a/files/justfiles/common/utilities.just
+++ b/files/justfiles/common/utilities.just
@@ -108,30 +108,6 @@ toolbox-assemble CONTAINER="prompt" ACTION="create" FILE="/etc/toolbox/toolbox.i
     source /usr/lib/ujust/ujust.sh
     ToolboxAssembleList "{{ FILE }}" "{{ ACTION }}" "{{ CONTAINER }}"
 
-# Install the official Docker packages
-install-docker:
-    #!/usr/bin/run0 /bin/bash
-    set -euo pipefail
-    if [[ ! -f "/usr/bin/rpm-ostree" ]]; then
-        echo "Cannot layer packages on a UKI system. Try Podman, rootless Docker or a systemd-sysext instead."
-        exit 1
-    fi
-    sed -i -e '/^\[docker-ce-stable\]$/,/^\[/s/^enabled *= *0.*/enabled=1/' /etc/yum.repos.d/docker-ce.repo
-    rpm-ostree refresh-md
-    rpm-ostree install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
-# Uninstall the official Docker packages
-uninstall-docker:
-    #!/usr/bin/run0 /bin/bash
-    set -euo pipefail
-    if [[ ! -f "/usr/bin/rpm-ostree" ]]; then
-        echo "Cannot unlayer packages on a UKI system."
-        exit 1
-    fi
-    cp /usr/share/secureblue/etc/yum.repos.d/docker-ce.repo /etc/yum.repos.d/docker-ce.repo
-    rpm-ostree refresh-md
-    rpm-ostree uninstall docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
 # Rebase to a different secureblue Desktop Environment/Atomic Desktop
 rebase-secureblue:
     #!/usr/bin/bash

--- a/files/system/etc/yum.repos.d/docker-ce.repo
+++ b/files/system/etc/yum.repos.d/docker-ce.repo
@@ -1,7 +1,7 @@
 [docker-ce-stable]
 name=Docker CE Stable - $basearch
 baseurl=https://download.docker.com/linux/fedora/$releasever/$basearch/stable
-enabled=0
+enabled=1
 gpgcheck=1
 # gpgkey=https://download.docker.com/linux/fedora/gpg
 gpgkey=file:///usr/share/pki/rpm-gpg/docker-ce.gpg

--- a/files/system/usr/lib/systemd/system-preset/40-secureblue.preset
+++ b/files/system/usr/lib/systemd/system-preset/40-secureblue.preset
@@ -41,3 +41,6 @@ disable systemd-homed-firstboot.service
 disable systemd-homed.service
 disable systemd-resolved.service
 disable rpm-ostree-countme.timer
+
+disable docker.service
+disable docker.socket

--- a/files/system/usr/lib/sysusers.d/docker.conf
+++ b/files/system/usr/lib/sysusers.d/docker.conf
@@ -1,0 +1,1 @@
+g docker - -

--- a/recipes/common/common-packages.yml
+++ b/recipes/common/common-packages.yml
@@ -53,3 +53,10 @@ install:
     - qemu-user-binfmt
     - virt-install
     - podman-machine
+
+    - docker-ce
+    - docker-ce-cli
+    - docker-ce-rootless-extras
+    - containerd.io
+    - docker-buildx-plugin
+    - docker-compose-plugin

--- a/recipes/common/securecore-modules.yml
+++ b/recipes/common/securecore-modules.yml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+modules:
+  - type: dnf
+    source: ghcr.io/blue-build/modules@sha256:c5ed99f07b15c8d575a4fa64a77e5cd5602b00da4c84379f5675db2ae4757061
+    remove:
+      packages:
+        - moby-engine
+        - docker-cli

--- a/recipes/securecore/recipe-securecore-main.yml
+++ b/recipes/securecore/recipe-securecore-main.yml
@@ -18,6 +18,7 @@ platforms:
   - linux/arm64
 
 modules:
+  - from-file: common/securecore-modules.yml
   - from-file: common/common-modules.yml
   - from-file: common/server-modules.yml
   - from-file: common/selinux-modules.yml


### PR DESCRIPTION
Pre-installs rootful and rootless Docker, disabled by default, on UKI images.

On securecore, it first uninstalls `moby-engine` and `docker-cli` because these are preinstalled on CoreOS and conflict with the official Docker - they're identical/drop-in replacements, just with different branding for legal reasons. There should be no friction from the transition.