### PR TITLE
fix: relax sandbox for user mode OpenVPN in NetworkManager.service

### DIFF
--- a/files/system/usr/lib/systemd/system/NetworkManager.service.d/40-sandbox.conf
+++ b/files/system/usr/lib/systemd/system/NetworkManager.service.d/40-sandbox.conf
@@ -1,15 +1,15 @@
 [Service]
 CapabilityBoundingSet=~CAP_AUDIT_WRITE CAP_BPF CAP_DAC_OVERRIDE CAP_KILL CAP_SYS_CHROOT CAP_SYS_MODULE
+DeviceAllow=/dev/net/tun
 DevicePolicy=closed
 # NM requires access to /run/dbus/
 InaccessiblePaths=/run/user/
 LockPersonality=true
 MemoryDenyWriteExecute=true
-PrivateDevices=true
 PrivateTmp=disconnected
 ProtectClock=true
 ProtectControlGroups=true
-ProtectHome=true
+ProtectHome=read-only
 ProtectHostname=private
 ProtectKernelLogs=true
 ProtectKernelModules=true


### PR DESCRIPTION
Closes #2548, adds to earlier partial fix #2549.

When key material is stored in files instead of bundled inside a profile these are installed to ~/.cert/nm-openvpn/*.pem. For such a profile NetworkManager requires read-only access to user's home directories.

Possibly write access is required for the importing of such a profile as well. This has not been tested and is out of scope for this patch.

OpenVPN in TUN mode, possibly also depending on certain options, also requires access to /dev/net/tun. Make this device path allowed.