### PR TITLE
fix(uki): disable 90s timeout for LUKS password

### DIFF
--- a/uki/scripts/prepare-rootfs.sh
+++ b/uki/scripts/prepare-rootfs.sh
@@ -53,6 +53,7 @@ cat > "/usr/lib/bootc/kargs.d/10-plymouth.toml" << 'EOF'
 kargs = [
   "quiet",
   "rhgb",
+  "systemd.default_device_timeout_sec=0",
 ]
 EOF
 # Temporary. See: https://github.com/systemd/systemd/issues/40159 and


### PR DESCRIPTION
On UKIs, the root partition is discovered using the Discoverable Partitions Specification, not an `rd.luks` karg as it is on OSTree. Because of this, systemd applies the default device timeout for mounting `/`, which is 90 seconds. If the LUKS password is not entered within this time, boot currently fails and the device must be restarted.

This PR disables the default device timeout on UKI images, allowing users more than 90 seconds to enter their LUKS password.

Note: the timeout currently serves the purpose of stopping boot from hanging when a device cannot be mounted within 90s. This change would make boot hang for broken devices on UKI images, rather than the current 90s delay. I think it's still worth making the change, but we can discuss.