### PR TITLE
fix: allow CAP_SETGID/SETUID for NetworkManager.service

### DIFF
--- a/files/system/usr/lib/systemd/system/NetworkManager.service.d/40-sandbox.conf
+++ b/files/system/usr/lib/systemd/system/NetworkManager.service.d/40-sandbox.conf
@@ -1,6 +1,5 @@
 [Service]
-CapabilityBoundingSet=~CAP_DAC_OVERRIDE CAP_SETGID CAP_SETUID CAP_KILL
-CapabilityBoundingSet=~CAP_SYS_MODULE CAP_AUDIT_WRITE CAP_SYS_CHROOT CAP_BPF
+CapabilityBoundingSet=~CAP_AUDIT_WRITE CAP_BPF CAP_DAC_OVERRIDE CAP_KILL CAP_SYS_CHROOT CAP_SYS_MODULE
 DevicePolicy=closed
 # NM requires access to /run/dbus/
 InaccessiblePaths=/run/user/


### PR DESCRIPTION
The previous fix (https://github.com/secureblue/secureblue/commit/f4dec21c5507fb0a8eba8f01a5f5eae641c408b5) allowed setgid/setuid syscalls through the seccomp filter, but didn't also restore the necessary capabilities.