### PR TITLE
feat: add QEMU USB drivers to server images

### DIFF
--- a/recipes/common/common-packages.yml
+++ b/recipes/common/common-packages.yml
@@ -45,7 +45,9 @@ install:
     - libvirt-nss
     - qemu-device-display-virtio-gpu
     - qemu-device-display-virtio-vga
+    - qemu-device-usb-host
     - qemu-device-usb-redirect
+    - qemu-device-usb-smartcard
     - qemu-kvm-core
     - qemu-img
     - qemu-tools


### PR DESCRIPTION
Previously some QEMU USB driver packages were only installed on desktop images, preventing USB passthrough from working on IoT.

Resolves #2611.