### PR TITLE
fix(selinux): deny noatsecure to userns-privileged transition

### DIFF
--- a/files/scripts/selinux/user_namespace/harden_container_userns.cil
+++ b/files/scripts/selinux/user_namespace/harden_container_userns.cil
@@ -4,3 +4,5 @@
 
 (deny container_domain self (user_namespace (create)))
 (deny container_runtime_domain self (user_namespace (create)))
+(deny unconfined_domain_type container_domain (process (noatsecure)))
+(deny unconfined_domain_type container_runtime_domain (process (noatsecure)))

--- a/files/scripts/selinux/user_namespace/harden_userns.cil
+++ b/files/scripts/selinux/user_namespace/harden_userns.cil
@@ -27,3 +27,4 @@
 (typeattributeset userns_restricted_domain (and (domain) (not (userns_privileged_domain))))
 
 (deny userns_restricted_domain self (user_namespace (create)))
+(deny userns_restricted_domain userns_privileged_domain (process (noatsecure)))


### PR DESCRIPTION
Deny `noatsecure` permission to transitions from a userns-unprivileged domain to a userns-privileged domain. This prevents the userns restrictions from being circumvented via `LD_PRELOAD` or similar mechanisms.