### PR TITLE
fix(iot): Remove tpm2-pkcs11

### DIFF
--- a/files/scripts/setchronysysconfig.sh
+++ b/files/scripts/setchronysysconfig.sh
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-if [[ "${OS_ARCH}" == "x86_64" ]]; then
+if [[ "${OS_ARCH}" == 'x86_64' ]]; then
     echo 'OPTIONS="-F1 -r"' > /etc/sysconfig/chronyd
 else
     echo 'OPTIONS="-F2 -r"' > /etc/sysconfig/chronyd

--- a/files/scripts/setchronysysconfig.sh
+++ b/files/scripts/setchronysysconfig.sh
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-if [[ "${OS_ARCH}" == 'x86_64' ]]; then
+if [[ "${OS_ARCH}" == "x86_64" ]]; then
     echo 'OPTIONS="-F1 -r"' > /etc/sysconfig/chronyd
 else
     echo 'OPTIONS="-F2 -r"' > /etc/sysconfig/chronyd

--- a/recipes/common/server-modules.yml
+++ b/recipes/common/server-modules.yml
@@ -13,6 +13,9 @@ modules:
         - firewalld
         - policycoreutils-python-utils
         - udisks2
+    remove:
+      packages:
+        - tpm2-pkcs11
 
   - type: files
     source: ghcr.io/blue-build/modules@sha256:c5ed99f07b15c8d575a4fa64a77e5cd5602b00da4c84379f5675db2ae4757061


### PR DESCRIPTION
If the `tpm2-pkcs11` package is installed, it will cause Chrony to perform certain syscalls that are not permitted when using the `-F1` option, resulting in a crash. Even when using the `-F2` option, the Chrony service may still encounter issues with our Chrony configuration (these issues do not occur with the default Fedora configuration). Removing the `tpm2-pkcs11` package resolves these issues, allowing Chrony to function fully when using the `-F1` option.

The `tpm2-pkcs11` package is not installed on the other images, and from my testing, I have not encountered any issues after removing it.

I am unsure whether this change will affect the securecore images build, as this package is not present in them and therefore cannot be removed. Ideally, there would be a separate module file for each server image, but currently, there is only one for both images (likely a legacy setup from when there was only one server image).

Closes https://github.com/secureblue/secureblue/issues/2623.