### PR TITLE
fix: install Dangerzone via Copr only on x86-64 arch

### DIFF
--- a/files/scripts/install-dangerzone.sh
+++ b/files/scripts/install-dangerzone.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright 2026 The Secureblue Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [[ "${OS_ARCH}" == 'x86_64' ]]; then
+    dnf install -y --setopt=install_weak_deps=False dangerzone
+else
+    echo 'Dangerzone is only available on x86-64 architecture; skipping installation.'
+fi

--- a/files/system/etc/yum.repos.d/secureblue-packages-fedora.repo
+++ b/files/system/etc/yum.repos.d/secureblue-packages-fedora.repo
@@ -9,4 +9,4 @@ gpgkey=file:///usr/share/pki/rpm-gpg/secureblue-copr-pubkey.gpg
 repo_gpgcheck=0
 enabled=1
 enabled_metadata=1
-includepkgs=bazaar*,brew-proxy*,bubblejail,crane*,hardened_malloc,homebrew,krunner-bazaar*,no_rlimit_as*,run0edit,secureblue-logos,slsa-verifier*,trivalent-subresource-filter,kernel*
+includepkgs=bazaar*,brew-proxy*,bubblejail,crane*,dangerzone,hardened_malloc,homebrew,kernel*,krunner-bazaar*,no_rlimit_as*,run0edit,secureblue-logos,slsa-verifier*,trivalent-subresource-filter

--- a/recipes/common/desktop-modules.yml
+++ b/recipes/common/desktop-modules.yml
@@ -11,18 +11,8 @@ modules:
 
   - from-file: common/desktop-packages.yml
 
-  # We have to install dangerzone with `skip-broken: true` because it's not
-  # available on ARM.
-  - type: dnf
-    source: ghcr.io/blue-build/modules@sha256:c5ed99f07b15c8d575a4fa64a77e5cd5602b00da4c84379f5675db2ae4757061
-    install:
-      install-weak-deps: false
-      skip-broken: true
-      skip-unavailable: true
-      packages:
-        - dangerzone
-
   - from-file: common/desktop-scripts.yml
+
   - type: justfiles
     source: ghcr.io/blue-build/modules@sha256:c5ed99f07b15c8d575a4fa64a77e5cd5602b00da4c84379f5675db2ae4757061
     validate: true

--- a/recipes/common/desktop-scripts.yml
+++ b/recipes/common/desktop-scripts.yml
@@ -7,6 +7,7 @@ source: ghcr.io/blue-build/modules@sha256:c5ed99f07b15c8d575a4fa64a77e5cd5602b00
 scripts:
   - install-trivalent.sh
   - installsubresourcefilter.sh
+  - install-dangerzone.sh
   - disablecups.sh
   - disablesshd.sh
   - disableavahidaemon.sh


### PR DESCRIPTION
Previously the installation was broken due to not being in the includepkgs list for the Copr repo.