### PR TITLE
fix(uki): don't uninstall tuned alongside rpm-ostree

### DIFF
--- a/uki/scripts/prepare-rootfs.sh
+++ b/uki/scripts/prepare-rootfs.sh
@@ -16,12 +16,13 @@ dnf upgrade -y --enablerepo=updates-testing --refresh bootc
 
 # Remove rpm-ostree legacy files.
 dnf remove -y \
-    rpm-ostree \
-    rpm-ostree-libs \
-    gnome-software-rpm-ostree \
-    plasma-discover-rpm-ostree
+    bootupd \
+    gnome-software-rpm-ostree plasma-discover-rpm-ostree
 dnf clean all
-rpm -e bootupd
+# --nodeps is used because tuned currently depends on `(rpm-ostree if bootc)`.
+# TODO: Switch back to dnf when tuned drops this dependency.
+rpm -e --nodeps rpm-ostree rpm-ostree-libs
+
 rm -vrf "/usr/lib/bootupd"
 rm -vrf "/usr/lib/ostree-boot"
 rm -vrf "/usr/etc"


### PR DESCRIPTION
`tuned` currently depends on `(rpm-ostree if bootc)`, presumably in ignorance of the composefs backend.

This PR switches from `dnf remove rpm-ostree` to `rpm -e --nodeps rpm-ostree` to leave tuned.

I will report this to the package maintainer to try to get a proper fix; ideally they would drop the hard dependency.