### PR TITLE
feat: installed patched bwrap version to expose limited userns

### DIFF
--- a/files/scripts/hardened_malloc-pam.sh
+++ b/files/scripts/hardened_malloc-pam.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-# SPDX-FileCopyrightText: Copyright 2025-2026 The Secureblue Authors
-#
-# SPDX-License-Identifier: Apache-2.0
-
-set -euo pipefail
-
-sed -i -e '$a\LD_PRELOAD DEFAULT="libhardened_malloc.so libno_rlimit_as.so"' -e '/^LD_PRELOAD[[:space:]]/d' /etc/security/pam_env.conf

--- a/files/scripts/selinux/flatpakfull/flatpakfull.te
+++ b/files/scripts/selinux/flatpakfull/flatpakfull.te
@@ -29,6 +29,14 @@ optional_policy(`
 ')
 
 optional_policy(`
+	bubblewrap_exec(flatpak_t)
+')
+
+optional_policy(`
+	bwrap_restricted_exec(flatpak_t)
+')
+
+optional_policy(`
 	gen_require(`
 		type unconfined_t;
 		attribute trivalent_domain;

--- a/files/scripts/selinux/user_namespace/harden_userns.cil
+++ b/files/scripts/selinux/user_namespace/harden_userns.cil
@@ -4,6 +4,8 @@
 
 (typeattribute userns_privileged_domain)
 (typeattributeset userns_privileged_domain (init_t install_t kernel_t))
+(optional bwrap_restricted_userns_privileged_domain
+          (typeattributeset userns_privileged_domain (bwrap_restricted_domain)))
 (optional colord_userns_privileged_domain
           (typeattributeset userns_privileged_domain (colord_t)))
 (optional container_userns_privileged_domain

--- a/files/scripts/selinux/user_namespace/userns_deny_unconfined_relabels.cil
+++ b/files/scripts/selinux/user_namespace/userns_deny_unconfined_relabels.cil
@@ -3,6 +3,8 @@
 ;; SPDX-License-Identifier: Apache-2.0 OR MIT
 
 (typeattribute userns_privileged_file_type)
+(optional bwrap_restricted_userns_privileged_file_type
+          (typeattributeset userns_privileged_file_type (bwrap_restricted_exec_t)))
 (optional colord_userns_privileged_file_type
           (typeattributeset userns_privileged_file_type (colord_exec_t)))
 (optional container_userns_privileged_file_type

--- a/files/scripts/set-ld-preload.sh
+++ b/files/scripts/set-ld-preload.sh
@@ -6,7 +6,5 @@
 
 set -euo pipefail
 
-# Make ld.so.preload readable only by root, so user processes can override
-# hardened_malloc by resetting LD_PRELOAD.
-umask 077
-echo 'libhardened_malloc.so' > /etc/ld.so.preload
+umask 022
+echo 'libhardened_malloc.so libno_rlimit_as.so' > /etc/ld.so.preload

--- a/files/scripts/systemsettings-standard-malloc.sh
+++ b/files/scripts/systemsettings-standard-malloc.sh
@@ -7,4 +7,4 @@
 set -euo pipefail
 
 # Unset LD_PRELOAD in all invocations of systemsettings in .desktop files
-sed -Ei 's/^Exec=systemsettings( .*)?$/Exec=env LD_PRELOAD= systemsettings\1/' /usr/share/applications/*.desktop
+sed -Ei 's/^Exec=systemsettings( .*)?$/Exec=with-standard-malloc systemsettings\1/' /usr/share/applications/*.desktop

--- a/files/system/etc/bwrap-restricted/config.toml
+++ b/files/system/etc/bwrap-restricted/config.toml
@@ -1,0 +1,10 @@
+# Configuration for bwrap-restricted
+
+# Path to the bwrap executable:
+bwrap_path = "/usr/bin/bwrap-original"
+
+# bwrap options to forbid:
+forbidden_options = ["--cap-add"]
+
+# Extra options to insert between the options list and the command arguments:
+extra_options = ["--cap-drop", "ALL"]

--- a/files/system/etc/profile.d/hardened_malloc.sh
+++ b/files/system/etc/profile.d/hardened_malloc.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/sh
-export LD_PRELOAD='libhardened_malloc.so libno_rlimit_as.so'

--- a/files/system/etc/yum.repos.d/secureblue-packages-fedora.repo
+++ b/files/system/etc/yum.repos.d/secureblue-packages-fedora.repo
@@ -9,4 +9,4 @@ gpgkey=file:///usr/share/pki/rpm-gpg/secureblue-copr-pubkey.gpg
 repo_gpgcheck=0
 enabled=1
 enabled_metadata=1
-includepkgs=bazaar*,brew-proxy*,bubblejail,crane*,dangerzone,hardened_malloc,homebrew,kernel*,krunner-bazaar*,no_rlimit_as*,run0edit,secureblue-logos,slsa-verifier*,trivalent-selinux,trivalent-subresource-filter
+includepkgs=bazaar*,brew-proxy*,bubblejail,bwrap-restricted*,crane*,dangerzone,hardened_malloc,homebrew,kernel*,krunner-bazaar*,no_rlimit_as*,run0edit,secureblue-logos,slsa-verifier*,trivalent-selinux,trivalent-subresource-filter

--- a/files/system/usr/bin/with-standard-malloc
+++ b/files/system/usr/bin/with-standard-malloc
@@ -18,4 +18,9 @@ case "${1-}" in
     *) ;;
 esac
 
-LD_PRELOAD='' exec -- "$@"
+# shellcheck disable=SC2016
+exec /usr/bin/bwrap-restricted \
+    --dev-bind / / \
+    --ro-bind-try /dev/null /etc/ld.so.preload \
+    --unsetenv LD_PRELOAD \
+    -- /usr/bin/bash -c 'exec -- "$0" "$@"' "$@"

--- a/files/system/usr/lib/environment.d/40-hardened_malloc.conf
+++ b/files/system/usr/lib/environment.d/40-hardened_malloc.conf
@@ -1,1 +1,0 @@
-LD_PRELOAD=libhardened_malloc.so libno_rlimit_as.so

--- a/files/system/usr/lib/systemd/system.conf.d/40-hardened_malloc.conf
+++ b/files/system/usr/lib/systemd/system.conf.d/40-hardened_malloc.conf
@@ -1,2 +1,0 @@
-[Manager]
-DefaultEnvironment="LD_PRELOAD=libhardened_malloc.so libno_rlimit_as.so"

--- a/files/system/usr/libexec/secureblue/audit_secureblue.py
+++ b/files/system/usr/libexec/secureblue/audit_secureblue.py
@@ -14,9 +14,7 @@ import configparser
 import filecmp
 import getpass
 import glob
-import os
 import signal
-import stat
 import subprocess
 import sys
 import traceback
@@ -1031,84 +1029,48 @@ def audit_kde_ghns(state):
 
 
 @audit
-def audit_ld_preload():
-    """Ensure ld.so.preload exists and is readable only by root."""
-    status = PASS
-    notes = []
-    rec = None
+def audit_hardened_malloc():
+    """Ensure hardened_malloc is set to be preloaded in place of the default system malloc."""
     ld_so_preload = "/etc/ld.so.preload"
     try:
-        stat_result = os.stat(ld_so_preload)
-    except FileNotFoundError:
+        with open(ld_so_preload, encoding="utf8") as f:
+            preloads = f.read().strip().split()
+    except OSError as err:
         status = FAIL
-        notes.append(Note(_("The file {0} was not found.").format(ld_so_preload), FAIL))
+        note = Note(_("{0} could not be read: {1}").format(ld_so_preload, err.strerror), FAIL)
     else:
-        mode = stat.S_IMODE(stat_result.st_mode)
-        expected_mode = 0o600
-        if mode != expected_mode:
+        if preloads == ["libhardened_malloc.so", "libno_rlimit_as.so"]:
+            status = PASS
+            note = None
+        elif "libhardened_malloc.so" in preloads:
             status = WARN
-            notes.append(
-                Note(
-                    _("{0} has mode {1:o} (expected {2:o})").format(
-                        ld_so_preload, mode, expected_mode
-                    ),
-                    WARN,
-                )
+            note = Note(
+                _("hardened_malloc is enabled, but {1} has been modified.").format(ld_so_preload),
+                WARN,
             )
-        if stat_result.st_uid != 0:
+        elif "libhardened_malloc-light.so" in preloads:
+            status = WARN
+            note = Note(
+                _("The '{0}' variant of hardened_malloc is enabled.").format("light"),
+                WARN,
+            )
+        elif "libhardened_malloc-pkey.so" in preloads:
+            status = WARN
+            note = Note(_("The '{0}' variant of hardened_malloc is enabled.").format("pkey"), WARN)
+        else:
             status = FAIL
-            notes.append(Note(_("{0} is owned by a non-root user!").format(ld_so_preload), FAIL))
+            note = Note(_("hardened_malloc is not enabled."), FAIL)
+
     if status != PASS:
         rec_lines = [
             _("The file {0} has been modified or deleted.").format(ld_so_preload),
-            _("To reset it and enable hardened_malloc for system processes, run:"),
+            _("To reset it and enable hardened_malloc, run:"),
             f"$ run0 -i cp -p /usr/share/secureblue{ld_so_preload} {ld_so_preload}",
         ]
         rec = "\n".join(rec_lines)
-    yield Report(
-        _("Ensuring {0} has expected permissions").format("ld.so.preload"),
-        status,
-        notes=notes,
-        recs=rec,
-    )
-
-
-@audit
-def audit_hardened_malloc():
-    """Ensure hardened_malloc is set to be preloaded in place of the default system malloc."""
-    rec = None
-    ld_preload = os.environ.get("LD_PRELOAD")
-    preloads = [] if ld_preload is None else ld_preload.split()
-    expected_preloads = ["libhardened_malloc.so", "libno_rlimit_as.so"]
-    if preloads == expected_preloads:
-        status = PASS
-        note = None
-    elif "libhardened_malloc.so" in preloads:
-        status = WARN
-        note = Note(
-            _("{0} is set, but {1} has been modified.").format("hardened_malloc", "LD_PRELOAD"),
-            WARN,
-        )
-    elif "libhardened_malloc-light.so" in preloads:
-        status = WARN
-        note = Note(
-            _("The '{0}' variant of {1} has been set.").format("light", "hardened_malloc"), WARN
-        )
-    elif "libhardened_malloc-pkey.so" in preloads:
-        status = WARN
-        note = Note(
-            _("The '{0}' variant of {1} has been set.").format("pkey", "hardened_malloc"), WARN
-        )
     else:
-        status = FAIL
-        note = Note(_("{0} has not been set.").format("LD_PRELOAD=libhardened_malloc.so"), FAIL)
+        rec = None
 
-    if status != PASS:
-        rec = _("""The environment variable {0} has been modified or is unset.
-                Check that {1} has not been overridden in
-                {2} or related configuration files.""").format(
-            "LD_PRELOAD", "LD_PRELOAD=libhardened_malloc.so", "/etc/profile.d"
-        )
     yield Report(
         _("Ensuring hardened_malloc is set to be preloaded"),
         status,

--- a/recipes/common/common-packages.yml
+++ b/recipes/common/common-packages.yml
@@ -7,6 +7,9 @@ source: ghcr.io/blue-build/modules@sha256:c5ed99f07b15c8d575a4fa64a77e5cd5602b00
 install:
   install-weak-deps: false
   packages:
+    - bwrap-restricted
+    - bwrap-restricted-selinux
+    - bwrap-restricted-shim
     - hardened_malloc
     - run0edit
     - dnsconfd-unbound

--- a/recipes/common/common-scripts.yml
+++ b/recipes/common/common-scripts.yml
@@ -7,7 +7,6 @@ source: ghcr.io/blue-build/modules@sha256:c5ed99f07b15c8d575a4fa64a77e5cd5602b00
 scripts:
   - set-ld-preload.sh
   - hardenlogindefs.sh
-  - hardened_malloc-pam.sh
   - disableresolved.sh
   - setup-dnsconfd.sh
   - authselect.sh


### PR DESCRIPTION
* Install SELinux policy for bubblewrap.
* Replace bubblewrap with a restricted version that patches out the `--cap-add` option, meaning it can't be used to create user namespaces with additional capabilities.
* Make `bubblewrap_t` a userns-privileged domain.
* Switch back to using `/etc/ld.so.preload` instead of `LD_PRELOAD` to preload hardened_malloc in all processes by default.
* Reimplement `with-standard-malloc` using bubblewrap to hide `/etc/ld.so.preload` from the process.

Note that this allows sandboxed thumbnailing via Glycin in Nautilus and Thunar.