### PR TITLE
fix(uki): build module_blacklist=nouveau UKI addon

### DIFF
--- a/uki/scripts/sign-uki-addons.sh
+++ b/uki/scripts/sign-uki-addons.sh
@@ -21,6 +21,7 @@ addons=(
     "mem_encrypt=on"
     "oops=panic"
     "amdgpu.dcdebugmask=0x10" # https://invent.kde.org/kde-linux/kde-linux/-/merge_requests/431
+    "module_blacklist=nouveau"
 )
 # We need a UKI addon (karg or initrd) to get the right keyboard layout at the
 # LUKS screen. Taken from `localectl list-keymaps`, deduplicated with niche ones


### PR DESCRIPTION
Signs the `module_blacklist=nouveau` UKI addon for users with Nvidia cards who want to disable their dGPUs entirely.

`module_blacklist=` seems to be the modern, initrd-agnostic way of blocklisting kernel modules, even from explicit loading (e.g. with `insmod`). This should work like the dracut-specific way (`rd.driver.blacklist` + `modprobe.blocklist`) but be even more robust.

The downside is that it takes a comma-separated list, which isn't ideal for a UKI addon (we would have to sign each combination), but the alternative `modprobe.blocklist` has this problem too.