### PR TITLE
chore: install trivalent-selinux from copr

### DIFF
--- a/files/scripts/install-trivalent.sh
+++ b/files/scripts/install-trivalent.sh
@@ -33,18 +33,6 @@ fi
 trivalent_rpm_sans_prefix=${trivalent_rpm#trivalent-}
 trivalent_version=${trivalent_rpm_sans_prefix%".${ARCH}.rpm"}
 
-trivalent_selinux_pkg="trivalent-selinux-${trivalent_version}"
-dnf --repo=secureblue -y download "${trivalent_selinux_pkg}"
-
-trivalent_selinux_rpm="${trivalent_selinux_pkg}.noarch.rpm"
-
-if [[ -f "${trivalent_selinux_rpm}" ]]; then
-    echo "Trivalent SELinux policy RPM: ${trivalent_selinux_rpm}"
-else
-    echo "trivalent-selinux RPM not found"
-    exit 1
-fi
-
 provenance_file="multiple.intoto.jsonl"
 curl -fLsS --retry 5 -O "https://github.com/secureblue/Trivalent/releases/download/${trivalent_version}/${provenance_file}"
 
@@ -52,10 +40,9 @@ slsa-verifier verify-artifact \
     --provenance-path "${provenance_file}" \
     --source-uri 'github.com/secureblue/Trivalent' \
     --source-branch 'live' \
-    "${trivalent_rpm}" "${trivalent_selinux_rpm}"
+    "${trivalent_rpm}"
 
 # Forcing GPG check for packages installed outside of a repository
-dnf --setopt=localpkg_gpgcheck=True --setopt=install_weak_deps=False -y \
-    install "${trivalent_rpm}" "${trivalent_selinux_rpm}"
+dnf --setopt=localpkg_gpgcheck=True --setopt=install_weak_deps=False -y install "${trivalent_rpm}"
 
 sed -i 's/org\.mozilla\.firefox\.desktop/trivalent.desktop/' /usr/share/applications/mimeapps.list

--- a/files/system/etc/yum.repos.d/secureblue-packages-fedora.repo
+++ b/files/system/etc/yum.repos.d/secureblue-packages-fedora.repo
@@ -9,4 +9,4 @@ gpgkey=file:///usr/share/pki/rpm-gpg/secureblue-copr-pubkey.gpg
 repo_gpgcheck=0
 enabled=1
 enabled_metadata=1
-includepkgs=bazaar*,brew-proxy*,bubblejail,crane*,dangerzone,hardened_malloc,homebrew,kernel*,krunner-bazaar*,no_rlimit_as*,run0edit,secureblue-logos,slsa-verifier*,trivalent-subresource-filter
+includepkgs=bazaar*,brew-proxy*,bubblejail,crane*,dangerzone,hardened_malloc,homebrew,kernel*,krunner-bazaar*,no_rlimit_as*,run0edit,secureblue-logos,slsa-verifier*,trivalent-selinux,trivalent-subresource-filter

--- a/recipes/common/desktop-packages.yml
+++ b/recipes/common/desktop-packages.yml
@@ -23,6 +23,7 @@ install:
     - brew-proxy
     - brew-proxy-selinux
     - firewall-config
+    - trivalent-selinux
 
     # yubikey enablement
     - pam-u2f


### PR DESCRIPTION
Should be merged after https://github.com/secureblue/Trivalent/pull/873 once trivalent-selinux has been built in the Copr repo.