### PR TITLE
feat: secureblue-priv-cmd service to run selected commands

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -37,29 +37,31 @@ jobs:
         run: |
           tmpfile=$(mktemp)
           cat <<'EOF' > "${tmpfile}"
-          pip==26.1.1 \
-            --hash=sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb
+          pip==26.2.1 \
+            --hash=sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e
 
-          blessed==1.42.0 \
-            --hash=sha256:f96c4a6dc664b48e0b832fa732acc16df67abd30f0ec35babf99025982f21852
+          blessed==1.48.0 \
+            --hash=sha256:c4ce01cba220f41d2ff244e9829cb4ef2390a26ace8ce1687b8bced1613676e5
+          dbus_fast==2.46.4 \
+            --hash=sha256:018c7d878857599e3478c56575aa2ed9ff52eb7a88c5118685db8e033b3916e9
           editor==1.8.0 \
             --hash=sha256:7d47ff88ae6c5f6c43d28c30b6f7fd59a24741175a1771ab06c969d946d7dfd0
           inquirer==3.4.1 \
             --hash=sha256:717bf146d547b595d2495e7285fd55545cff85e5ce01decc7487d2ec6a605412
-          jinxed==2.0.0 \
-            --hash=sha256:b3df1be5262a37145ef42875a8bbf918f1a563fbd035359650dd9fc0bb2b9294
+          jinxed==2.1.0 \
+            --hash=sha256:43b802d18b70e405d410fb66eb2837d1101e7e5ea922e666507bb43f34d11d09
           readchar==4.2.2 \
             --hash=sha256:92daf7e42c52b0787e6c75d01ecfb9a94f4ceff3764958b570c1dddedd47b200
           rpm==0.4.0 \
             --hash=sha256:0ef697cb5fb73bf9300a13d423529d7ec215239bf95c5ecb145e6610645f6067
-          ruff==0.15.14 \
-            --hash=sha256:715c543cf450c4888251f91c52f1942a800541d9bddd7ac060aa4e6b77ae7cba
+          ruff==0.16.3 \
+            --hash=sha256:294b95c4ae0cda9388525c2047778aa758d6b8d4bb876fd4e9eaa3ebc92343eb
           runs==1.3.0 \
             --hash=sha256:e71a551cfa8da9ef882cac1d5a108bda78c9edee5b8d87e37c1003da5b6a7bed
-          ty==0.0.38 \
-            --hash=sha256:375d3a964c6b4aea2e9237fdb5eb9ed03dc43088986a94209a28a4ea3b62001c
-          wcwidth==0.7.0 \
-            --hash=sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2
+          ty==0.0.72 \
+            --hash=sha256:802c5970a77d7739e6f499921fbb6984fb7ad8a31d95e1ff42fd46f3642e4f3b
+          wcwidth==0.8.2 \
+            --hash=sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85
           xmod==1.10.0 \
             --hash=sha256:bebf8493b7ac63097401590a329c9ed20da224de0583a522e7ccb634af122f5a
           EOF

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/files/justfiles/common/wrappers.just
+++ b/files/justfiles/common/wrappers.just
@@ -7,6 +7,11 @@
 @audit-secureblue *args:
     exec /usr/bin/python3 /usr/libexec/secureblue/audit_secureblue.py "$@"
 
+# Get bootc status
+[positional-arguments]
+@bootc-status:
+    exec /usr/libexec/secureblue/secureblue-priv-cmd bootc-status
+
 # Run a non-flatpak application with standard memory allocator
 [no-cd]
 [no-exit-message]

--- a/files/scripts/installselinuxpolicies.sh
+++ b/files/scripts/installselinuxpolicies.sh
@@ -10,7 +10,7 @@ selinux_policy_version="$(rpm -q --qf '%{version}-%{release}' selinux-policy)"
 dnf install -y --setopt=install_weak_deps=False --enable-repo=updates-archive \
     "selinux-policy-devel-${selinux_policy_version}"
 
-policy_modules=(flatpakfull nautilus systemsettings thunar)
+policy_modules=(flatpakfull nautilus secureblue-misc systemsettings thunar)
 
 cil_policy_modules=(
     './selinux/flatpakfull/grant_systemd_flatpak_exec.cil'

--- a/files/scripts/selinux/secureblue-misc/secureblue-misc.fc
+++ b/files/scripts/selinux/secureblue-misc/secureblue-misc.fc
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: NONE
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# This file left intentionally blank

--- a/files/scripts/selinux/secureblue-misc/secureblue-misc.if
+++ b/files/scripts/selinux/secureblue-misc/secureblue-misc.if
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: NONE
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# This file left intentionally blank

--- a/files/scripts/selinux/secureblue-misc/secureblue-misc.te
+++ b/files/scripts/selinux/secureblue-misc/secureblue-misc.te
@@ -1,0 +1,18 @@
+policy_module(secureblue-misc, 1.0.0)
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+# This policy module is for miscellaneous policy fixes not yet added upstream.
+
+# Fixes https://github.com/fedora-selinux/selinux-policy/issues/3349
+# Remove after this change makes it into an upstream release:
+# https://github.com/fedora-selinux/selinux-policy/pull/3350
+optional_policy(`
+	gen_require(`
+		type unconfined_service_t;
+		role system_r;
+	')
+	anaconda_run_install(unconfined_service_t, system_r)
+')

--- a/files/scripts/selinux/systemsettings/systemsettings.te
+++ b/files/scripts/selinux/systemsettings/systemsettings.te
@@ -36,7 +36,7 @@ optional_policy(`
 	allow trivalent_domain systemsettings_t:fifo_file write;
 ')
 
-# Required for accountsd to access systemsettings's tmp file.
+# Required for accountsd to access systemsettings tmp file.
 # Otherwise, changing a user profile photo will fail.
 optional_policy(`
 	gen_require(`

--- a/files/system/usr/lib/systemd/system/secureblue-priv-cmd-daemon.service
+++ b/files/system/usr/lib/systemd/system/secureblue-priv-cmd-daemon.service
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[Unit]
+Description=Allows secureblue users to run selected privileged commands
+
+[Service]
+Type=dbus
+BusName=dev.secureblue.PrivCmd0
+ExecStart=/usr/bin/python3 /usr/libexec/secureblue/priv-cmd/daemon.py

--- a/files/system/usr/libexec/secureblue/priv-cmd/client.py
+++ b/files/system/usr/libexec/secureblue/priv-cmd/client.py
@@ -1,0 +1,140 @@
+#!/usr/bin/python3
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Client-side of secureblue-priv-cmd command-line program. Allows unprivileged
+users to invoke various commands as root.
+"""
+
+import asyncio
+import errno
+import sys
+from typing import Final
+
+from dbus_fast import BusType, DBusError
+from dbus_fast.aio import MessageBus, ProxyInterface
+from dbus_fast.introspection import Node
+
+DBUS_NAME: Final[str] = "dev.secureblue.PrivCmd0"
+DBUS_PATH: Final[str] = "/dev/secureblue/PrivCmd0"
+DBUS_INTERFACE: Final[str] = "dev.secureblue.PrivCmd0"
+
+PROGRAM_NAME: Final[str] = sys.argv[0].rsplit("/", maxsplit=1)[-1]
+HELP_MESSAGE: Final[str] = f"""\
+Allows unprivileged users to run specific privileged commands as root via a
+DBus-activated service.
+
+usage:
+{PROGRAM_NAME} bootc-status
+    Run `bootc status`.
+{PROGRAM_NAME} bootc-upgrade
+    Run `bootc upgrade`.
+{PROGRAM_NAME} bootc-upgrade-check
+    Run `bootc upgrade --check`.
+{PROGRAM_NAME} semodule-list
+    Run `semodule -l`.
+{PROGRAM_NAME} --help
+    Print this message.
+"""
+
+
+def print_error(msg: str) -> None:
+    print(f"{PROGRAM_NAME}: {msg}", file=sys.stderr)
+
+
+async def _print_lines(pty_fd: int) -> None:
+    with open(pty_fd, encoding="utf8") as pty:
+        try:
+            for line in pty:
+                print(line, end="")
+        except OSError as err:
+            # EIO ("I/O error") is expected when the other end of the pty is closed
+            if err.errno != errno.EIO:
+                raise
+
+
+class CommandHandler:
+    child_exited_event: asyncio.Event
+    pid: int | None
+    exit_code: int | None
+    unchecked_exit_codes: dict[int, int]
+
+    def __init__(self) -> None:
+        self.child_exited_event = asyncio.Event()
+        self.pid = None
+        self.exit_code = None
+        self.unchecked_exit_codes = {}
+
+    def set_exit_code(self, pid: int, exit_code: int) -> None:
+        if self.pid is None:
+            self.unchecked_exit_codes[pid] = exit_code
+        elif pid == self.pid:
+            self.exit_code = exit_code
+            self.child_exited_event.set()
+
+    async def call_command(self, interface: ProxyInterface, cmd: str) -> int:
+        try:
+            method = getattr(interface, f"call_{cmd.replace('-', '_')}")
+        except AttributeError:
+            print(f"Error: invalid command '{cmd}'")
+            return 2
+
+        interface.on_child_exited(self.set_exit_code)  # ty: ignore[unresolved-attribute]
+        pid, pty_fd = await method()
+
+        self.pid = pid
+        # Handle case where child process exited in the brief window before we
+        # received the reply over DBus:
+        if pid in self.unchecked_exit_codes:
+            self.exit_code = self.unchecked_exit_codes[pid]
+            self.unchecked_exit_codes.clear()
+            self.child_exited_event.set()
+
+        # Print lines as they're received while waiting for child process exit signal
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(_print_lines(pty_fd))
+            tg.create_task(self.child_exited_event.wait())
+
+        if self.exit_code is None:
+            raise RuntimeError("unreachable")
+        return self.exit_code
+
+
+async def main() -> int:
+    arg_count = len(sys.argv) - 1
+    if arg_count != 1:
+        print_error(f"Expected 1 argument, got {arg_count}. Run with --help option for usage.")
+        return 2
+
+    cmd = sys.argv[1].casefold()
+    if cmd in ("--help", "help", "-h"):
+        print(HELP_MESSAGE)
+        return 0
+
+    bus = await MessageBus(bus_type=BusType.SYSTEM, negotiate_unix_fd=True).connect()
+
+    try:
+        with open(f"/usr/share/dbus-1/interfaces/{DBUS_INTERFACE}.xml", encoding="utf8") as f:
+            introspection_xml = f.read()
+    except OSError:
+        introspection = await bus.introspect(DBUS_NAME, DBUS_PATH)
+    else:
+        introspection = Node.parse(introspection_xml)
+
+    proxy = bus.get_proxy_object(DBUS_NAME, DBUS_PATH, introspection)
+    interface = proxy.get_interface(DBUS_INTERFACE)
+    handler = CommandHandler()
+    try:
+        return await handler.call_command(interface, cmd)
+    except DBusError as err:
+        print_error(f"Error: {err}")
+        return 1
+    finally:
+        bus.disconnect()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/files/system/usr/libexec/secureblue/priv-cmd/daemon.py
+++ b/files/system/usr/libexec/secureblue/priv-cmd/daemon.py
@@ -1,0 +1,125 @@
+#!/usr/bin/python3
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+DBus-activated daemon for secureblue-priv-cmd command-line program. Allows
+unprivileged users to invoke various commands as root.
+"""
+
+import asyncio
+import fcntl
+import os
+import pty
+import struct
+import subprocess
+import termios
+from dataclasses import dataclass
+from typing import Annotated, Final
+
+from dbus_fast import BusType
+from dbus_fast.aio import MessageBus
+from dbus_fast.service import ServiceInterface
+from dbus_fast.service import method as dbus_method
+from dbus_fast.service import signal as dbus_signal
+
+
+# Shim for older versions of dbus-fast. When newer dbus-fast version is in
+# stable Fedora repos, we can replace this with:
+# from dbus_fast.annotations import DBusSignature
+@dataclass(frozen=True, slots=True)
+class DBusSignature:
+    signature: str
+
+
+# Reminder: change these to `tuple[int, int]` when a newer dbus-fast version is
+# available in the stable Fedora repos.
+uh: Final = Annotated[list[int], DBusSignature("uh")]
+uy: Final = Annotated[list[int], DBusSignature("uy")]
+
+
+class PrivCmdInterface(ServiceInterface):
+    _bus: MessageBus
+    _background_tasks: set[asyncio.Task]
+    _idle_counter: int
+    _idle_monitor_task: asyncio.Task | None
+
+    def __init__(self, bus: MessageBus, *, idle_timeout_secs: int | None = None):
+        super().__init__("dev.secureblue.PrivCmd0")
+        self._bus = bus
+        self._background_tasks = set()
+        self._idle_counter = 0
+        self._idle_monitor_task = None
+        if idle_timeout_secs is not None:
+            max_idle_count = idle_timeout_secs / 10
+            self._idle_monitor_task = asyncio.create_task(self._idle_monitor(10, max_idle_count))
+
+    def _run_command(self, *args: str) -> tuple[int, int]:
+        """Run command in pty."""
+        cmdline = " ".join(args)
+        print(f"Command requested: {cmdline}")
+        self._idle_counter = 0
+        (m, s) = pty.openpty()
+        # Set pty dimensions to 24 rows, 80 columns
+        fcntl.ioctl(m, termios.TIOCSWINSZ, struct.pack("HHHH", 24, 80, 0, 0))
+        proc = subprocess.Popen(args, stdin=subprocess.DEVNULL, stdout=s, stderr=s, close_fds=True)
+        print(f"PID {proc.pid}: Running command: {cmdline}")
+        task = asyncio.create_task(self._signal_exit_code(proc, s))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        return (proc.pid, m)
+
+    @dbus_method()
+    def BootcStatus(self) -> "uh":
+        """Display bootc status."""
+        return list(self._run_command("/usr/bin/bootc", "status"))
+
+    @dbus_method()
+    def BootcUpgrade(self) -> "uh":
+        """Run bootc upgrade."""
+        return list(self._run_command("/usr/bin/bootc", "upgrade"))
+
+    @dbus_method()
+    def BootcUpgradeCheck(self) -> "uh":
+        """Run bootc upgrade --check."""
+        return list(self._run_command("/usr/bin/bootc", "upgrade", "--check"))
+
+    @dbus_method()
+    def SemoduleList(self) -> "uh":
+        """List enabled SELinux modules"""
+        return list(self._run_command("/usr/bin/semodule", "-l"))
+
+    @dbus_signal()
+    def ChildExited(self, pid: int, exit_code: int) -> "uy":
+        return [pid, min(exit_code, 255)]
+
+    async def _signal_exit_code(self, proc: subprocess.Popen, pts: int) -> None:
+        proc.wait()
+        self.ChildExited(proc.pid, proc.returncode)
+        os.close(pts)
+        print(f"PID {proc.pid}: Child process exited with code {proc.returncode}")
+
+    async def _idle_monitor(self, freq_secs: float, exit_at_counter: float) -> None:
+        while self._idle_counter < exit_at_counter:
+            await asyncio.sleep(freq_secs)
+            if self._background_tasks:
+                self._idle_counter = 0
+            else:
+                self._idle_counter += 1
+        print("Daemon exiting due to idleness.")
+        self._bus.disconnect()
+
+
+async def main() -> None:
+    bus = await MessageBus(bus_type=BusType.SYSTEM, negotiate_unix_fd=True).connect()
+    interface = PrivCmdInterface(bus, idle_timeout_secs=300)
+    bus.export("/dev/secureblue/PrivCmd0", interface)
+    await bus.request_name("dev.secureblue.PrivCmd0")
+    print("Serving at DBus name dev.secureblue.PrivCmd0")
+    await bus.wait_for_disconnect()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/files/system/usr/libexec/secureblue/secureblue-priv-cmd
+++ b/files/system/usr/libexec/secureblue/secureblue-priv-cmd
@@ -1,0 +1,1 @@
+priv-cmd/client.py

--- a/files/system/usr/libexec/secureblue/update_system.py
+++ b/files/system/usr/libexec/secureblue/update_system.py
@@ -6,15 +6,35 @@
 
 """Update system (with provenance verification)."""
 
+import os
 import sys
 from pathlib import Path
 from subprocess import DEVNULL, CalledProcessError, Popen, run
 
 
+def run_bootc_or_rpm_ostree_upgrade() -> None:
+    """Upgrade using bootc if possible, or rpm-ostree if not."""
+    is_root = os.geteuid() == 0
+    if is_root:
+        check_cmd = ["/usr/bin/bootc", "upgrade", "--check"]
+    else:
+        check_cmd = ["/usr/libexec/secureblue/secureblue-priv-cmd", "bootc-upgrade-check"]
+    check_result = run(check_cmd, check=False, capture_output=True, text=True)
+    use_rpm_ostree = "local rpm-ostree modifications" in check_result.stderr
+
+    if use_rpm_ostree:
+        upgrade_cmd = ["/usr/bin/rpm-ostree", "upgrade"]
+    elif is_root:
+        upgrade_cmd = ["/usr/bin/bootc", "upgrade"]
+    else:
+        upgrade_cmd = ["/usr/libexec/secureblue/secureblue-priv-cmd", "bootc-upgrade"]
+    run(upgrade_cmd, check=True)
+
+
 def main() -> int:
     try:
         run(["/usr/libexec/secureblue/verify-provenance.sh"], check=True)
-        run(["/usr/bin/rpm-ostree", "upgrade"], check=True)
+        run_bootc_or_rpm_ostree_upgrade()
         if Path("/usr/libexec/secureblue/security-update-notification").is_file():
             Popen(
                 ["/usr/libexec/secureblue/security-update-notification"],

--- a/files/system/usr/share/dbus-1/interfaces/dev.secureblue.PrivCmd0.xml
+++ b/files/system/usr/share/dbus-1/interfaces/dev.secureblue.PrivCmd0.xml
@@ -1,0 +1,26 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/dev/secureblue/PrivCmd0">
+  <interface name="dev.secureblue.PrivCmd0">
+    <method name="BootcStatus">
+      <arg direction="out" name="pid" type="u"/>
+      <arg direction="out" name="pty" type="h"/>
+    </method>
+    <method name="BootcUpgrade">
+      <arg direction="out" name="pid" type="u"/>
+      <arg direction="out" name="pty" type="h"/>
+    </method>
+    <method name="BootcUpgradeCheck">
+      <arg direction="out" name="pid" type="u"/>
+      <arg direction="out" name="pty" type="h"/>
+    </method>
+    <method name="SemoduleList">
+      <arg direction="out" name="pid" type="u"/>
+      <arg direction="out" name="pty" type="h"/>
+    </method>
+    <signal name="ChildExited">
+      <arg direction="out" name="pid" type="u"/>
+      <arg direction="out" name="exit_code" type="y"/>
+    </signal>
+  </interface>
+</node>

--- a/files/system/usr/share/dbus-1/system-services/dev.secureblue.PrivCmd0.service
+++ b/files/system/usr/share/dbus-1/system-services/dev.secureblue.PrivCmd0.service
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[D-BUS Service]
+Name=dev.secureblue.PrivCmd0
+User=root
+Exec=/usr/bin/python3 /usr/libexec/secureblue/priv-cmd/daemon.py
+SystemdService=secureblue-priv-cmd-daemon.service

--- a/files/system/usr/share/dbus-1/system.d/dev.secureblue.PrivCmd0.conf
+++ b/files/system/usr/share/dbus-1/system.d/dev.secureblue.PrivCmd0.conf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+
+<!--
+SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<busconfig>
+  <policy user="root">
+    <allow own="dev.secureblue.PrivCmd0" />
+  </policy>
+
+  <policy context="default">
+    <allow send_destination="dev.secureblue.PrivCmd0" send_path="/dev/secureblue/PrivCmd0" />
+  </policy>
+</busconfig>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ description = "secureblue is a security-focused desktop and server Linux operati
 readme = "docs/README.md"
 license-files = ["LICENSES/*.txt"]
 dependencies = [
+    "dbus-fast~=2.45",
     "inquirer",
     "rpm",
 ]
@@ -60,6 +61,9 @@ pycodestyle.max-doc-length = 100
 [tool.ruff.lint.per-file-ignores]
 # Don't require audit checks' function signatures to have type hints.
 "files/system/usr/libexec/secureblue/audit_secureblue.py" = ["ANN"]
+
+# Ignore non-snake-case function names in DBus interface
+"files/system/usr/libexec/secureblue/priv-cmd/daemon.py" = ["N802"]
 
 # Allow partial executable paths in subprocess invocations in dev tools
 "tools/*.py" = ["S607"]

--- a/recipes/common/common-packages.yml
+++ b/recipes/common/common-packages.yml
@@ -33,7 +33,8 @@ install:
     # address hardened_malloc incompatibilities
     - no_rlimit_as
 
-    # For use in unprivileged ujust scripts
+    # Python dependencies for use in scripts
+    - python3-dbus-fast
     - python3-inquirer
 
     # provenance deps

--- a/tools/install-sysext.sh
+++ b/tools/install-sysext.sh
@@ -11,3 +11,5 @@ cd "${0%/*}"
 cd "$(git rev-parse --show-toplevel)"
 install -Dm 644 -t /run/extensions sysext-tmp/secureblue-dev.raw
 systemd-sysext refresh
+systemctl daemon-reload
+busctl call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus ReloadConfig

--- a/tools/remove-sysext.sh
+++ b/tools/remove-sysext.sh
@@ -9,3 +9,5 @@ set -euo pipefail
 umask 022
 rm -f /run/extensions/secureblue-dev.raw
 systemd-sysext refresh
+systemctl daemon-reload
+busctl call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus ReloadConfig


### PR DESCRIPTION
Add a `secureblue-priv-cmd` client and corresponding DBus-activated service that allows unprivileged users to invoke selected commands as root. The list of possible commands is hard-coded and must be limited to commands that are harmless to allow any user to run. Currently the only such commands are `bootc status`, `bootc upgrade`, `bootc upgrade --check`, and `semodule -l`.

Also incorporate these commands into `ujust update-system` (to use bootc if possible) and a new `ujust bootc-status`.

For this to work with bootc commands, we have to add an SELinux policy fix that hasn't been merged upstream yet.