### PR TITLE
fix: Make the example.butane file import the secureboot key

### DIFF
--- a/docs/example.butane
+++ b/docs/example.butane
@@ -42,9 +42,33 @@ storage:
       contents:
         inline: |
           sudo systemctl disable --now zincati.service 2>/dev/null
+          sudo systemctl mask zincati.service 2>/dev/null
           sudo systemctl stop rpm-ostreed-automatic.timer rpm-ostreed-automatic.service 2>/dev/null
 
-          echo 'Rebasing to securecore (secureblue CoreOS image)...'
+          tmpdir="$(mktemp -d)"
+
+          curl -so "${tmpdir}/akmods-secureblue.der" \
+          https://raw.githubusercontent.com/secureblue/secureblue/refs/heads/live/files/system/usr/share/pki/akmods/certs/akmods-secureblue.der
+
+          expected_checksum="fb8491059eabecf332f6a9e01e3aa35f0832f2f4d43df3f6f5ce2dfdac0ba9a8"
+          found_checksum="$(sha256sum "${tmpdir}"/akmods-secureblue.der | awk '{print $1}')"
+
+          if [ "${found_checksum}" != "${expected_checksum}" ]; then
+              echo "Error: Mismatched checksums."
+              echo "Expected: ${expected_checksum}"
+              echo "Found: ${found_checksum}"
+              echo "Please report this on the official Discord server or GitHub repo."
+              rm -rf "${tmpdir}"
+              exit 1
+          else
+              sudo mokutil --timeout -1
+              echo 'The next line will prompt for a MOK password. Input "secureblue".'
+              sudo mokutil --import "${tmpdir}"/akmods-secureblue.der
+              echo "At next reboot, the mokutil UEFI menu UI will be displayed (*QWERTY* keyboard input and navigation)."
+              echo 'Then, select "Enroll MOK", and input "secureblue" as the password.'
+          fi
+
+          echo "Rebasing to securecore (secureblue CoreOS image)..."
 
           # If you want Nvidia or ZFS support, replace 'securecore-main-hardened' below with
           # the name of the image you want. See here for a list of securecore images:
@@ -52,9 +76,9 @@ storage:
           sudo rpm-ostree rebase ostree-image-signed:docker://ghcr.io/secureblue/securecore-main-hardened:latest
           status=$?
 
-          if [ "$status" -ne 0 ]; then
-            echo "Error: Secureblue installation failed." >&2
-            exit "$status"
+          if [ "${status}" -ne 0 ]; then
+            echo "Error: secureblue installation failed." >&2
+            exit "${status}"
           else
             sudo cp /usr/share/secureblue/etc/containers/policy.json /etc/containers/policy.json
             sed -i -e '/\/opt\/install_secureblue.sh/d' /var/home/core/.bash_profile

--- a/docs/example.butane
+++ b/docs/example.butane
@@ -57,7 +57,7 @@ storage:
               echo "Error: Mismatched checksums."
               echo "Expected: ${expected_checksum}"
               echo "Found: ${found_checksum}"
-              echo "Please report this on the official Discord server or GitHub repo."
+              echo "Please open a GitHub issue reporting this finding."
               rm -rf "${tmpdir}"
               exit 1
           else


### PR DESCRIPTION
Closes: #2512

Should be merged at the same time as:  https://github.com/secureblue/secureblue.dev/pull/399