### PR TITLE
fix: versionlock Qt6 packages

### DIFF
--- a/files/scripts/versionlock-qt6.sh
+++ b/files/scripts/versionlock-qt6.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# Prevent broken Qt6 updates if it's updated in the repos more recently than
+# the last base image build.
+
+dnf versionlock add 'qt6-*'

--- a/recipes/common/kinoite-modules.yml
+++ b/recipes/common/kinoite-modules.yml
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 modules:
+  - type: script
+    source: ghcr.io/blue-build/modules@sha256:c5ed99f07b15c8d575a4fa64a77e5cd5602b00da4c84379f5675db2ae4757061
+    scripts:
+      - versionlock-qt6.sh
   - type: dnf
     source: ghcr.io/blue-build/modules@sha256:c5ed99f07b15c8d575a4fa64a77e5cd5602b00da4c84379f5675db2ae4757061
     remove:


### PR DESCRIPTION
This prevents a broken partial Qt6 update if there's an update to Qt6 packages in the Fedora repos more recently than the last base image build.