### PR TITLE
fix: don't allow users to choose Quad9 for DoH (closes #2619)

### DIFF
--- a/files/system/usr/libexec/secureblue/dns_selector.py
+++ b/files/system/usr/libexec/secureblue/dns_selector.py
@@ -149,6 +149,15 @@ def ask_servers(https_only: bool = False) -> DNSServers:
     data = json.loads(SERVERS_JSON_PATH.read_text(encoding="utf-8"))
     providers = data["providers"]
 
+    # If we're asking for servers for DoH use only, there's no point in showing
+    # providers/servers with no DoH endpoint.
+    if https_only:
+        providers = [
+            {**p, "servers": [s for s in p["servers"] if s.get("https")]}
+            for p in providers
+            if any(s.get("https") for s in p["servers"])
+        ]
+
     print("Select a DNS provider:")
     custom_option = len(providers) + 1
     for i, p in enumerate(providers, start=1):

--- a/files/system/usr/share/secureblue/secure-dns-providers.json
+++ b/files/system/usr/share/secureblue/secure-dns-providers.json
@@ -101,8 +101,8 @@
                         "dns+tls://149.112.112.112#dns.quad9.net"
                     ],
                     "ipv6": [
-                        "dns+tls://2620:fe::fe#dns.quad9.net",
-                        "dns+tls://2620:fe::9#dns.quad9.net"
+                        "dns+tls://[2620:fe::fe]#dns.quad9.net",
+                        "dns+tls://[2620:fe::9]#dns.quad9.net"
                     ]
                 },
                 {
@@ -112,8 +112,8 @@
                         "dns+tls://149.112.112.11#dns11.quad9.net"
                     ],
                     "ipv6": [
-                        "dns+tls://2620:fe::11#dns11.quad9.net",
-                        "dns+tls://2620:fe::fe:11#dns11.quad9.net"
+                        "dns+tls://[2620:fe::11]#dns11.quad9.net",
+                        "dns+tls://[2620:fe::fe:11]#dns11.quad9.net"
                     ]
                 },
                 {
@@ -123,8 +123,8 @@
                         "dns+tls://149.112.112.10#dns10.quad9.net"
                     ],
                     "ipv6": [
-                        "dns+tls://2620:fe::10#dns10.quad9.net",
-                        "dns+tls://2620:fe::fe:10#dns10.quad9.net"
+                        "dns+tls://[2620:fe::10]#dns10.quad9.net",
+                        "dns+tls://[2620:fe::fe:10]#dns10.quad9.net"
                     ]
                 }
             ]


### PR DESCRIPTION
We recently added Quad9 as a DNS provider without a DoH endpoint. When a user chooses to configure Global DNS _via the wizard_, the DNS selector already knows not to offer DoH, as expected.

However, if a user manually chooses to enable DoH, the wizard still allows the user to choose Quad9. This PR fixes that bug. @Commenter25 