### PR TITLE
chore: Remove check for signed image in securebluecleanup

### DIFF
--- a/files/system/usr/libexec/secureblue/securebluecleanup
+++ b/files/system/usr/libexec/secureblue/securebluecleanup
@@ -29,16 +29,3 @@ then
     flatpak remote-delete --user --force flathub || true
     flatpak remove --system --noninteractive --all || true
 fi
-
-# Ensure we are on signed
-RPM_OSTREE_STATUS=$(rpm-ostree status --json --booted)
-IMAGE_BASE_STRING=$(echo "${RPM_OSTREE_STATUS}" | jq -r '.deployments[0]."container-image-reference" // empty')
-echo "Current image base: ${IMAGE_BASE_STRING}"
-if [[ "${IMAGE_BASE_STRING}" == *"ostree-image-signed"* ]]; then
-    echo "Already on signed. Exiting..."
-    exit 0
-fi
-
-IMAGE_REF_NAME=${IMAGE_BASE_STRING##*/}
-echo "Rebasing to ${IMAGE_REF_NAME}"
-rpm-ostree rebase "ostree-image-signed:docker://ghcr.io/secureblue/${IMAGE_REF_NAME}"


### PR DESCRIPTION
Vestige from before we had installation ISOs.

Fails on bootc systems, causing the service to never create the stamp and re-run repeatedly, reverting the user's changes to authselect and Flatpak remotes.