### PR TITLE
fix(selinux): treat /usr/share/secureblue/etc as alias of /etc

### DIFF
--- a/files/scripts/backupetc.sh
+++ b/files/scripts/backupetc.sh
@@ -9,4 +9,9 @@
 # /etc/ and /usr/etc/ populated in an image (undefined behaviour), so instead we
 # explicitly make a backup in /usr/share/secureblue/etc/.
 
+cat <<'EOF' >> /etc/selinux/targeted/contexts/files/file_contexts.subs_dist
+# Build-time backup of /etc created by secureblue
+/usr/share/secureblue/etc    /etc
+EOF
+
 cp -a /etc /usr/share/secureblue/


### PR DESCRIPTION
The build-time backup of `/etc` at `/usr/share/secureblue/etc` should be treated as an alias of `/etc` for SELinux labeling purposes. This can be achieved using `file_contexts.subs_dist`.