### PR TITLE
ci: group dependabot updates for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,15 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:


### PR DESCRIPTION
Change Dependabot settings so GitHub Actions dependencies are updated weekly in a single grouped PR, rather than daily in individual PRs. This does not affect dependency updates that are marked as security updates.