### PR TITLE
ci: re-enable jscpd with a scoped config

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -47,7 +47,6 @@ jobs:
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: false # covered by zizmor.yml
           SKIP: zizmor # covered by zizmor.yml
           VALIDATE_SHELL_SHFMT: false # too many false positives by default
-          VALIDATE_JSCPD: false # too many false positives by default
           VALIDATE_MARKDOWN: false # covered by MARKDOWN_PRETTIER
           VALIDATE_BIOME_FORMAT: false # defaults that contradict other linters
           VALIDATE_BIOME_LINT: false # defaults that contradict other linters

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,4 @@
+{
+  "threshold": 2,
+  "ignore": ["files/po/**", "**/*.svg", "LICENSES/**", ".github/**", "recipes/**"]
+}


### PR DESCRIPTION
Hi! I maintain jscpd. While surveying Super Linter configs I came across this line in your workflow:

```yaml
VALIDATE_JSCPD: false # too many false positives by default
```

You're right about the defaults. I ran jscpd v5 (the version Super Linter v8.7.0 ships) on the tree, and out of the box it reports 129 clones — most of them not meaningful for a repo like this:

| What gets flagged | Clones | Assessment |
|---|---|---|
| `files/po/*` translation catalogs | 64 | identical `msgid` blocks across languages — duplicates by definition |
| CI matrix boilerplate in `.github/workflows/` | ~25 | noise (and zizmor already owns that ground) |
| `recipes/*-*.yml` image variants | ~15 | near-identical by design |
| SVG logo copies, `LICENSES/*.txt` | 9 | not code |
| **Actual bash/python code** | **7** | real duplication |

This PR proposes re-enabling the check with a scoped `.jscpd.json` (picked up via your `LINTER_RULES_PATH: .`) that excludes the noise categories above and gates the rest at 2% duplicated lines — the tree currently sits at 1.62%, so CI passes as-is.

The 7 real findings are why I believe the check could earn its keep here specifically: the four LUKS helpers (`luks-{enable,disable}-{fido2,tpm2}-*.sh`) share overlapping ~40–46 line blocks, and `libdistrobox.sh`/`libtoolbox.sh` share two ~24-line blocks. For security-critical scripts that's a drift risk — a fix applied to one copy can silently miss the others. With this config, only *growth* of that duplication past 2% would fail the build.

The knobs are easy to tune if you'd prefer a different scope (per-path ignores, `threshold`, or `failOnNewClones` with a committed baseline for a strict no-new-duplication gate) — happy to adjust.

If you happen to remember what triggered the false positives originally, I'd be grateful for the details — it's exactly the feedback I'm using to improve v5's defaults. And if you'd prefer to keep jscpd disabled, that's completely understandable — please feel free to close this.
