### PR TITLE
ci: use new self-repository syntax for local actions

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -34,7 +34,7 @@ jobs:
       actions: read # Needed to read actions and actions logs for provenance generation
       packages: write # Needed to publish images
       id-token: write # Needed for token generation for signing
-    uses: ./.github/workflows/build-one-recipe.yml
+    uses: $/.github/workflows/build-one-recipe.yml
     with:
       recipe: general/recipe-silverblue-main.yml
       rechunk: true
@@ -51,7 +51,7 @@ jobs:
       actions: read # Needed to read actions and actions logs for provenance generation
       packages: write # Needed to publish images
       id-token: write # Needed for token generation for signing
-    uses: ./.github/workflows/build-sealed-image.yml
+    uses: $/.github/workflows/build-sealed-image.yml
     with:
       image: ${{ needs.silverblue-main.outputs.IMAGE_NAME }}
       base_tag: ${{ needs.silverblue-main.outputs.IMAGE_TAG }}
@@ -69,7 +69,7 @@ jobs:
       actions: read # Needed to read actions and actions logs for provenance generation
       packages: write # Needed to publish images
       id-token: write # Needed for token generation for signing
-    uses: ./.github/workflows/build-one-recipe.yml
+    uses: $/.github/workflows/build-one-recipe.yml
     with:
       recipe: general/recipe-kinoite-main.yml
       rechunk: true
@@ -86,7 +86,7 @@ jobs:
       actions: read # Needed to read actions and actions logs for provenance generation
       packages: write # Needed to publish images
       id-token: write # Needed for token generation for signing
-    uses: ./.github/workflows/build-sealed-image.yml
+    uses: $/.github/workflows/build-sealed-image.yml
     with:
       image: ${{ needs.kinoite-main.outputs.IMAGE_NAME }}
       base_tag: ${{ needs.kinoite-main.outputs.IMAGE_TAG }}
@@ -104,7 +104,7 @@ jobs:
       actions: read # Needed to read actions and actions logs for provenance generation
       packages: write # Needed to publish images
       id-token: write # Needed for token generation for signing
-    uses: ./.github/workflows/build-one-recipe.yml
+    uses: $/.github/workflows/build-one-recipe.yml
     with:
       recipe: general/recipe-sericea-main.yml
       rechunk: true
@@ -121,7 +121,7 @@ jobs:
       actions: read # Needed to read actions and actions logs for provenance generation
       packages: write # Needed to publish images
       id-token: write # Needed for token generation for signing
-    uses: ./.github/workflows/build-sealed-image.yml
+    uses: $/.github/workflows/build-sealed-image.yml
     with:
       image: ${{ needs.sericea-main.outputs.IMAGE_NAME }}
       base_tag: ${{ needs.sericea-main.outputs.IMAGE_TAG }}
@@ -139,7 +139,7 @@ jobs:
       actions: read # Needed to read actions and actions logs for provenance generation
       packages: write # Needed to publish images
       id-token: write # Needed for token generation for signing
-    uses: ./.github/workflows/build-one-recipe.yml
+    uses: $/.github/workflows/build-one-recipe.yml
     with:
       recipe: general/recipe-cosmic-main.yml
       rechunk: true
@@ -156,7 +156,7 @@ jobs:
       actions: read # Needed to read actions and actions logs for provenance generation
       packages: write # Needed to publish images
       id-token: write # Needed for token generation for signing
-    uses: ./.github/workflows/build-sealed-image.yml
+    uses: $/.github/workflows/build-sealed-image.yml
     with:
       image: ${{ needs.cosmic-main.outputs.IMAGE_NAME }}
       base_tag: ${{ needs.cosmic-main.outputs.IMAGE_TAG }}
@@ -181,7 +181,7 @@ jobs:
         recipe:
           - general/recipe-silverblue-nvidia.yml
           - general/recipe-silverblue-nvidia-open.yml
-    uses: ./.github/workflows/build-one-recipe.yml
+    uses: $/.github/workflows/build-one-recipe.yml
     with:
       recipe: ${{ matrix.recipe }}
       rechunk: true
@@ -204,7 +204,7 @@ jobs:
         recipe:
           - general/recipe-kinoite-nvidia.yml
           - general/recipe-kinoite-nvidia-open.yml
-    uses: ./.github/workflows/build-one-recipe.yml
+    uses: $/.github/workflows/build-one-recipe.yml
     with:
       recipe: ${{ matrix.recipe }}
       rechunk: true
@@ -227,7 +227,7 @@ jobs:
         recipe:
           - general/recipe-sericea-nvidia.yml
           - general/recipe-sericea-nvidia-open.yml
-    uses: ./.github/workflows/build-one-recipe.yml
+    uses: $/.github/workflows/build-one-recipe.yml
     with:
       recipe: ${{ matrix.recipe }}
       rechunk: true
@@ -250,7 +250,7 @@ jobs:
         recipe:
           - general/recipe-cosmic-nvidia.yml
           - general/recipe-cosmic-nvidia-open.yml
-    uses: ./.github/workflows/build-one-recipe.yml
+    uses: $/.github/workflows/build-one-recipe.yml
     with:
       recipe: ${{ matrix.recipe }}
       rechunk: true
@@ -266,7 +266,7 @@ jobs:
       actions: read # Needed to read actions and actions logs for provenance generation
       packages: write # Needed to publish images
       id-token: write # Needed for token generation for signing
-    uses: ./.github/workflows/build-one-recipe.yml
+    uses: $/.github/workflows/build-one-recipe.yml
     with:
       recipe: securecore/recipe-securecore-main.yml
       rechunk: true
@@ -283,7 +283,7 @@ jobs:
       actions: read # Needed to read actions and actions logs for provenance generation
       packages: write # Needed to publish images
       id-token: write # Needed for token generation for signing
-    uses: ./.github/workflows/build-sealed-image.yml
+    uses: $/.github/workflows/build-sealed-image.yml
     with:
       image: ${{ needs.securecore-main.outputs.IMAGE_NAME }}
       base_tag: ${{ needs.securecore-main.outputs.IMAGE_TAG }}
@@ -308,7 +308,7 @@ jobs:
         recipe:
           - securecore/recipe-securecore-nvidia.yml
           - securecore/recipe-securecore-nvidia-open.yml
-    uses: ./.github/workflows/build-one-recipe.yml
+    uses: $/.github/workflows/build-one-recipe.yml
     with:
       recipe: ${{ matrix.recipe }}
       rechunk: true
@@ -325,7 +325,7 @@ jobs:
       actions: read # Needed to read actions and actions logs for provenance generation
       packages: write # Needed to publish images
       id-token: write # Needed for token generation for signing
-    uses: ./.github/workflows/build-one-recipe.yml
+    uses: $/.github/workflows/build-one-recipe.yml
     with:
       recipe: securecore/recipe-securecore-zfs-main.yml
       rechunk: true
@@ -348,7 +348,7 @@ jobs:
         recipe:
           - securecore/recipe-securecore-zfs-nvidia.yml
           - securecore/recipe-securecore-zfs-nvidia-open.yml
-    uses: ./.github/workflows/build-one-recipe.yml
+    uses: $/.github/workflows/build-one-recipe.yml
     with:
       recipe: ${{ matrix.recipe }}
       rechunk: true
@@ -364,7 +364,7 @@ jobs:
       actions: read # Needed to read actions and actions logs for provenance generation
       packages: write # Needed to publish images
       id-token: write # Needed for token generation for signing
-    uses: ./.github/workflows/build-one-recipe.yml
+    uses: $/.github/workflows/build-one-recipe.yml
     with:
       recipe: iot/recipe-iot-main.yml
       rechunk: true
@@ -381,7 +381,7 @@ jobs:
       actions: read # Needed to read actions and actions logs for provenance generation
       packages: write # Needed to publish images
       id-token: write # Needed for token generation for signing
-    uses: ./.github/workflows/build-sealed-image.yml
+    uses: $/.github/workflows/build-sealed-image.yml
     with:
       image: ${{ needs.iot-main.outputs.IMAGE_NAME }}
       base_tag: ${{ needs.iot-main.outputs.IMAGE_TAG }}
@@ -406,7 +406,7 @@ jobs:
         recipe:
           - iot/recipe-iot-nvidia.yml
           - iot/recipe-iot-nvidia-open.yml
-    uses: ./.github/workflows/build-one-recipe.yml
+    uses: $/.github/workflows/build-one-recipe.yml
     with:
       recipe: ${{ matrix.recipe }}
       rechunk: true
@@ -423,7 +423,7 @@ jobs:
       actions: read # Needed to read actions and actions logs for provenance generation
       packages: write # Needed to publish images
       id-token: write # Needed for token generation for signing
-    uses: ./.github/workflows/build-one-recipe.yml
+    uses: $/.github/workflows/build-one-recipe.yml
     with:
       recipe: iot/recipe-iot-zfs-main.yml
       rechunk: true
@@ -446,7 +446,7 @@ jobs:
         recipe:
           - iot/recipe-iot-zfs-nvidia.yml
           - iot/recipe-iot-zfs-nvidia-open.yml
-    uses: ./.github/workflows/build-one-recipe.yml
+    uses: $/.github/workflows/build-one-recipe.yml
     with:
       recipe: ${{ matrix.recipe }}
       rechunk: true

--- a/.github/workflows/build-one-recipe.yml
+++ b/.github/workflows/build-one-recipe.yml
@@ -219,7 +219,7 @@ jobs:
 
       - name: Runner setup
         id: runner_setup
-        uses: ./.github/workflows/shared-runner-setup
+        uses: $/.github/workflows/shared-runner-setup
         with:
           needs_cosign: ${{ steps.image_data.outputs.IMAGE_NAME != 'securecore-main-hardened' && steps.image_data.outputs.IMAGE_NAME != 'iot-main-hardened' }}
           needs_slsa_crane: ${{ startsWith(steps.image_data.outputs.BASE_IMAGE, format('ghcr.io/{0}/', github.repository_owner)) }}

--- a/.github/workflows/build-sealed-image.yml
+++ b/.github/workflows/build-sealed-image.yml
@@ -202,7 +202,7 @@ jobs:
           persist-credentials: false
 
       - name: "Set up runner"
-        uses: ./.github/workflows/shared-runner-setup
+        uses: $/.github/workflows/shared-runner-setup
         with:
           needs_cosign: true
           needs_slsa_crane: true
@@ -332,7 +332,7 @@ jobs:
           persist-credentials: false
 
       - name: "Set up runner"
-        uses: ./.github/workflows/shared-runner-setup
+        uses: $/.github/workflows/shared-runner-setup
         with:
           needs_cosign: true
 

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: Runner setup
         id: runner_setup
-        uses: ./.github/workflows/shared-runner-setup
+        uses: $/.github/workflows/shared-runner-setup
 
       - name: Set up test keys
         id: test_keys

--- a/.github/workflows/pr_build_all_main.yml
+++ b/.github/workflows/pr_build_all_main.yml
@@ -49,7 +49,7 @@ jobs:
         platform:
           - linux/amd64
           - linux/arm64
-    uses: ./.github/workflows/pr_build.yml
+    uses: $/.github/workflows/pr_build.yml
     with:
       recipe: ${{ matrix.recipe }}
       platform: ${{ matrix.platform }}

--- a/.github/workflows/pr_build_minimal.yml
+++ b/.github/workflows/pr_build_minimal.yml
@@ -33,7 +33,7 @@ jobs:
         platform:
           - linux/amd64
           - linux/arm64
-    uses: ./.github/workflows/pr_build.yml
+    uses: $/.github/workflows/pr_build.yml
     with:
       recipe: general/recipe-silverblue-main.yml
       platform: ${{ matrix.platform }}

--- a/.github/workflows/pr_build_nvidia.yml
+++ b/.github/workflows/pr_build_nvidia.yml
@@ -36,7 +36,7 @@ jobs:
         recipe:
           - general/recipe-silverblue-nvidia-open.yml
           - general/recipe-silverblue-nvidia.yml
-    uses: ./.github/workflows/pr_build.yml
+    uses: $/.github/workflows/pr_build.yml
     with:
       recipe: ${{ matrix.recipe }}
       platform: linux/amd64

--- a/.github/workflows/pr_build_zfs.yml
+++ b/.github/workflows/pr_build_zfs.yml
@@ -36,7 +36,7 @@ jobs:
         recipe:
           - securecore/recipe-securecore-zfs-main.yml
           - iot/recipe-iot-zfs-main.yml
-    uses: ./.github/workflows/pr_build.yml
+    uses: $/.github/workflows/pr_build.yml
     with:
       recipe: ${{ matrix.recipe }}
       platform: linux/amd64

--- a/.github/workflows/sign-systemd-boot.yml
+++ b/.github/workflows/sign-systemd-boot.yml
@@ -38,7 +38,7 @@ jobs:
           persist-credentials: false
 
       - name: "Runner setup"
-        uses: ./.github/workflows/shared-runner-setup
+        uses: $/.github/workflows/shared-runner-setup
 
       - name: "Log in to registry"
         uses: redhat-actions/podman-login@50c2d9a331bb67c8fdab99b86455fad05e2e3252 # v2.0
@@ -97,7 +97,7 @@ jobs:
           persist-credentials: false
 
       - name: "Set up runner"
-        uses: ./.github/workflows/shared-runner-setup
+        uses: $/.github/workflows/shared-runner-setup
         with:
           needs_cosign: true
 

--- a/.github/workflows/sign-uki-addons.yml
+++ b/.github/workflows/sign-uki-addons.yml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: "Set up runner"
-        uses: ./.github/workflows/shared-runner-setup
+        uses: $/.github/workflows/shared-runner-setup
 
       - name: "Log in to registry"
         uses: redhat-actions/podman-login@50c2d9a331bb67c8fdab99b86455fad05e2e3252 # v2.0
@@ -95,7 +95,7 @@ jobs:
           persist-credentials: false
 
       - name: "Set up runner"
-        uses: ./.github/workflows/shared-runner-setup
+        uses: $/.github/workflows/shared-runner-setup
         with:
           needs_cosign: true
 


### PR DESCRIPTION
This makes the action not dependent on the runner's local filesystem state, and counts as a pinned action. For more info, see: https://docs.zizmor.sh/audits/#self-repository