### PR TITLE
feat: enable brew-proxy service to fix file ownership

### DIFF
--- a/files/system/desktop/usr/lib/systemd/system-preset/35-secureblue-desktop.preset
+++ b/files/system/desktop/usr/lib/systemd/system-preset/35-secureblue-desktop.preset
@@ -2,6 +2,7 @@ enable flatpak-system-update.timer
 
 # Homebrew
 enable brew-proxy-setup.service
+enable brew-proxy-fix-ownership.service
 enable brew-update.timer
 enable brew-upgrade.timer
 enable secureblue-brew-proxy-migration.service


### PR DESCRIPTION
This mitigates the UID/GID "drift" bug that some users have encountered, where the UID/GID of a system user changes with an update, breaking file ownership in /home/linuxbrew: https://gitlab.com/fedora/ostree/sig/-/work_items/90

See also https://codeberg.org/HastD/brew-proxy/releases/tag/v0.3.6